### PR TITLE
Add fursuit species lookup table

### DIFF
--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -35,7 +35,7 @@ import type { FursuitsRow } from '../../src/types/database';
 
 type FursuitDetails = Pick<
   FursuitsRow,
-  'id' | 'name' | 'species' | 'avatar_url' | 'unique_code' | 'owner_id'
+  'id' | 'name' | 'species' | 'species_id' | 'avatar_url' | 'unique_code' | 'owner_id'
 > & { created_at: string | null; bio: FursuitBio | null };
 
 type CatchRecord = {
@@ -80,10 +80,16 @@ export default function CatchScreen() {
           id,
           name,
           species,
+          species_id,
           avatar_url,
           unique_code,
           owner_id,
           created_at,
+          species_entry:fursuit_species (
+            id,
+            name,
+            normalized_name
+          ),
           fursuit_bios (
             version,
             fursuit_name,
@@ -119,7 +125,8 @@ export default function CatchScreen() {
       const normalizedFursuit: FursuitDetails = {
         id: fursuit.id,
         name: fursuit.name,
-        species: fursuit.species ?? null,
+        species: (fursuit as any)?.species_entry?.name ?? fursuit.species ?? null,
+        species_id: (fursuit as any)?.species_entry?.id ?? fursuit.species_id ?? null,
         avatar_url: fursuit.avatar_url ?? null,
         unique_code: fursuit.unique_code ?? null,
         owner_id: fursuit.owner_id,

--- a/src/features/leaderboard/api/leaderboard.ts
+++ b/src/features/leaderboard/api/leaderboard.ts
@@ -11,6 +11,7 @@ export type SuitLeaderboardEntry = {
   fursuitId: string;
   name: string;
   species: string | null;
+  speciesId: string | null;
   avatarUrl: string | null;
   ownerProfileId: string | null;
   ownerUsername: string | null;
@@ -172,8 +173,14 @@ export async function fetchConventionSuitLeaderboard(conventionId: string): Prom
         id,
         name,
         species,
+        species_id,
         avatar_url,
         owner_id,
+        species_entry:fursuit_species (
+          id,
+          name,
+          normalized_name
+        ),
         owner:profiles (id, username)
       )
     `
@@ -189,8 +196,10 @@ export async function fetchConventionSuitLeaderboard(conventionId: string): Prom
       id: string | null;
       name: string | null;
       species: string | null;
+      species_id: string | null;
       avatar_url: string | null;
       owner_id: string | null;
+      species_entry?: { id: string | null; name: string | null; normalized_name: string | null } | null;
       owner: { id: string | null; username: string | null } | null;
     } | null;
   }[];
@@ -200,6 +209,7 @@ export async function fetchConventionSuitLeaderboard(conventionId: string): Prom
     {
       name: string;
       species: string | null;
+      speciesId: string | null;
       avatarUrl: string | null;
       ownerProfileId: string | null;
       ownerUsername: string | null;
@@ -214,7 +224,8 @@ export async function fetchConventionSuitLeaderboard(conventionId: string): Prom
 
     suitMap.set(suit.id, {
       name: suit.name,
-      species: suit.species ?? null,
+      species: suit.species_entry?.name ?? suit.species ?? null,
+      speciesId: suit.species_entry?.id ?? suit.species_id ?? null,
       avatarUrl: suit.avatar_url ?? null,
       ownerProfileId: suit.owner_id ?? null,
       ownerUsername: suit.owner?.username ?? null,
@@ -254,6 +265,7 @@ export async function fetchConventionSuitLeaderboard(conventionId: string): Prom
         fursuitId: suitId,
         name: suit?.name ?? 'Unknown suit',
         species: suit?.species ?? null,
+        speciesId: suit?.speciesId ?? null,
         avatarUrl: suit?.avatarUrl ?? null,
         ownerProfileId: suit?.ownerProfileId ?? null,
         ownerUsername: suit?.ownerUsername ?? null,

--- a/src/features/species/index.ts
+++ b/src/features/species/index.ts
@@ -1,0 +1,100 @@
+import { supabase } from '../../lib/supabase';
+
+export type FursuitSpeciesOption = {
+  id: string;
+  name: string;
+  normalizedName: string;
+};
+
+export const FURSUIT_SPECIES_QUERY_KEY = 'fursuit-species';
+
+const SPECIES_FIELDS = 'id, name, normalized_name';
+
+const mapSpeciesRecord = (input: any): FursuitSpeciesOption => ({
+  id: input.id,
+  name: input.name,
+  normalizedName: input.normalized_name,
+});
+
+const compareSpeciesOptions = (a: FursuitSpeciesOption, b: FursuitSpeciesOption) =>
+  a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+
+export const sortSpeciesOptions = (options: FursuitSpeciesOption[]) =>
+  [...options].sort(compareSpeciesOptions);
+
+export const normalizeSpeciesName = (value: string) =>
+  value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+
+export async function fetchFursuitSpecies(): Promise<FursuitSpeciesOption[]> {
+  const client = supabase as any;
+  const { data, error } = await client
+    .from('fursuit_species')
+    .select(SPECIES_FIELDS)
+    .order('name', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load fursuit species: ${error.message}`);
+  }
+
+  return sortSpeciesOptions((data ?? []).map(mapSpeciesRecord));
+}
+
+export async function ensureSpeciesEntry(name: string): Promise<FursuitSpeciesOption> {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    throw new Error('Species name is required');
+  }
+
+  const normalizedName = normalizeSpeciesName(trimmedName);
+  const client = supabase as any;
+
+  const { data: existing, error: lookupError } = await client
+    .from('fursuit_species')
+    .select(SPECIES_FIELDS)
+    .eq('normalized_name', normalizedName)
+    .maybeSingle();
+
+  if (lookupError && lookupError.code !== 'PGRST116') {
+    throw new Error(`Failed to look up species: ${lookupError.message}`);
+  }
+
+  if (existing) {
+    return mapSpeciesRecord(existing);
+  }
+
+  const { data: created, error: insertError } = await client
+    .from('fursuit_species')
+    .insert({ name: trimmedName })
+    .select(SPECIES_FIELDS)
+    .single();
+
+  if (!insertError && created) {
+    return mapSpeciesRecord(created);
+  }
+
+  if (insertError?.code === '23505') {
+    const { data: retry, error: retryError } = await client
+      .from('fursuit_species')
+      .select(SPECIES_FIELDS)
+      .eq('normalized_name', normalizedName)
+      .maybeSingle();
+
+    if (retryError) {
+      throw new Error(`Failed to finish species lookup: ${retryError.message}`);
+    }
+
+    if (retry) {
+      return mapSpeciesRecord(retry);
+    }
+  }
+
+  if (insertError) {
+    throw new Error(`Failed to save species: ${insertError.message}`);
+  }
+
+  throw new Error('Failed to save species');
+}

--- a/src/features/suits/api/caughtSuits.ts
+++ b/src/features/suits/api/caughtSuits.ts
@@ -25,9 +25,15 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
         id,
         name,
         species,
+        species_id,
         avatar_url,
         unique_code,
         created_at,
+        species_entry:fursuit_species (
+          id,
+          name,
+          normalized_name
+        ),
         fursuit_bios (
           version,
           fursuit_name,
@@ -57,7 +63,10 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
       ? ({
           id: record.fursuit.id,
           name: record.fursuit.name,
-          species: record.fursuit.species ?? null,
+          species:
+            (record.fursuit.species_entry?.name ?? record.fursuit.species) ?? null,
+          speciesId:
+            (record.fursuit.species_entry?.id ?? record.fursuit.species_id) ?? null,
           avatar_url: record.fursuit.avatar_url ?? null,
           unique_code: record.fursuit.unique_code ?? null,
           created_at: record.fursuit.created_at ?? null,

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -16,9 +16,15 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       owner_id,
       name,
       species,
+      species_id,
       avatar_url,
       unique_code,
       created_at,
+      species_entry:fursuit_species (
+        id,
+        name,
+        normalized_name
+      ),
       owner_profile:profiles (
         id,
         username,
@@ -74,12 +80,16 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     }));
 
   const bio = mapLatestFursuitBio(data.fursuit_bios ?? null);
+  const speciesEntry = data.species_entry ?? null;
+  const speciesName = speciesEntry?.name ?? data.species ?? null;
+  const speciesId = speciesEntry?.id ?? data.species_id ?? null;
 
   return {
     id: data.id,
     owner_id: data.owner_id,
     name: data.name,
-    species: data.species ?? null,
+    species: speciesName,
+    speciesId: speciesId,
     avatar_url: data.avatar_url ?? null,
     unique_code: data.unique_code ?? null,
     created_at: data.created_at ?? null,

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -17,9 +17,15 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       id,
       name,
       species,
+      species_id,
       avatar_url,
       unique_code,
       created_at,
+      species_entry:fursuit_species (
+        id,
+        name,
+        normalized_name
+      ),
       fursuit_conventions:fursuit_conventions (
         convention:conventions (
           id,
@@ -67,11 +73,15 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       }));
 
     const bio = mapLatestFursuitBio(item.fursuit_bios ?? null);
+    const speciesEntry = item.species_entry ?? null;
+    const speciesName = speciesEntry?.name ?? item.species ?? null;
+    const speciesId = speciesEntry?.id ?? item.species_id ?? null;
 
     return {
       id: item.id,
       name: item.name,
-      species: item.species ?? null,
+      species: speciesName,
+      speciesId: speciesId,
       avatar_url: item.avatar_url ?? null,
       unique_code: item.unique_code ?? null,
       created_at: item.created_at ?? null,

--- a/src/features/suits/types.ts
+++ b/src/features/suits/types.ts
@@ -20,6 +20,7 @@ export type FursuitSummary = {
   id: string;
   name: string;
   species: string | null;
+  speciesId: string | null;
   avatar_url: string | null;
   unique_code: string | null;
   created_at: string | null;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -38,6 +38,7 @@ export interface FursuitsRow {
   owner_id: string;
   name: string;
   species: string | null;
+  species_id: string | null;
   avatar_url: string | null;
   unique_code: string | null;
   created_at: string | null;
@@ -49,6 +50,7 @@ export interface FursuitsInsert {
   owner_id: string;
   name: string;
   species?: string | null;
+  species_id?: string | null;
   avatar_url?: string | null;
   unique_code: string | null;
   created_at?: string | null;
@@ -60,8 +62,33 @@ export interface FursuitsUpdate {
   owner_id?: string;
   name?: string;
   species?: string | null;
+  species_id?: string | null;
   avatar_url?: string | null;
   unique_code?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface FursuitSpeciesRow {
+  id: string;
+  name: string;
+  normalized_name: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface FursuitSpeciesInsert {
+  id?: string;
+  name: string;
+  normalized_name?: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface FursuitSpeciesUpdate {
+  id?: string;
+  name?: string;
+  normalized_name?: string;
   created_at?: string | null;
   updated_at?: string | null;
 }
@@ -241,6 +268,12 @@ export interface Database {
             columns: ['owner_id'];
             referencedRelation: 'profiles';
             referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'fursuits_species_id_fkey';
+            columns: ['species_id'];
+            referencedRelation: 'fursuit_species';
+            referencedColumns: ['id'];
           }
         ];
       };
@@ -319,6 +352,12 @@ export interface Database {
             referencedColumns: ['id'];
           }
         ];
+      };
+      fursuit_species: {
+        Row: FursuitSpeciesRow;
+        Insert: FursuitSpeciesInsert;
+        Update: FursuitSpeciesUpdate;
+        Relationships: [];
       };
     };
     Views: {

--- a/supabase/migrations/20250305120000_add_fursuit_species_lookup.sql
+++ b/supabase/migrations/20250305120000_add_fursuit_species_lookup.sql
@@ -1,0 +1,83 @@
+-- Create lookup table for standardizing fursuit species
+create table if not exists public.fursuit_species (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  normalized_name text generated always as (
+    lower(
+      regexp_replace(
+        btrim(name),
+        '\s+',
+        ' ',
+        'g'
+      )
+    )
+  ) stored,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint fursuit_species_name_length_check
+    check (char_length(btrim(name)) between 2 and 120)
+);
+
+create unique index if not exists fursuit_species_normalized_name_unique
+  on public.fursuit_species (normalized_name);
+
+create index if not exists fursuit_species_created_at_idx
+  on public.fursuit_species (created_at desc);
+
+-- Ensure updated_at stays current on write operations
+create or replace function public.set_fursuit_species_updated_at()
+returns trigger as
+$$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger set_fursuit_species_updated_at
+  before update on public.fursuit_species
+  for each row
+  execute function public.set_fursuit_species_updated_at();
+
+-- Attach species to fursuits
+alter table if exists public.fursuits
+  add column if not exists species_id uuid;
+
+alter table if exists public.fursuits
+  add constraint fursuits_species_id_fkey
+  foreign key (species_id)
+  references public.fursuit_species(id)
+  on delete restrict;
+
+create index if not exists fursuits_species_id_idx
+  on public.fursuits (species_id);
+
+-- Seed the lookup with common species entries
+insert into public.fursuit_species (name)
+values
+  ('Wolf'),
+  ('Fox'),
+  ('Dragon'),
+  ('Dutch Angel Dragon'),
+  ('Sergal'),
+  ('Husky'),
+  ('Cat'),
+  ('Dog'),
+  ('Tiger'),
+  ('Lion'),
+  ('Rabbit'),
+  ('Deer'),
+  ('Otter'),
+  ('Raccoon'),
+  ('Shark'),
+  ('Bird'),
+  ('Bear'),
+  ('Hyena'),
+  ('Horse'),
+  ('Cow'),
+  ('Goat'),
+  ('Bat'),
+  ('Mouse'),
+  ('Hybrid')
+  on conflict (normalized_name)
+  do nothing;

--- a/supabase/migrations/20250306110000_remove_is_common_from_fursuit_species.sql
+++ b/supabase/migrations/20250306110000_remove_is_common_from_fursuit_species.sql
@@ -1,0 +1,45 @@
+-- Remove the deprecated is_common flag from the species lookup.
+alter table if exists public.fursuit_species
+  drop column if exists is_common;
+
+-- Reseed canonical species names to cover freshly created environments.
+insert into public.fursuit_species (name)
+values
+  ('Wolf'),
+  ('Fox'),
+  ('Dragon'),
+  ('Dutch Angel Dragon'),
+  ('Sergal'),
+  ('Husky'),
+  ('Cat'),
+  ('Dog'),
+  ('Tiger'),
+  ('Lion'),
+  ('Rabbit'),
+  ('Deer'),
+  ('Otter'),
+  ('Raccoon'),
+  ('Shark'),
+  ('Bird'),
+  ('Bear'),
+  ('Hyena'),
+  ('Horse'),
+  ('Cow'),
+  ('Goat'),
+  ('Bat'),
+  ('Mouse'),
+  ('Hybrid')
+on conflict (normalized_name) do nothing;
+
+-- Lock down access with restrictive row-level security policies.
+alter table public.fursuit_species enable row level security;
+
+create policy fursuit_species_read_access
+  on public.fursuit_species
+  for select
+  using (true);
+
+create policy fursuit_species_insert_authenticated
+  on public.fursuit_species
+  for insert
+  with check (auth.uid() is not null);


### PR DESCRIPTION
Added a normalized fursuit_species lookup table (with species_id references) plus Supabase migrations, TypeScript types, and client-side hooks to surface curated species suggestions when adding/editing suits. Also expanded suit-fetching APIs, catches, and leaderboards to join the lookup, while keeping catch submission and navigation flows smooth (redirecting back to “My Suits” after a new suit is saved).