### PR TITLE
Add daily tasks for players to complete daily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ yarn-error.*
 /android
 
 # Local PRDs for feature development
-/prds
+/docs

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,6 +34,7 @@ import {
   type AchievementWithStatus,
 } from '../../src/features/achievements';
 import { useDailyTasks } from '../../src/features/daily-tasks';
+import type { Database } from '../../src/types/database';
 import { colors, spacing, radius } from '../../src/theme';
 
 const features = [
@@ -110,26 +111,6 @@ export default function HomeScreen() {
     refetchOnReconnect: false,
   });
 
-  const {
-    data: dailyTasksData,
-    error: dailyTasksError,
-    isLoading: isDailyTasksLoading,
-    isFetching: isDailyTasksFetching,
-    refetch: refetchDailyTasks,
-    countdown: dailyCountdown,
-  } = useDailyTasks(userId);
-
-  const dailyTotalTasks = dailyTasksData?.totalCount ?? 0;
-  const dailyCompletedTasks = dailyTasksData?.completedCount ?? 0;
-  const dailyProgressValue =
-    dailyTotalTasks > 0 ? Math.min(dailyCompletedTasks / dailyTotalTasks, 1) : 0;
-  const dailyRemainingTasks = Math.max(dailyTotalTasks - dailyCompletedTasks, 0);
-  const dailyTasksErrorMessage = dailyTasksError?.message ?? null;
-  const isDailyTasksBusy = isDailyTasksLoading || (isDailyTasksFetching && !isDailyTasksLoading);
-  const hasDailyAssignments = dailyTotalTasks > 0;
-  const dailyAllComplete = hasDailyAssignments && dailyRemainingTasks === 0;
-  const dailyCurrentStreak = dailyTasksData?.streak.current ?? 0;
-
   const unlockedAchievements = useMemo(
     () => achievementStatuses.filter((achievement) => achievement.unlocked),
     [achievementStatuses]
@@ -190,6 +171,26 @@ export default function HomeScreen() {
       return availableConventions[0]?.id ?? null;
     });
   }, [availableConventions]);
+
+  const {
+    data: dailyTasksData,
+    error: dailyTasksError,
+    isLoading: isDailyTasksLoading,
+    isFetching: isDailyTasksFetching,
+    refetch: refetchDailyTasks,
+    countdown: dailyCountdown,
+  } = useDailyTasks(userId, selectedConventionId);
+
+  const dailyTotalTasks = dailyTasksData?.totalCount ?? 0;
+  const dailyCompletedTasks = dailyTasksData?.completedCount ?? 0;
+  const dailyProgressValue =
+    dailyTotalTasks > 0 ? Math.min(dailyCompletedTasks / dailyTotalTasks, 1) : 0;
+  const dailyRemainingTasks = Math.max(dailyTotalTasks - dailyCompletedTasks, 0);
+  const dailyTasksErrorMessage = dailyTasksError?.message ?? null;
+  const isDailyTasksBusy = isDailyTasksLoading || (isDailyTasksFetching && !isDailyTasksLoading);
+  const hasDailyAssignments = dailyTotalTasks > 0;
+  const dailyAllComplete = hasDailyAssignments && dailyRemainingTasks === 0;
+  const dailyCurrentStreak = dailyTasksData?.streak.current ?? 0;
 
   const {
     data: leaderboardEntries = [],
@@ -272,16 +273,21 @@ export default function HomeScreen() {
     void refetchLeaderboard({ throwOnError: false });
     void refetchSuitLeaderboard({ throwOnError: false });
 
-    if (!userId) {
+    if (!userId || !selectedConventionId) {
       return;
     }
 
-    const { error } = await supabase.rpc('record_leaderboard_refresh');
+    const payload: Database['public']['Functions']['record_leaderboard_refresh']['Args'] = {
+      convention_id: selectedConventionId,
+    };
+
+    const { error } = await supabase.rpc('record_leaderboard_refresh', payload as never);
+
     if (error) {
       console.error('Failed to record leaderboard refresh', error);
       Alert.alert('Refresh failed', 'We could not record your refresh. Please try again.');
     }
-  }, [refetchLeaderboard, refetchSuitLeaderboard, userId]);
+  }, [refetchLeaderboard, refetchSuitLeaderboard, userId, selectedConventionId]);
 
   return (
     <View style={styles.wrapper}>
@@ -326,7 +332,9 @@ export default function HomeScreen() {
           <Text style={styles.sectionEyebrow}>Daily tasks</Text>
           <Text style={styles.sectionTitle}>Keep your streak going</Text>
 
-          {isDailyTasksBusy ? (
+          {!selectedConventionId ? (
+            <Text style={styles.message}>Pick a convention to unlock daily tasks.</Text>
+          ) : isDailyTasksBusy ? (
             <Text style={styles.message}>Checking today's lineup...</Text>
           ) : dailyTasksErrorMessage ? (
             <View style={styles.helper}>
@@ -367,6 +375,7 @@ export default function HomeScreen() {
             variant="outline"
             onPress={() => router.push('/daily-tasks')}
             style={styles.dailyCta}
+            disabled={!selectedConventionId}
           >
             View daily tasks
           </TailTagButton>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,7 +7,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { TailTagButton } from '../../src/components/ui/TailTagButton';
 import { TailTagCard } from '../../src/components/ui/TailTagCard';
+import { TailTagProgressBar } from '../../src/components/ui/TailTagProgressBar';
 import { useAuth } from '../../src/features/auth';
+import { supabase } from '../../src/lib/supabase';
 import {
   CONVENTIONS_QUERY_KEY,
   CONVENTIONS_STALE_TIME,
@@ -31,6 +33,7 @@ import {
   useAchievementNotificationsToast,
   type AchievementWithStatus,
 } from '../../src/features/achievements';
+import { useDailyTasks } from '../../src/features/daily-tasks';
 import { colors, spacing, radius } from '../../src/theme';
 
 const features = [
@@ -106,6 +109,26 @@ export default function HomeScreen() {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
+
+  const {
+    data: dailyTasksData,
+    error: dailyTasksError,
+    isLoading: isDailyTasksLoading,
+    isFetching: isDailyTasksFetching,
+    refetch: refetchDailyTasks,
+    countdown: dailyCountdown,
+  } = useDailyTasks(userId);
+
+  const dailyTotalTasks = dailyTasksData?.totalCount ?? 0;
+  const dailyCompletedTasks = dailyTasksData?.completedCount ?? 0;
+  const dailyProgressValue =
+    dailyTotalTasks > 0 ? Math.min(dailyCompletedTasks / dailyTotalTasks, 1) : 0;
+  const dailyRemainingTasks = Math.max(dailyTotalTasks - dailyCompletedTasks, 0);
+  const dailyTasksErrorMessage = dailyTasksError?.message ?? null;
+  const isDailyTasksBusy = isDailyTasksLoading || (isDailyTasksFetching && !isDailyTasksLoading);
+  const hasDailyAssignments = dailyTotalTasks > 0;
+  const dailyAllComplete = hasDailyAssignments && dailyRemainingTasks === 0;
+  const dailyCurrentStreak = dailyTasksData?.streak.current ?? 0;
 
   const unlockedAchievements = useMemo(
     () => achievementStatuses.filter((achievement) => achievement.unlocked),
@@ -245,6 +268,21 @@ export default function HomeScreen() {
     return pieces.join(' · ');
   };
 
+  const handleReloadStandings = useCallback(async () => {
+    void refetchLeaderboard({ throwOnError: false });
+    void refetchSuitLeaderboard({ throwOnError: false });
+
+    if (!userId) {
+      return;
+    }
+
+    const { error } = await supabase.rpc('record_leaderboard_refresh');
+    if (error) {
+      console.error('Failed to record leaderboard refresh', error);
+      Alert.alert('Refresh failed', 'We could not record your refresh. Please try again.');
+    }
+  }, [refetchLeaderboard, refetchSuitLeaderboard, userId]);
+
   return (
     <View style={styles.wrapper}>
       <LinearGradient
@@ -283,6 +321,56 @@ export default function HomeScreen() {
             </View>
           </View>
         </View>
+
+        <TailTagCard style={styles.dailyCard}>
+          <Text style={styles.sectionEyebrow}>Daily tasks</Text>
+          <Text style={styles.sectionTitle}>Keep your streak going</Text>
+
+          {isDailyTasksBusy ? (
+            <Text style={styles.message}>Checking today's lineup...</Text>
+          ) : dailyTasksErrorMessage ? (
+            <View style={styles.helper}>
+              <Text style={styles.error}>{dailyTasksErrorMessage}</Text>
+              <TailTagButton
+                variant="outline"
+                size="sm"
+                onPress={() => {
+                  void refetchDailyTasks({ throwOnError: false });
+                }}
+              >
+                Try again
+              </TailTagButton>
+            </View>
+          ) : !hasDailyAssignments ? (
+            <Text style={styles.message}>Tasks unlock once today's rotation goes live.</Text>
+          ) : (
+            <View style={styles.dailySummaryBlock}>
+              <View style={styles.dailySummaryHeader}>
+                <Text style={styles.dailySummaryText}>
+                  {dailyCompletedTasks} / {dailyTotalTasks} complete
+                </Text>
+                <Text style={styles.dailyCountdown}>Resets in {dailyCountdown}</Text>
+              </View>
+              <TailTagProgressBar value={dailyProgressValue} style={styles.dailyProgressBar} />
+              <View style={styles.dailySummaryFooter}>
+                <Text style={styles.dailySummaryText}>
+                  {dailyAllComplete
+                    ? 'All tasks complete - bonus secured.'
+                    : `${dailyRemainingTasks} task${dailyRemainingTasks === 1 ? '' : 's'} remaining`}
+                </Text>
+                <Text style={styles.dailyStreakLabel}>Streak: {dailyCurrentStreak}</Text>
+              </View>
+            </View>
+          )}
+
+          <TailTagButton
+            variant="outline"
+            onPress={() => router.push('/daily-tasks')}
+            style={styles.dailyCta}
+          >
+            View daily tasks
+          </TailTagButton>
+        </TailTagCard>
 
         <TailTagCard style={styles.achievementsCard}>
           <Text style={styles.sectionEyebrow}>Achievements</Text>
@@ -384,6 +472,16 @@ export default function HomeScreen() {
 
               {selectedConventionId ? (
                 <View style={styles.leaderboardStack}>
+                  <View style={styles.leaderboardToolbar}>
+                    <TailTagButton
+                      variant="outline"
+                      size="sm"
+                      onPress={handleReloadStandings}
+                      style={styles.reloadButton}
+                    >
+                      Reload standings
+                    </TailTagButton>
+                  </View>
                   <View>
                     {isLeaderboardBusy ? (
                       <Text style={styles.message}>Loading leaderboard…</Text>
@@ -600,6 +698,45 @@ const styles = StyleSheet.create({
     width: maxContentWidth,
     marginBottom: spacing.xl,
   },
+  dailyCard: {
+    width: maxContentWidth,
+    marginBottom: spacing.xl,
+    gap: spacing.md,
+  },
+  dailySummaryBlock: {
+    gap: spacing.sm,
+  },
+  dailySummaryHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  dailySummaryFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  dailySummaryText: {
+    color: 'rgba(203,213,225,0.9)',
+    fontSize: 14,
+  },
+  dailyProgressBar: {
+    backgroundColor: 'rgba(148,163,184,0.25)',
+    width: '100%',
+  },
+  dailyCountdown: {
+    color: colors.primary,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  dailyStreakLabel: {
+    color: colors.primary,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  dailyCta: {
+    alignSelf: 'flex-start',
+  },
   achievementsCard: {
     width: maxContentWidth,
     marginBottom: spacing.xl,
@@ -733,6 +870,13 @@ const styles = StyleSheet.create({
   selectorButton: {
     minHeight: 36,
     paddingHorizontal: spacing.md,
+  },
+  leaderboardToolbar: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  reloadButton: {
+    alignSelf: 'flex-end',
   },
   suitLeaderboardSection: {
     gap: spacing.sm,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -72,6 +72,9 @@ function RootLayoutNav() {
 
       {/* Achievements */}
       <Stack.Screen name="achievements/index" options={{ headerShown: false }} />
+
+      {/* Daily tasks */}
+      <Stack.Screen name="daily-tasks/index" options={{ headerShown: false }} />
     </Stack>
   );
 }

--- a/app/daily-tasks/index.tsx
+++ b/app/daily-tasks/index.tsx
@@ -134,7 +134,6 @@ export default function DailyTasksScreen() {
     error,
     refetch,
     countdown,
-    millisecondsUntilReset,
   } = useDailyTasks(userId, selectedConventionId);
 
   const tasks = data?.tasks ?? [];

--- a/app/daily-tasks/index.tsx
+++ b/app/daily-tasks/index.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -7,28 +8,38 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
 
 import { TailTagButton } from '../../src/components/ui/TailTagButton';
 import { TailTagCard } from '../../src/components/ui/TailTagCard';
 import { TailTagProgressBar } from '../../src/components/ui/TailTagProgressBar';
 import { useAuth } from '../../src/features/auth';
-import { useDailyTasks, type DailyTaskProgress } from '../../src/features/daily-tasks';
+import {
+  CONVENTIONS_QUERY_KEY,
+  CONVENTIONS_STALE_TIME,
+  PROFILE_CONVENTIONS_QUERY_KEY,
+  type ConventionSummary,
+  fetchConventions,
+  fetchProfileConventionIds,
+} from '../../src/features/conventions';
+import { useDailyTasks } from '../../src/features/daily-tasks';
 import { colors, radius, spacing } from '../../src/theme';
 
-function formatDayLabel(day: string): string {
-  const parsed = new Date(`${day}T00:00:00.000Z`);
-  if (Number.isNaN(parsed.getTime())) {
+function formatDayLabel(day: string, timezone: string): string {
+  try {
+    const date = new Date(`${day}T00:00:00`);
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+      timeZone: timezone,
+    }).format(date);
+  } catch {
     return day;
   }
-
-  return new Intl.DateTimeFormat('en-US', {
-    weekday: 'long',
-    month: 'short',
-    day: 'numeric',
-  }).format(parsed);
 }
 
-function formatCompletionTime(iso: string | null): string {
+function formatCompletionTime(iso: string | null, timezone: string): string {
   if (!iso) {
     return '';
   }
@@ -41,12 +52,13 @@ function formatCompletionTime(iso: string | null): string {
   return new Intl.DateTimeFormat('en-US', {
     hour: 'numeric',
     minute: '2-digit',
+    timeZone: timezone,
   }).format(parsed);
 }
 
-function getTaskStatusCopy(task: DailyTaskProgress): string {
-  const remaining = Math.max(task.requirement - task.currentCount, 0);
-  if (task.isCompleted) {
+function getTaskStatusCopy(taskRequirement: number, currentCount: number, isCompleted: boolean): string {
+  const remaining = Math.max(taskRequirement - currentCount, 0);
+  if (isCompleted) {
     return 'Completed';
   }
 
@@ -63,24 +75,76 @@ export default function DailyTasksScreen() {
   const userId = session?.user.id ?? null;
 
   const {
+    data: conventions = [],
+    isLoading: isConventionsLoading,
+    error: conventionsError,
+  } = useQuery<ConventionSummary[], Error>({
+    queryKey: [CONVENTIONS_QUERY_KEY],
+    queryFn: () => fetchConventions(),
+    staleTime: CONVENTIONS_STALE_TIME,
+    enabled: Boolean(userId),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const {
+    data: profileConventionIds = [],
+    isLoading: isProfileConventionsLoading,
+    error: profileConventionsError,
+  } = useQuery<string[], Error>({
+    queryKey: [PROFILE_CONVENTIONS_QUERY_KEY, userId],
+    queryFn: () => fetchProfileConventionIds(userId!),
+    enabled: Boolean(userId),
+    staleTime: CONVENTIONS_STALE_TIME,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const availableConventions = useMemo(() => {
+    if (!profileConventionIds || profileConventionIds.length === 0) {
+      return [] as ConventionSummary[];
+    }
+    return conventions.filter((convention) => profileConventionIds.includes(convention.id));
+  }, [conventions, profileConventionIds]);
+
+  const [selectedConventionId, setSelectedConventionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (availableConventions.length === 0) {
+      setSelectedConventionId(null);
+      return;
+    }
+
+    setSelectedConventionId((current) => {
+      if (current && availableConventions.some((convention) => convention.id === current)) {
+        return current;
+      }
+      return availableConventions[0]?.id ?? null;
+    });
+  }, [availableConventions]);
+
+  const selectedConvention = useMemo(() => {
+    return availableConventions.find((item) => item.id === selectedConventionId) ?? null;
+  }, [availableConventions, selectedConventionId]);
+
+  const {
     data,
     isLoading,
     isFetching,
     error,
     refetch,
     countdown,
-    day,
-  } = useDailyTasks(userId);
+    millisecondsUntilReset,
+  } = useDailyTasks(userId, selectedConventionId);
 
   const tasks = data?.tasks ?? [];
   const totalCount = data?.totalCount ?? 0;
   const completedCount = data?.completedCount ?? 0;
-  const streak = data?.streak ?? { current: 0, best: 0, lastCompletedDay: null };
   const allComplete = totalCount > 0 && completedCount === totalCount;
-  const progressValue = totalCount > 0 ? completedCount / totalCount : 0;
-
-  const formattedDay = useMemo(() => formatDayLabel(day), [day]);
+  const progressValue = totalCount > 0 ? Math.min(completedCount / totalCount, 1) : 0;
   const remainingCount = Math.max(totalCount - completedCount, 0);
+  const timezone = data?.timezone ?? selectedConvention?.timezone ?? 'UTC';
+
   const isRefreshing = isFetching && !isLoading;
 
   const handleBack = useCallback(() => {
@@ -90,6 +154,13 @@ export default function DailyTasksScreen() {
   const handleRetry = useCallback(() => {
     void refetch({ throwOnError: false });
   }, [refetch]);
+
+  const handleConventionRequired = useCallback(() => {
+    Alert.alert('Select a convention', 'Pick a convention to view its daily lineup.');
+  }, []);
+
+  const conventionErrorMessage = conventionsError?.message ?? profileConventionsError?.message ?? null;
+  const isLoadingConventions = isConventionsLoading || isProfileConventionsLoading;
 
   return (
     <ScrollView
@@ -111,10 +182,42 @@ export default function DailyTasksScreen() {
         </TailTagButton>
       </View>
 
+      <TailTagCard style={styles.selectorCard}>
+        <Text style={styles.selectorEyebrow}>Convention</Text>
+        {isLoadingConventions ? (
+          <Text style={styles.message}>Loading conventions...</Text>
+        ) : conventionErrorMessage ? (
+          <View style={styles.helper}>
+            <Text style={styles.error}>{conventionErrorMessage}</Text>
+            <TailTagButton variant="outline" size="sm" onPress={handleRetry}>
+              Try again
+            </TailTagButton>
+          </View>
+        ) : availableConventions.length === 0 ? (
+          <Text style={styles.message}>Opt into a convention to unlock daily tasks.</Text>
+        ) : (
+          <View style={styles.selectorRow}>
+            {availableConventions.map((convention) => (
+              <TailTagButton
+                key={convention.id}
+                size="sm"
+                variant={selectedConventionId === convention.id ? 'primary' : 'outline'}
+                onPress={() => setSelectedConventionId(convention.id)}
+                style={styles.selectorButton}
+              >
+                {convention.name}
+              </TailTagButton>
+            ))}
+          </View>
+        )}
+      </TailTagCard>
+
       <TailTagCard style={styles.summaryCard}>
         <View style={styles.summaryHeader}>
           <Text style={styles.summaryEyebrow}>Daily Tasks</Text>
-          <Text style={styles.summaryTitle}>{formattedDay}</Text>
+          <Text style={styles.summaryTitle}>
+            {data ? formatDayLabel(data.day, timezone) : 'Pick a convention'}
+          </Text>
         </View>
 
         <View style={styles.summaryStatsRow}>
@@ -126,11 +229,11 @@ export default function DailyTasksScreen() {
           </View>
           <View style={styles.summaryStat}>
             <Text style={styles.statLabel}>Current streak</Text>
-            <Text style={styles.statValue}>{streak.current}</Text>
+            <Text style={styles.statValue}>{data?.streak.current ?? 0}</Text>
           </View>
           <View style={styles.summaryStat}>
             <Text style={styles.statLabel}>Best streak</Text>
-            <Text style={styles.statValue}>{streak.best}</Text>
+            <Text style={styles.statValue}>{data?.streak.best ?? 0}</Text>
           </View>
         </View>
 
@@ -138,13 +241,17 @@ export default function DailyTasksScreen() {
           <TailTagProgressBar value={progressValue} />
           <View style={styles.progressFooter}>
             <Text style={styles.progressHelper}>
-              {totalCount === 0
+              {!selectedConventionId
+                ? 'Pick a convention to begin.'
+                : totalCount === 0
                 ? "Today's lineup is being prepared."
                 : allComplete
                 ? 'All tasks complete - great job!'
                 : `${remainingCount} task${remainingCount === 1 ? '' : 's'} remaining`}
             </Text>
-            <Text style={styles.countdownLabel}>Resets in {countdown}</Text>
+            <Text style={styles.countdownLabel}>
+              Resets in {selectedConventionId ? countdown : '--:--:--'}
+            </Text>
           </View>
         </View>
       </TailTagCard>
@@ -152,7 +259,14 @@ export default function DailyTasksScreen() {
       <TailTagCard style={styles.tasksCard}>
         <Text style={styles.tasksTitle}>Today's tasks</Text>
 
-        {isLoading ? (
+        {!selectedConventionId ? (
+          <View style={styles.helper}>
+            <Text style={styles.message}>Select a convention to view tasks.</Text>
+            <TailTagButton variant="outline" size="sm" onPress={handleConventionRequired}>
+              Choose convention
+            </TailTagButton>
+          </View>
+        ) : isLoading ? (
           <Text style={styles.message}>Loading daily tasks...</Text>
         ) : error ? (
           <View style={styles.errorBlock}>
@@ -169,14 +283,16 @@ export default function DailyTasksScreen() {
               const progressFraction = task.requirement > 0 ? Math.min(task.currentCount / task.requirement, 1) : 0;
               const clampedCount = Math.min(task.currentCount, task.requirement);
               const progressLabel = `${clampedCount} / ${task.requirement}`;
-              const completionTime = task.isCompleted ? formatCompletionTime(task.completedAt) : '';
+              const completionTime = task.isCompleted
+                ? formatCompletionTime(task.completedAt, timezone)
+                : '';
 
               return (
                 <View key={task.id} style={styles.taskRow}>
                   <View style={styles.taskHeader}>
                     <Text style={styles.taskTitle}>{task.name}</Text>
                     <Text style={task.isCompleted ? styles.taskBadgeDone : styles.taskBadgePending}>
-                      {getTaskStatusCopy(task)}
+                      {getTaskStatusCopy(task.requirement, task.currentCount, task.isCompleted)}
                     </Text>
                   </View>
                   <Text style={styles.taskDescription}>{task.description}</Text>
@@ -211,6 +327,24 @@ const styles = StyleSheet.create({
   headerRow: {
     flexDirection: 'row',
     justifyContent: 'flex-start',
+  },
+  selectorCard: {
+    gap: spacing.sm,
+  },
+  selectorEyebrow: {
+    color: colors.slate200,
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  selectorRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  selectorButton: {
+    minHeight: 36,
+    paddingHorizontal: spacing.md,
   },
   summaryCard: {
     gap: spacing.lg,
@@ -279,6 +413,13 @@ const styles = StyleSheet.create({
   },
   message: {
     color: colors.slate200,
+    fontSize: 14,
+  },
+  helper: {
+    gap: spacing.sm,
+  },
+  error: {
+    color: colors.destructive,
     fontSize: 14,
   },
   errorBlock: {

--- a/app/daily-tasks/index.tsx
+++ b/app/daily-tasks/index.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useMemo } from 'react';
+import {
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { TailTagButton } from '../../src/components/ui/TailTagButton';
+import { TailTagCard } from '../../src/components/ui/TailTagCard';
+import { TailTagProgressBar } from '../../src/components/ui/TailTagProgressBar';
+import { useAuth } from '../../src/features/auth';
+import { useDailyTasks, type DailyTaskProgress } from '../../src/features/daily-tasks';
+import { colors, radius, spacing } from '../../src/theme';
+
+function formatDayLabel(day: string): string {
+  const parsed = new Date(`${day}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return day;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  }).format(parsed);
+}
+
+function formatCompletionTime(iso: string | null): string {
+  if (!iso) {
+    return '';
+  }
+
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(parsed);
+}
+
+function getTaskStatusCopy(task: DailyTaskProgress): string {
+  const remaining = Math.max(task.requirement - task.currentCount, 0);
+  if (task.isCompleted) {
+    return 'Completed';
+  }
+
+  if (remaining === 0) {
+    return 'Ready to claim';
+  }
+
+  return `${remaining} to go`;
+}
+
+export default function DailyTasksScreen() {
+  const router = useRouter();
+  const { session } = useAuth();
+  const userId = session?.user.id ?? null;
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+    countdown,
+    day,
+  } = useDailyTasks(userId);
+
+  const tasks = data?.tasks ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const completedCount = data?.completedCount ?? 0;
+  const streak = data?.streak ?? { current: 0, best: 0, lastCompletedDay: null };
+  const allComplete = totalCount > 0 && completedCount === totalCount;
+  const progressValue = totalCount > 0 ? completedCount / totalCount : 0;
+
+  const formattedDay = useMemo(() => formatDayLabel(day), [day]);
+  const remainingCount = Math.max(totalCount - completedCount, 0);
+  const isRefreshing = isFetching && !isLoading;
+
+  const handleBack = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const handleRetry = useCallback(() => {
+    void refetch({ throwOnError: false });
+  }, [refetch]);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.container}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={() => {
+            void refetch({ throwOnError: false });
+          }}
+          tintColor={colors.primary}
+        />
+      }
+    >
+      <View style={styles.headerRow}>
+        <TailTagButton variant="ghost" onPress={handleBack}>
+          Back
+        </TailTagButton>
+      </View>
+
+      <TailTagCard style={styles.summaryCard}>
+        <View style={styles.summaryHeader}>
+          <Text style={styles.summaryEyebrow}>Daily Tasks</Text>
+          <Text style={styles.summaryTitle}>{formattedDay}</Text>
+        </View>
+
+        <View style={styles.summaryStatsRow}>
+          <View style={styles.summaryStat}>
+            <Text style={styles.statLabel}>Completed</Text>
+            <Text style={styles.statValue}>
+              {completedCount} / {totalCount}
+            </Text>
+          </View>
+          <View style={styles.summaryStat}>
+            <Text style={styles.statLabel}>Current streak</Text>
+            <Text style={styles.statValue}>{streak.current}</Text>
+          </View>
+          <View style={styles.summaryStat}>
+            <Text style={styles.statLabel}>Best streak</Text>
+            <Text style={styles.statValue}>{streak.best}</Text>
+          </View>
+        </View>
+
+        <View style={styles.progressBlock}>
+          <TailTagProgressBar value={progressValue} />
+          <View style={styles.progressFooter}>
+            <Text style={styles.progressHelper}>
+              {totalCount === 0
+                ? "Today's lineup is being prepared."
+                : allComplete
+                ? 'All tasks complete - great job!'
+                : `${remainingCount} task${remainingCount === 1 ? '' : 's'} remaining`}
+            </Text>
+            <Text style={styles.countdownLabel}>Resets in {countdown}</Text>
+          </View>
+        </View>
+      </TailTagCard>
+
+      <TailTagCard style={styles.tasksCard}>
+        <Text style={styles.tasksTitle}>Today's tasks</Text>
+
+        {isLoading ? (
+          <Text style={styles.message}>Loading daily tasks...</Text>
+        ) : error ? (
+          <View style={styles.errorBlock}>
+            <Text style={styles.errorText}>{error.message}</Text>
+            <TailTagButton variant="outline" size="sm" onPress={handleRetry}>
+              Try again
+            </TailTagButton>
+          </View>
+        ) : tasks.length === 0 ? (
+          <Text style={styles.message}>No tasks available right now. Check back shortly.</Text>
+        ) : (
+          <View style={styles.tasksList}>
+            {tasks.map((task) => {
+              const progressFraction = task.requirement > 0 ? Math.min(task.currentCount / task.requirement, 1) : 0;
+              const clampedCount = Math.min(task.currentCount, task.requirement);
+              const progressLabel = `${clampedCount} / ${task.requirement}`;
+              const completionTime = task.isCompleted ? formatCompletionTime(task.completedAt) : '';
+
+              return (
+                <View key={task.id} style={styles.taskRow}>
+                  <View style={styles.taskHeader}>
+                    <Text style={styles.taskTitle}>{task.name}</Text>
+                    <Text style={task.isCompleted ? styles.taskBadgeDone : styles.taskBadgePending}>
+                      {getTaskStatusCopy(task)}
+                    </Text>
+                  </View>
+                  <Text style={styles.taskDescription}>{task.description}</Text>
+                  <TailTagProgressBar value={progressFraction} style={styles.taskProgress} />
+                  <View style={styles.taskFooter}>
+                    <Text style={styles.taskProgressLabel}>{progressLabel}</Text>
+                    {completionTime ? (
+                      <Text style={styles.taskCompletionLabel}>Completed at {completionTime}</Text>
+                    ) : null}
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+        )}
+      </TailTagCard>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  container: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xl,
+    paddingTop: spacing.lg,
+    gap: spacing.lg,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  summaryCard: {
+    gap: spacing.lg,
+  },
+  summaryHeader: {
+    gap: spacing.xs,
+  },
+  summaryEyebrow: {
+    color: colors.slate200,
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  summaryTitle: {
+    color: colors.foreground,
+    fontSize: 24,
+    fontWeight: '600',
+  },
+  summaryStatsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+  summaryStat: {
+    flex: 1,
+    backgroundColor: colors.accent,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+  },
+  statLabel: {
+    color: colors.slate200,
+    fontSize: 12,
+    marginBottom: spacing.xs,
+  },
+  statValue: {
+    color: colors.foreground,
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  progressBlock: {
+    gap: spacing.sm,
+  },
+  progressFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  progressHelper: {
+    color: colors.slate200,
+    fontSize: 14,
+  },
+  countdownLabel: {
+    color: colors.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  tasksCard: {
+    gap: spacing.md,
+  },
+  tasksTitle: {
+    color: colors.foreground,
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  message: {
+    color: colors.slate200,
+    fontSize: 14,
+  },
+  errorBlock: {
+    gap: spacing.sm,
+  },
+  errorText: {
+    color: colors.destructive,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  tasksList: {
+    gap: spacing.md,
+  },
+  taskRow: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    gap: spacing.sm,
+  },
+  taskHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  taskTitle: {
+    color: colors.foreground,
+    fontSize: 18,
+    fontWeight: '600',
+    flex: 1,
+  },
+  taskBadgePending: {
+    color: colors.amber,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  taskBadgeDone: {
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  taskDescription: {
+    color: colors.slate200,
+    fontSize: 14,
+  },
+  taskProgress: {
+    backgroundColor: 'rgba(148,163,184,0.18)',
+  },
+  taskFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  taskProgressLabel: {
+    color: colors.slate200,
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  taskCompletionLabel: {
+    color: colors.slate200,
+    fontSize: 12,
+  },
+});

--- a/services/achievements-listener/src/index.ts
+++ b/services/achievements-listener/src/index.ts
@@ -9,6 +9,7 @@ import type {
   AwardResult,
   Achievement,
   Json,
+  CatchEventPayload,
 } from "#achievements-processor";
 
 const processorExports = (achievementsProcessorModule as unknown as {
@@ -172,6 +173,8 @@ type RawDailyTaskRow = {
 type DailyAssignment = {
   day: string;
   position: number;
+  conventionId: string;
+  timezone: string;
   task: DailyTaskDefinition;
 };
 
@@ -188,42 +191,160 @@ type DailyProgressRow = {
   completed_at: string | null;
 };
 
+type ConventionInfo = {
+  id: string;
+  timezone: string;
+};
+
 const DAILY_ASSIGNMENT_CACHE_TTL_SUCCESS_MS = 5 * 60 * 1000; // 5 minutes
 const DAILY_ASSIGNMENT_CACHE_TTL_EMPTY_MS = 60 * 1000; // 1 minute
 const DAILY_LOG_PREFIX = "[daily]";
 
 const dailyAssignmentCache = new Map<string, DailyAssignmentCacheEntry>();
+const conventionInfoCache = new Map<string, ConventionInfo>();
 
-function toUtcDay(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
+const assignmentCacheKey = (conventionId: string, day: string) => `${conventionId}:${day}`;
 
-function isoToUtcDay(iso: string): string {
-  const parsed = new Date(iso);
-  if (Number.isNaN(parsed.getTime())) {
-    return toUtcDay(new Date());
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const dateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getDateFormatter(timezone: string) {
+  if (!dateFormatterCache.has(timezone)) {
+    dateFormatterCache.set(
+      timezone,
+      new Intl.DateTimeFormat("en-CA", {
+        timeZone: timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }),
+    );
   }
-  return toUtcDay(parsed);
+  return dateFormatterCache.get(timezone)!;
 }
 
-function parseDay(day: string): Date {
-  return new Date(`${day}T00:00:00.000Z`);
+function getDateTimeFormatter(timezone: string) {
+  if (!dateTimeFormatterCache.has(timezone)) {
+    dateTimeFormatterCache.set(
+      timezone,
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+        timeZoneName: "shortOffset",
+      }),
+    );
+  }
+  return dateTimeFormatterCache.get(timezone)!;
 }
 
-function previousDay(day: string): string {
-  const date = parseDay(day);
-  date.setUTCDate(date.getUTCDate() - 1);
-  return toUtcDay(date);
+function pad(value: number): string {
+  return value.toString().padStart(2, "0");
 }
 
-function dayRange(day: string): { start: string; end: string } {
-  const startDate = parseDay(day);
-  const endDate = parseDay(day);
-  endDate.setUTCDate(endDate.getUTCDate() + 1);
-  return {
-    start: startDate.toISOString(),
-    end: endDate.toISOString(),
+async function getConventionInfo(conventionId: string): Promise<ConventionInfo> {
+  const cached = conventionInfoCache.get(conventionId);
+  if (cached) {
+    return cached;
+  }
+
+  const { data, error } = await client
+    .from("conventions")
+    .select("id, timezone")
+    .eq("id", conventionId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Unable to load convention ${conventionId}: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(`Convention ${conventionId} not found`);
+  }
+
+  const info: ConventionInfo = {
+    id: data.id as string,
+    timezone: (data.timezone as string | null) ?? "UTC",
   };
+  conventionInfoCache.set(conventionId, info);
+  return info;
+}
+
+function getLocalDayFromTimestamp(timestampIso: string, timezone: string): string {
+  const date = new Date(timestampIso);
+  if (Number.isNaN(date.getTime())) {
+    return getDateFormatter(timezone).format(new Date());
+  }
+  const formatter = getDateFormatter(timezone);
+  const parts = formatter.formatToParts(date);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const year = Number(lookup.year);
+  const month = Number(lookup.month);
+  const dayNumber = Number(lookup.day);
+  return `${year}-${pad(month)}-${pad(dayNumber)}`;
+}
+
+function getOffsetMilliseconds(timestamp: number, timezone: string): number {
+  const date = new Date(timestamp);
+  const formatter = getDateTimeFormatter(timezone);
+  const parts = formatter.formatToParts(date);
+  const timeZoneName = parts.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT';
+  const match = timeZoneName.match(/GMT([+-])(\d{2})(?::(\d{2}))?/);
+  if (!match) return 0;
+  const sign = match[1] === '+' ? 1 : -1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? '0');
+  return sign * ((hours * 60 + minutes) * 60 * 1000);
+}
+
+function zonedTimeToUtc(
+  timezone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): Date {
+  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+  let offset = getOffsetMilliseconds(utcTimestamp, timezone);
+  let adjusted = utcTimestamp - offset;
+
+  const newOffset = getOffsetMilliseconds(adjusted, timezone);
+  if (newOffset !== offset) {
+    offset = newOffset;
+    adjusted = utcTimestamp - offset;
+  }
+
+  return new Date(adjusted);
+}
+
+function getDayRangeUtc(day: string, timezone: string): { startUtc: string; endUtc: string } {
+  const [year, month, dayNumber] = day.split('-').map((value) => Number(value));
+  const start = zonedTimeToUtc(timezone, year, month, dayNumber);
+  const end = zonedTimeToUtc(timezone, year, month, dayNumber + 1);
+  return {
+    startUtc: start.toISOString(),
+    endUtc: end.toISOString(),
+  };
+}
+
+function previousDayLocal(day: string, timezone: string): string {
+  const [year, month, dayNumber] = day.split('-').map((value) => Number(value));
+  const startOfDayUtc = zonedTimeToUtc(timezone, year, month, dayNumber);
+  const previous = new Date(startOfDayUtc.getTime() - 24 * 60 * 60 * 1000);
+  const formatter = getDateFormatter(timezone);
+  const parts = formatter.formatToParts(previous);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const prevYear = Number(lookup.year);
+  const prevMonth = Number(lookup.month);
+  const prevDay = Number(lookup.day);
+  return `${prevYear}-${pad(prevMonth)}-${pad(prevDay)}`;
 }
 
 function coerceIso(iso: string | null | undefined, fallback: string): string {
@@ -251,8 +372,12 @@ function determineEventTimestamp(event: AchievementEvent): string {
   return createdFallback;
 }
 
-async function loadDailyAssignments(day: string): Promise<DailyAssignment[]> {
-  const cacheHit = dailyAssignmentCache.get(day);
+async function loadDailyAssignments(
+  conventionId: string,
+  day: string,
+): Promise<DailyAssignment[]> {
+  const cacheKey = assignmentCacheKey(conventionId, day);
+  const cacheHit = dailyAssignmentCache.get(cacheKey);
   const now = Date.now();
   if (cacheHit && now - cacheHit.fetchedAt < cacheHit.ttlMs) {
     return cacheHit.assignments;
@@ -261,13 +386,14 @@ async function loadDailyAssignments(day: string): Promise<DailyAssignment[]> {
   const { data, error } = await client
     .from("daily_assignments")
     .select(
-      "day, position, task:daily_tasks(id, kind, name, description, requirement, metadata, is_active)"
+      "day, convention_id, position, task:daily_tasks(id, kind, name, description, requirement, metadata, is_active), convention:conventions(timezone)"
     )
+    .eq("convention_id", conventionId)
     .eq("day", day)
     .order("position", { ascending: true });
 
   if (error) {
-    throw new Error(`Unable to load daily assignments for ${day}: ${error.message}`);
+    throw new Error(`Unable to load daily assignments for ${day} (${conventionId}): ${error.message}`);
   }
 
   const assignments: DailyAssignment[] = [];
@@ -294,9 +420,13 @@ async function loadDailyAssignments(day: string): Promise<DailyAssignment[]> {
       continue;
     }
 
+    const timezone = (row.convention as { timezone?: string } | null)?.timezone ?? "UTC";
+
     assignments.push({
       day: row.day as string,
       position: row.position as number,
+      conventionId: row.convention_id as string,
+      timezone,
       task: {
         id: task.id,
         kind: taskKind,
@@ -312,7 +442,7 @@ async function loadDailyAssignments(day: string): Promise<DailyAssignment[]> {
     ? DAILY_ASSIGNMENT_CACHE_TTL_SUCCESS_MS
     : DAILY_ASSIGNMENT_CACHE_TTL_EMPTY_MS;
 
-  dailyAssignmentCache.set(day, {
+  dailyAssignmentCache.set(cacheKey, {
     assignments,
     fetchedAt: now,
     ttlMs,
@@ -321,17 +451,29 @@ async function loadDailyAssignments(day: string): Promise<DailyAssignment[]> {
   return assignments;
 }
 
-async function getDailyAssignments(day: string): Promise<DailyAssignment[]> {
+async function getDailyAssignments(
+  conventionId: string,
+  day: string,
+  timezone: string,
+): Promise<DailyAssignment[]> {
   try {
-    return await loadDailyAssignments(day);
+    const assignments = await loadDailyAssignments(conventionId, day);
+    if (assignments.length === 0) {
+      logger.debug(`${DAILY_LOG_PREFIX} No assignments found for ${day} (convention ${conventionId})`);
+    }
+    return assignments;
   } catch (error) {
-    logger.error(`Failed fetching daily assignments for ${day}`, error);
+    logger.error(
+      `${DAILY_LOG_PREFIX} Failed fetching daily assignments for ${day} (convention ${conventionId})`,
+      error,
+    );
     return [];
   }
 }
 
 async function fetchProgressMap(
   userId: string,
+  conventionId: string,
   day: string,
   taskIds: string[],
 ): Promise<Map<string, DailyProgressRow>> {
@@ -341,6 +483,7 @@ async function fetchProgressMap(
     .from("user_daily_progress")
     .select("task_id, current_count, is_completed, completed_at")
     .eq("user_id", userId)
+    .eq("convention_id", conventionId)
     .eq("day", day)
     .in("task_id", taskIds);
 
@@ -363,6 +506,7 @@ async function fetchProgressMap(
 
 async function upsertProgress(
   userId: string,
+  conventionId: string,
   day: string,
   assignment: DailyAssignment,
   progressMap: Map<string, DailyProgressRow>,
@@ -392,6 +536,7 @@ async function upsertProgress(
     .from("user_daily_progress")
     .upsert({
       user_id: userId,
+      convention_id: conventionId,
       day,
       task_id: assignment.task.id,
       current_count: clampedCount,
@@ -417,9 +562,11 @@ async function upsertProgress(
 
 async function ensureAllTasksCompleted(
   userId: string,
+  conventionId: string,
   day: string,
   assignments: DailyAssignment[],
   eventTimestampIso: string,
+  timezone: string,
 ): Promise<void> {
   if (assignments.length === 0) return;
 
@@ -427,6 +574,7 @@ async function ensureAllTasksCompleted(
     .from("user_daily_progress")
     .select("task_id, is_completed, completed_at")
     .eq("user_id", userId)
+    .eq("convention_id", conventionId)
     .eq("day", day);
 
   if (error) {
@@ -453,6 +601,7 @@ async function ensureAllTasksCompleted(
     .from("user_daily_streaks")
     .select("current_streak, best_streak, last_completed_day")
     .eq("user_id", userId)
+    .eq("convention_id", conventionId)
     .maybeSingle();
 
   if (streakError) {
@@ -463,7 +612,7 @@ async function ensureAllTasksCompleted(
     return;
   }
 
-  const prevDay = previousDay(day);
+  const prevDay = previousDayLocal(day, timezone);
   const currentStreakPrior = streakRow?.current_streak ?? 0;
   const bestStreakPrior = streakRow?.best_streak ?? 0;
   const lastCompletedDay = streakRow?.last_completed_day ?? null;
@@ -475,6 +624,7 @@ async function ensureAllTasksCompleted(
     .from("user_daily_streaks")
     .upsert({
       user_id: userId,
+      convention_id: conventionId,
       current_streak: newCurrentStreak,
       best_streak: newBestStreak,
       last_completed_day: day,
@@ -485,25 +635,28 @@ async function ensureAllTasksCompleted(
   }
 
   logger.info(
-    `${DAILY_LOG_PREFIX} User ${userId} completed all tasks for ${day} (streak ${newCurrentStreak})`,
+    `${DAILY_LOG_PREFIX} User ${userId} completed all tasks for ${day} (convention ${conventionId}, streak ${newCurrentStreak})`,
   );
 }
 
 async function fetchCatchesForDay(
   userId: string,
+  conventionId: string,
   day: string,
+  timezone: string,
 ): Promise<{ total: number; distinct: number }> {
-  const { start, end } = dayRange(day);
+  const { startUtc, endUtc } = getDayRangeUtc(day, timezone);
   const { data, error } = await client
     .from("catches")
     .select("fursuit_id")
     .eq("catcher_id", userId)
-    .gte("caught_at", start)
-    .lt("caught_at", end);
+    .eq("convention_id", conventionId)
+    .gte("caught_at", startUtc)
+    .lt("caught_at", endUtc);
 
   if (error) {
     throw new Error(
-      `Unable to load catches for user ${userId} on ${day}: ${error.message}`,
+      `Unable to load catches for user ${userId} on ${day} (convention ${conventionId}): ${error.message}`,
     );
   }
 
@@ -522,19 +675,62 @@ async function fetchCatchesForDay(
   };
 }
 
-async function processCatchDailyTasks(
-  event: AchievementEvent,
-  day: string,
-  assignments: DailyAssignment[],
-  eventTimestampIso: string,
-): Promise<void> {
-  const payload = event.payload as {
-    catcher_id?: string | null;
-  } | null;
+async function fetchCatchContext(
+  catchId: string,
+): Promise<{ catcher_id: string | null; convention_id: string | null } | null> {
+  const { data, error } = await client
+    .from('catches')
+    .select('catcher_id, convention_id')
+    .eq('id', catchId)
+    .maybeSingle();
 
-  const userId = payload?.catcher_id ?? null;
+  if (error) {
+    logger.error(`${DAILY_LOG_PREFIX} Failed loading catch ${catchId}`, error);
+    throw new Error(`Unable to load catch ${catchId}: ${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const row = data as { catcher_id: string | null; convention_id: string | null };
+  return row;
+}
+
+async function processCatchDailyTasks(event: AchievementEvent): Promise<void> {
+  const payload = event.payload as CatchEventPayload;
+  const catchId = payload?.catch_id;
+
+  if (!catchId) {
+    logger.warn(`${DAILY_LOG_PREFIX} Catch event ${event.id} missing catch_id`);
+    return;
+  }
+
+  const catchContext = await fetchCatchContext(catchId);
+  if (!catchContext) {
+    logger.warn(`${DAILY_LOG_PREFIX} Catch ${catchId} not found; skipping`);
+    return;
+  }
+
+  const userId = catchContext.catcher_id;
   if (!userId) {
-    logger.warn(`${DAILY_LOG_PREFIX} Catch event ${event.id} missing catcher_id`);
+    logger.warn(`${DAILY_LOG_PREFIX} Catch ${catchId} missing catcher_id`);
+    return;
+  }
+
+  const conventionId = catchContext.convention_id;
+  if (!conventionId) {
+    logger.debug(`${DAILY_LOG_PREFIX} Catch ${catchId} has no convention; skipping`);
+    return;
+  }
+
+  const { timezone } = await getConventionInfo(conventionId);
+  const eventTimestampIso = determineEventTimestamp(event);
+  const day = getLocalDayFromTimestamp(eventTimestampIso, timezone);
+  const assignments = await getDailyAssignments(conventionId, day, timezone);
+
+  if (assignments.length === 0) {
+    logger.debug(`${DAILY_LOG_PREFIX} No assignments for ${day} (convention ${conventionId})`);
     return;
   }
 
@@ -543,9 +739,13 @@ async function processCatchDailyTasks(
     return;
   }
 
-  const stats = await fetchCatchesForDay(userId, day);
+  const stats = await fetchCatchesForDay(userId, conventionId, day, timezone);
+  if (stats.total === 0 && stats.distinct === 0) {
+    return;
+  }
+
   const taskIds = relevantAssignments.map((assignment) => assignment.task.id);
-  const progressMap = await fetchProgressMap(userId, day, taskIds);
+  const progressMap = await fetchProgressMap(userId, conventionId, day, taskIds);
 
   let changed = false;
 
@@ -559,6 +759,7 @@ async function processCatchDailyTasks(
 
     const updated = await upsertProgress(
       userId,
+      conventionId,
       day,
       assignment,
       progressMap,
@@ -572,23 +773,31 @@ async function processCatchDailyTasks(
   }
 
   if (changed) {
-    await ensureAllTasksCompleted(userId, day, assignments, eventTimestampIso);
+    await ensureAllTasksCompleted(userId, conventionId, day, assignments, eventTimestampIso, timezone);
   }
 }
 
-async function processLeaderboardDailyTasks(
-  event: AchievementEvent,
-  day: string,
-  assignments: DailyAssignment[],
-  eventTimestampIso: string,
-): Promise<void> {
+async function processLeaderboardDailyTasks(event: AchievementEvent): Promise<void> {
   const payload = event.payload as {
     user_id?: string | null;
+    convention_id?: string | null;
   } | null;
 
   const userId = payload?.user_id ?? null;
-  if (!userId) {
-    logger.warn(`${DAILY_LOG_PREFIX} Leaderboard refresh event ${event.id} missing user_id`);
+  const conventionId = payload?.convention_id ?? null;
+
+  if (!userId || !conventionId) {
+    logger.warn(`${DAILY_LOG_PREFIX} Leaderboard refresh event ${event.id} missing identifiers`);
+    return;
+  }
+
+  const { timezone } = await getConventionInfo(conventionId);
+  const eventTimestampIso = determineEventTimestamp(event);
+  const day = getLocalDayFromTimestamp(eventTimestampIso, timezone);
+  const assignments = await getDailyAssignments(conventionId, day, timezone);
+
+  if (assignments.length === 0) {
+    logger.debug(`${DAILY_LOG_PREFIX} No assignments for ${day} (convention ${conventionId})`);
     return;
   }
 
@@ -598,7 +807,7 @@ async function processLeaderboardDailyTasks(
   }
 
   const taskIds = relevantAssignments.map((assignment) => assignment.task.id);
-  const progressMap = await fetchProgressMap(userId, day, taskIds);
+  const progressMap = await fetchProgressMap(userId, conventionId, day, taskIds);
 
   let changed = false;
 
@@ -608,6 +817,7 @@ async function processLeaderboardDailyTasks(
 
     const updated = await upsertProgress(
       userId,
+      conventionId,
       day,
       assignment,
       progressMap,
@@ -621,31 +831,20 @@ async function processLeaderboardDailyTasks(
   }
 
   if (changed) {
-    await ensureAllTasksCompleted(userId, day, assignments, eventTimestampIso);
+    await ensureAllTasksCompleted(userId, conventionId, day, assignments, eventTimestampIso, timezone);
   }
 }
 
 async function processDailyTasks(event: AchievementEvent): Promise<void> {
-  const eventTimestampIso = determineEventTimestamp(event);
-  const day = isoToUtcDay(eventTimestampIso);
-  const assignments = await getDailyAssignments(day);
-
-  if (assignments.length === 0) {
-    logger.debug(`${DAILY_LOG_PREFIX} No assignments for ${day}, skipping event ${event.id}`);
-    return;
-  }
-
-  const eventType = event.event_type as string;
-
-  switch (eventType) {
+  switch (event.event_type) {
     case "catch.created":
-      await processCatchDailyTasks(event, day, assignments, eventTimestampIso);
+      await processCatchDailyTasks(event);
       break;
     case "leaderboard.refreshed":
-      await processLeaderboardDailyTasks(event, day, assignments, eventTimestampIso);
+      await processLeaderboardDailyTasks(event);
       break;
     default:
-      logger.debug(`${DAILY_LOG_PREFIX} No handler for event type ${eventType}`);
+      logger.debug(`${DAILY_LOG_PREFIX} No handler for event type ${event.event_type}`);
   }
 }
 

--- a/services/achievements-listener/src/index.ts
+++ b/services/achievements-listener/src/index.ts
@@ -146,6 +146,509 @@ const processor = createAchievementProcessor({
   onAwardGranted: insertNotification,
 });
 
+type DailyTaskKind = "catch" | "view_bio" | "leaderboard" | "meta" | "share";
+
+type DailyTaskMetadata = Record<string, unknown>;
+
+type DailyTaskDefinition = {
+  id: string;
+  kind: DailyTaskKind;
+  name: string;
+  description: string;
+  requirement: number;
+  metadata: DailyTaskMetadata;
+};
+
+type RawDailyTaskRow = {
+  id: string;
+  kind: string;
+  name: string;
+  description: string;
+  requirement: number;
+  metadata?: unknown;
+  is_active?: boolean | null;
+};
+
+type DailyAssignment = {
+  day: string;
+  position: number;
+  task: DailyTaskDefinition;
+};
+
+type DailyAssignmentCacheEntry = {
+  assignments: DailyAssignment[];
+  fetchedAt: number;
+  ttlMs: number;
+};
+
+type DailyProgressRow = {
+  task_id: string;
+  current_count: number;
+  is_completed: boolean;
+  completed_at: string | null;
+};
+
+const DAILY_ASSIGNMENT_CACHE_TTL_SUCCESS_MS = 5 * 60 * 1000; // 5 minutes
+const DAILY_ASSIGNMENT_CACHE_TTL_EMPTY_MS = 60 * 1000; // 1 minute
+const DAILY_LOG_PREFIX = "[daily]";
+
+const dailyAssignmentCache = new Map<string, DailyAssignmentCacheEntry>();
+
+function toUtcDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function isoToUtcDay(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return toUtcDay(new Date());
+  }
+  return toUtcDay(parsed);
+}
+
+function parseDay(day: string): Date {
+  return new Date(`${day}T00:00:00.000Z`);
+}
+
+function previousDay(day: string): string {
+  const date = parseDay(day);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return toUtcDay(date);
+}
+
+function dayRange(day: string): { start: string; end: string } {
+  const startDate = parseDay(day);
+  const endDate = parseDay(day);
+  endDate.setUTCDate(endDate.getUTCDate() + 1);
+  return {
+    start: startDate.toISOString(),
+    end: endDate.toISOString(),
+  };
+}
+
+function coerceIso(iso: string | null | undefined, fallback: string): string {
+  if (!iso) return fallback;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback;
+  }
+  return parsed.toISOString();
+}
+
+function determineEventTimestamp(event: AchievementEvent): string {
+  const createdFallback = coerceIso(event.created_at, new Date().toISOString());
+  if (event.event_type === "catch.created") {
+    const payload = event.payload as { caught_at?: string | null } | null;
+    if (payload?.caught_at) {
+      return coerceIso(payload.caught_at, createdFallback);
+    }
+  } else if (event.event_type === "leaderboard.refreshed") {
+    const payload = event.payload as { refreshed_at?: string | null } | null;
+    if (payload?.refreshed_at) {
+      return coerceIso(payload.refreshed_at, createdFallback);
+    }
+  }
+  return createdFallback;
+}
+
+async function loadDailyAssignments(day: string): Promise<DailyAssignment[]> {
+  const cacheHit = dailyAssignmentCache.get(day);
+  const now = Date.now();
+  if (cacheHit && now - cacheHit.fetchedAt < cacheHit.ttlMs) {
+    return cacheHit.assignments;
+  }
+
+  const { data, error } = await client
+    .from("daily_assignments")
+    .select(
+      "day, position, task:daily_tasks(id, kind, name, description, requirement, metadata, is_active)"
+    )
+    .eq("day", day)
+    .order("position", { ascending: true });
+
+  if (error) {
+    throw new Error(`Unable to load daily assignments for ${day}: ${error.message}`);
+  }
+
+  const assignments: DailyAssignment[] = [];
+  for (const row of data ?? []) {
+    const taskRelation = row.task as unknown;
+    const resolvedTask = Array.isArray(taskRelation) ? taskRelation[0] : taskRelation;
+
+    if (!resolvedTask || typeof resolvedTask !== "object") {
+      continue;
+    }
+
+    const task = resolvedTask as RawDailyTaskRow;
+    if (task.is_active === false) continue;
+
+    const taskKind = task.kind as DailyTaskKind;
+    if (
+      taskKind !== "catch"
+      && taskKind !== "view_bio"
+      && taskKind !== "leaderboard"
+      && taskKind !== "meta"
+      && taskKind !== "share"
+    ) {
+      logger.warn(`${DAILY_LOG_PREFIX} Unknown task kind '${task.kind}'`);
+      continue;
+    }
+
+    assignments.push({
+      day: row.day as string,
+      position: row.position as number,
+      task: {
+        id: task.id,
+        kind: taskKind,
+        name: task.name,
+        description: task.description,
+        requirement: task.requirement,
+        metadata: (task.metadata ?? {}) as DailyTaskMetadata,
+      },
+    });
+  }
+
+  const ttlMs = assignments.length > 0
+    ? DAILY_ASSIGNMENT_CACHE_TTL_SUCCESS_MS
+    : DAILY_ASSIGNMENT_CACHE_TTL_EMPTY_MS;
+
+  dailyAssignmentCache.set(day, {
+    assignments,
+    fetchedAt: now,
+    ttlMs,
+  });
+
+  return assignments;
+}
+
+async function getDailyAssignments(day: string): Promise<DailyAssignment[]> {
+  try {
+    return await loadDailyAssignments(day);
+  } catch (error) {
+    logger.error(`Failed fetching daily assignments for ${day}`, error);
+    return [];
+  }
+}
+
+async function fetchProgressMap(
+  userId: string,
+  day: string,
+  taskIds: string[],
+): Promise<Map<string, DailyProgressRow>> {
+  if (taskIds.length === 0) return new Map();
+
+  const { data, error } = await client
+    .from("user_daily_progress")
+    .select("task_id, current_count, is_completed, completed_at")
+    .eq("user_id", userId)
+    .eq("day", day)
+    .in("task_id", taskIds);
+
+  if (error) {
+    throw new Error(`Unable to load daily progress for ${userId} on ${day}: ${error.message}`);
+  }
+
+  const map = new Map<string, DailyProgressRow>();
+  for (const row of data ?? []) {
+    const entry = row as DailyProgressRow;
+    map.set(entry.task_id, {
+      task_id: entry.task_id,
+      current_count: entry.current_count ?? 0,
+      is_completed: entry.is_completed ?? false,
+      completed_at: entry.completed_at ?? null,
+    });
+  }
+  return map;
+}
+
+async function upsertProgress(
+  userId: string,
+  day: string,
+  assignment: DailyAssignment,
+  progressMap: Map<string, DailyProgressRow>,
+  absoluteCount: number,
+  eventTimestampIso: string,
+): Promise<boolean> {
+  const existing = progressMap.get(assignment.task.id);
+  const currentCount = existing?.current_count ?? 0;
+  const targetCount = Math.max(currentCount, absoluteCount);
+  const clampedCount = Math.min(targetCount, assignment.task.requirement);
+  const completed = clampedCount >= assignment.task.requirement;
+  const shouldUpdate =
+    !existing
+    || existing.current_count !== clampedCount
+    || existing.is_completed !== completed
+    || (completed && !existing.completed_at);
+
+  if (!shouldUpdate) {
+    return false;
+  }
+
+  const completedAt = completed
+    ? existing?.completed_at ?? eventTimestampIso
+    : null;
+
+  const { error } = await client
+    .from("user_daily_progress")
+    .upsert({
+      user_id: userId,
+      day,
+      task_id: assignment.task.id,
+      current_count: clampedCount,
+      is_completed: completed,
+      completed_at: completedAt,
+    });
+
+  if (error) {
+    throw new Error(
+      `Unable to upsert daily progress for user ${userId}, task ${assignment.task.id}: ${error.message}`,
+    );
+  }
+
+  progressMap.set(assignment.task.id, {
+    task_id: assignment.task.id,
+    current_count: clampedCount,
+    is_completed: completed,
+    completed_at: completedAt,
+  });
+
+  return true;
+}
+
+async function ensureAllTasksCompleted(
+  userId: string,
+  day: string,
+  assignments: DailyAssignment[],
+  eventTimestampIso: string,
+): Promise<void> {
+  if (assignments.length === 0) return;
+
+  const { data, error } = await client
+    .from("user_daily_progress")
+    .select("task_id, is_completed, completed_at")
+    .eq("user_id", userId)
+    .eq("day", day);
+
+  if (error) {
+    throw new Error(`Unable to verify daily completion for ${userId} on ${day}: ${error.message}`);
+  }
+
+  const completionMap = new Map<string, { is_completed: boolean; completed_at: string | null }>();
+  for (const row of data ?? []) {
+    completionMap.set(row.task_id as string, {
+      is_completed: Boolean(row.is_completed),
+      completed_at: (row.completed_at as string | null) ?? null,
+    });
+  }
+
+  const allComplete = assignments.every((assignment) =>
+    completionMap.get(assignment.task.id)?.is_completed === true
+  );
+
+  if (!allComplete) {
+    return;
+  }
+
+  const { data: streakRow, error: streakError } = await client
+    .from("user_daily_streaks")
+    .select("current_streak, best_streak, last_completed_day")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (streakError) {
+    throw new Error(`Unable to load streak for ${userId}: ${streakError.message}`);
+  }
+
+  if (streakRow?.last_completed_day === day) {
+    return;
+  }
+
+  const prevDay = previousDay(day);
+  const currentStreakPrior = streakRow?.current_streak ?? 0;
+  const bestStreakPrior = streakRow?.best_streak ?? 0;
+  const lastCompletedDay = streakRow?.last_completed_day ?? null;
+
+  const newCurrentStreak = lastCompletedDay === prevDay ? currentStreakPrior + 1 : 1;
+  const newBestStreak = Math.max(bestStreakPrior, newCurrentStreak);
+
+  const { error: upsertError } = await client
+    .from("user_daily_streaks")
+    .upsert({
+      user_id: userId,
+      current_streak: newCurrentStreak,
+      best_streak: newBestStreak,
+      last_completed_day: day,
+    });
+
+  if (upsertError) {
+    throw new Error(`Unable to update streak for ${userId}: ${upsertError.message}`);
+  }
+
+  logger.info(
+    `${DAILY_LOG_PREFIX} User ${userId} completed all tasks for ${day} (streak ${newCurrentStreak})`,
+  );
+}
+
+async function fetchCatchesForDay(
+  userId: string,
+  day: string,
+): Promise<{ total: number; distinct: number }> {
+  const { start, end } = dayRange(day);
+  const { data, error } = await client
+    .from("catches")
+    .select("fursuit_id")
+    .eq("catcher_id", userId)
+    .gte("caught_at", start)
+    .lt("caught_at", end);
+
+  if (error) {
+    throw new Error(
+      `Unable to load catches for user ${userId} on ${day}: ${error.message}`,
+    );
+  }
+
+  const rows = data ?? [];
+  const unique = new Set<string>();
+  for (const row of rows) {
+    const fursuitId = (row as { fursuit_id?: string | null }).fursuit_id;
+    if (fursuitId) {
+      unique.add(fursuitId);
+    }
+  }
+
+  return {
+    total: rows.length,
+    distinct: unique.size,
+  };
+}
+
+async function processCatchDailyTasks(
+  event: AchievementEvent,
+  day: string,
+  assignments: DailyAssignment[],
+  eventTimestampIso: string,
+): Promise<void> {
+  const payload = event.payload as {
+    catcher_id?: string | null;
+  } | null;
+
+  const userId = payload?.catcher_id ?? null;
+  if (!userId) {
+    logger.warn(`${DAILY_LOG_PREFIX} Catch event ${event.id} missing catcher_id`);
+    return;
+  }
+
+  const relevantAssignments = assignments.filter((assignment) => assignment.task.kind === "catch");
+  if (relevantAssignments.length === 0) {
+    return;
+  }
+
+  const stats = await fetchCatchesForDay(userId, day);
+  const taskIds = relevantAssignments.map((assignment) => assignment.task.id);
+  const progressMap = await fetchProgressMap(userId, day, taskIds);
+
+  let changed = false;
+
+  for (const assignment of relevantAssignments) {
+    const metadata = assignment.task.metadata ?? {};
+    const requiresDistinct = metadata.distinct === true;
+    const absoluteCount = requiresDistinct ? stats.distinct : stats.total;
+    if (absoluteCount === 0) {
+      continue;
+    }
+
+    const updated = await upsertProgress(
+      userId,
+      day,
+      assignment,
+      progressMap,
+      absoluteCount,
+      eventTimestampIso,
+    );
+
+    if (updated) {
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await ensureAllTasksCompleted(userId, day, assignments, eventTimestampIso);
+  }
+}
+
+async function processLeaderboardDailyTasks(
+  event: AchievementEvent,
+  day: string,
+  assignments: DailyAssignment[],
+  eventTimestampIso: string,
+): Promise<void> {
+  const payload = event.payload as {
+    user_id?: string | null;
+  } | null;
+
+  const userId = payload?.user_id ?? null;
+  if (!userId) {
+    logger.warn(`${DAILY_LOG_PREFIX} Leaderboard refresh event ${event.id} missing user_id`);
+    return;
+  }
+
+  const relevantAssignments = assignments.filter((assignment) => assignment.task.kind === "leaderboard");
+  if (relevantAssignments.length === 0) {
+    return;
+  }
+
+  const taskIds = relevantAssignments.map((assignment) => assignment.task.id);
+  const progressMap = await fetchProgressMap(userId, day, taskIds);
+
+  let changed = false;
+
+  for (const assignment of relevantAssignments) {
+    const existing = progressMap.get(assignment.task.id);
+    const nextCount = Math.min((existing?.current_count ?? 0) + 1, assignment.task.requirement);
+
+    const updated = await upsertProgress(
+      userId,
+      day,
+      assignment,
+      progressMap,
+      nextCount,
+      eventTimestampIso,
+    );
+
+    if (updated) {
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await ensureAllTasksCompleted(userId, day, assignments, eventTimestampIso);
+  }
+}
+
+async function processDailyTasks(event: AchievementEvent): Promise<void> {
+  const eventTimestampIso = determineEventTimestamp(event);
+  const day = isoToUtcDay(eventTimestampIso);
+  const assignments = await getDailyAssignments(day);
+
+  if (assignments.length === 0) {
+    logger.debug(`${DAILY_LOG_PREFIX} No assignments for ${day}, skipping event ${event.id}`);
+    return;
+  }
+
+  const eventType = event.event_type as string;
+
+  switch (eventType) {
+    case "catch.created":
+      await processCatchDailyTasks(event, day, assignments, eventTimestampIso);
+      break;
+    case "leaderboard.refreshed":
+      await processLeaderboardDailyTasks(event, day, assignments, eventTimestampIso);
+      break;
+    default:
+      logger.debug(`${DAILY_LOG_PREFIX} No handler for event type ${eventType}`);
+  }
+}
+
 let queue = Promise.resolve();
 
 function enqueue(event: AchievementEvent) {
@@ -162,10 +665,11 @@ async function handleEvent(event: AchievementEvent) {
     return;
   }
 
+  let processResult: ProcessResult | undefined;
+
   await pRetry(
     async () => {
-      const result = await processor.processEvent(event);
-      logResult(result);
+      processResult = await processor.processEvent(event);
     },
     {
       retries: 3,
@@ -177,6 +681,26 @@ async function handleEvent(event: AchievementEvent) {
     },
   ).catch((error) => {
     logger.error(`Failed processing event ${event.id} after retries`, error);
+  });
+
+  if (processResult) {
+    logResult(processResult);
+  }
+
+  await pRetry(
+    async () => {
+      await processDailyTasks(event);
+    },
+    {
+      retries: 3,
+      onFailedAttempt: (error) => {
+        logger.warn(
+          `Daily tasks attempt ${error.attemptNumber} failed for event ${event.id}: ${(error as Error).message}`,
+        );
+      },
+    },
+  ).catch((error) => {
+    logger.error(`Failed updating daily tasks for event ${event.id} after retries`, error);
   });
 }
 

--- a/src/components/ui/TailTagProgressBar.tsx
+++ b/src/components/ui/TailTagProgressBar.tsx
@@ -1,0 +1,47 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+
+import { colors, radius } from '../../theme';
+
+type TailTagProgressBarProps = {
+  value: number;
+  trackColor?: string;
+  indicatorColor?: string;
+  style?: StyleProp<ViewStyle>;
+  fillStyle?: StyleProp<ViewStyle>;
+};
+
+export function TailTagProgressBar({
+  value,
+  trackColor = 'rgba(148,163,184,0.25)',
+  indicatorColor = colors.primary,
+  style,
+  fillStyle,
+}: TailTagProgressBarProps) {
+  const clamped = Math.min(Math.max(value, 0), 1);
+  const widthPercent = `${Math.round(clamped * 100)}%` as `${number}%`;
+
+  return (
+    <View style={[styles.track, { backgroundColor: trackColor }, style]}>
+      <View
+        style={[
+          styles.fill,
+          { backgroundColor: indicatorColor, width: widthPercent },
+          fillStyle,
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    height: 8,
+    borderRadius: radius.md,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: radius.md,
+  },
+});

--- a/src/features/conventions/api/conventions.ts
+++ b/src/features/conventions/api/conventions.ts
@@ -7,6 +7,7 @@ export type ConventionSummary = {
   location: string | null;
   start_date: string | null;
   end_date: string | null;
+  timezone: string;
 };
 
 export const CONVENTIONS_QUERY_KEY = 'conventions';
@@ -17,7 +18,7 @@ export async function fetchConventions(): Promise<ConventionSummary[]> {
   const client = supabase as any;
   const { data, error } = await client
     .from('conventions')
-    .select('id, slug, name, location, start_date, end_date')
+    .select('id, slug, name, location, start_date, end_date, timezone')
     .order('start_date', { ascending: true, nullsFirst: false })
     .order('name', { ascending: true });
 
@@ -25,14 +26,15 @@ export async function fetchConventions(): Promise<ConventionSummary[]> {
     throw new Error(`We couldn't load conventions: ${error.message}`);
   }
 
-  return (data ?? []).map((convention: any) => ({
-    id: convention.id,
-    slug: convention.slug,
-    name: convention.name,
-    location: convention.location ?? null,
-    start_date: convention.start_date ?? null,
-    end_date: convention.end_date ?? null,
-  }));
+    return (data ?? []).map((convention: any) => ({
+      id: convention.id,
+      slug: convention.slug,
+      name: convention.name,
+      location: convention.location ?? null,
+      start_date: convention.start_date ?? null,
+      end_date: convention.end_date ?? null,
+      timezone: convention.timezone ?? 'UTC',
+    }));
 }
 
 export const createConventionsQueryOptions = () => ({

--- a/src/features/daily-tasks/api/dailyTasks.ts
+++ b/src/features/daily-tasks/api/dailyTasks.ts
@@ -1,0 +1,160 @@
+import { supabase } from '../../../lib/supabase';
+import type {
+  DailyAssignmentsRow,
+  DailyTaskKind,
+  DailyTasksRow,
+  Json,
+  UserDailyProgressRow,
+  UserDailyStreaksRow,
+} from '../../../types/database';
+
+export type DailyTaskRecord = {
+  id: string;
+  name: string;
+  description: string;
+  kind: DailyTaskKind;
+  requirement: number;
+  metadata: Json;
+};
+
+export type DailyTaskProgress = DailyTaskRecord & {
+  position: number;
+  currentCount: number;
+  isCompleted: boolean;
+  completedAt: string | null;
+};
+
+export type DailyTasksSummary = {
+  day: string;
+  tasks: DailyTaskProgress[];
+  totalCount: number;
+  completedCount: number;
+  remainingCount: number;
+  streak: {
+    current: number;
+    best: number;
+    lastCompletedDay: string | null;
+  };
+};
+
+type FetchDailyTasksParams = {
+  day: string;
+  userId: string;
+};
+
+type AssignmentRow = DailyAssignmentsRow & {
+  task: DailyTasksRow | DailyTasksRow[] | null;
+};
+
+type ProgressRow = Pick<
+  UserDailyProgressRow,
+  'task_id' | 'current_count' | 'is_completed' | 'completed_at'
+>;
+
+type StreakRow = Pick<
+  UserDailyStreaksRow,
+  'current_streak' | 'best_streak' | 'last_completed_day'
+>;
+
+const EMPTY_STREAK = {
+  current: 0,
+  best: 0,
+  lastCompletedDay: null as string | null,
+};
+
+export async function fetchDailyTasks({ day, userId }: FetchDailyTasksParams): Promise<DailyTasksSummary> {
+  const assignmentsPromise = supabase
+    .from('daily_assignments')
+    .select(
+      'id, day, position, task:daily_tasks(id, name, description, kind, requirement, metadata, is_active)'
+    )
+    .eq('day', day)
+    .order('position', { ascending: true });
+
+  const progressPromise = supabase
+    .from('user_daily_progress')
+    .select('task_id, current_count, is_completed, completed_at')
+    .eq('user_id', userId)
+    .eq('day', day);
+
+  const streakPromise = supabase
+    .from('user_daily_streaks')
+    .select('current_streak, best_streak, last_completed_day')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  const [assignmentsResult, progressResult, streakResult] = await Promise.all([
+    assignmentsPromise,
+    progressPromise,
+    streakPromise,
+  ]);
+
+  if (assignmentsResult.error) {
+    throw new Error(`We couldn't load today's tasks: ${assignmentsResult.error.message}`);
+  }
+
+  if (progressResult.error) {
+    throw new Error(`We couldn't load your task progress: ${progressResult.error.message}`);
+  }
+
+  if (streakResult.error) {
+    throw new Error(`We couldn't load your streak: ${streakResult.error.message}`);
+  }
+
+  const progressMap = new Map<string, ProgressRow>();
+  for (const row of (progressResult.data ?? []) as ProgressRow[]) {
+    progressMap.set(row.task_id, row);
+  }
+
+  const tasks: DailyTaskProgress[] = [];
+
+  for (const row of (assignmentsResult.data ?? []) as AssignmentRow[]) {
+    const relation = row.task;
+    const resolvedTask = Array.isArray(relation) ? relation[0] : relation;
+
+    if (!resolvedTask || resolvedTask.is_active === false) {
+      continue;
+    }
+
+    const progress = progressMap.get(resolvedTask.id);
+    const currentCount = Math.max(progress?.current_count ?? 0, 0);
+    const requirement = Math.max(resolvedTask.requirement ?? 0, 0);
+
+    tasks.push({
+      id: resolvedTask.id,
+      name: resolvedTask.name,
+      description: resolvedTask.description,
+      kind: resolvedTask.kind,
+      requirement,
+      metadata: resolvedTask.metadata ?? ({} as Json),
+      position: row.position,
+      currentCount,
+      isCompleted: progress?.is_completed ?? false,
+      completedAt: progress?.completed_at ?? null,
+    });
+  }
+
+  tasks.sort((a, b) => a.position - b.position);
+
+  const totalCount = tasks.length;
+  const completedCount = tasks.filter((task) => task.isCompleted).length;
+  const remainingCount = Math.max(totalCount - completedCount, 0);
+
+  const streakRow = (streakResult.data ?? null) as StreakRow | null;
+  const streak = streakRow
+    ? {
+        current: streakRow.current_streak ?? 0,
+        best: streakRow.best_streak ?? 0,
+        lastCompletedDay: streakRow.last_completed_day ?? null,
+      }
+    : { ...EMPTY_STREAK };
+
+  return {
+    day,
+    tasks,
+    totalCount,
+    completedCount,
+    remainingCount,
+    streak,
+  } satisfies DailyTasksSummary;
+}

--- a/src/features/daily-tasks/api/dailyTasks.ts
+++ b/src/features/daily-tasks/api/dailyTasks.ts
@@ -30,6 +30,10 @@ export type DailyTasksSummary = {
   totalCount: number;
   completedCount: number;
   remainingCount: number;
+  conventionId: string;
+  timezone: string;
+  resetAt: string;
+  millisecondsUntilReset: number;
   streak: {
     current: number;
     best: number;
@@ -38,8 +42,8 @@ export type DailyTasksSummary = {
 };
 
 type FetchDailyTasksParams = {
-  day: string;
   userId: string;
+  conventionId: string;
 };
 
 type AssignmentRow = DailyAssignmentsRow & {
@@ -62,25 +66,166 @@ const EMPTY_STREAK = {
   lastCompletedDay: null as string | null,
 };
 
-export async function fetchDailyTasks({ day, userId }: FetchDailyTasksParams): Promise<DailyTasksSummary> {
+type ConventionTimezoneRow = {
+  id: string;
+  timezone: string;
+};
+
+const dateCache = new Map<string, Intl.DateTimeFormat>();
+
+function getDateFormatter(timezone: string) {
+  if (!dateCache.has(timezone)) {
+    dateCache.set(
+      timezone,
+      new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }),
+    );
+  }
+  return dateCache.get(timezone)!;
+}
+
+function getDateTimeFormatter(timezone: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'shortOffset',
+  });
+}
+
+function pad(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+function getLocalDay(now: Date, timezone: string): {
+  day: string;
+  year: number;
+  month: number;
+  dayNumber: number;
+} {
+  const formatter = getDateFormatter(timezone);
+  const parts = formatter.formatToParts(now);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const year = Number(lookup.year);
+  const month = Number(lookup.month);
+  const dayNumber = Number(lookup.day);
+  return {
+    day: `${year}-${pad(month)}-${pad(dayNumber)}`,
+    year,
+    month,
+    dayNumber,
+  };
+}
+
+function getOffsetMilliseconds(timestamp: number, timezone: string): number {
+  const date = new Date(timestamp);
+  const formatter = getDateTimeFormatter(timezone);
+  const parts = formatter.formatToParts(date);
+  const timeZoneName = parts.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT';
+  const match = timeZoneName.match(/GMT([+-])(\d{2})(?::(\d{2}))?/);
+  if (!match) return 0;
+  const sign = match[1] === '+' ? 1 : -1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? '0');
+  return sign * ((hours * 60 + minutes) * 60 * 1000);
+}
+
+function zonedTimeToUtc(
+  timezone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): Date {
+  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+  let offset = getOffsetMilliseconds(utcTimestamp, timezone);
+  let adjusted = utcTimestamp - offset;
+
+  const newOffset = getOffsetMilliseconds(adjusted, timezone);
+  if (newOffset !== offset) {
+    offset = newOffset;
+    adjusted = utcTimestamp - offset;
+  }
+
+  return new Date(adjusted);
+}
+
+function computeResetMetadata(timezone: string, nowUtc: Date) {
+  const localDay = getLocalDay(nowUtc, timezone);
+  const nextResetDate = zonedTimeToUtc(
+    timezone,
+    localDay.year,
+    localDay.month,
+    localDay.dayNumber + 1,
+  );
+  const resetAtIso = nextResetDate.toISOString();
+  const millisecondsUntilReset = Math.max(nextResetDate.getTime() - nowUtc.getTime(), 0);
+
+  return {
+    day: localDay.day,
+    resetAtIso,
+    millisecondsUntilReset,
+  };
+}
+
+export async function fetchDailyTasks({
+  userId,
+  conventionId,
+}: FetchDailyTasksParams): Promise<DailyTasksSummary> {
+  const { data: conventionRow, error: conventionError } = await supabase
+    .from('conventions')
+    .select('id, timezone')
+    .eq('id', conventionId)
+    .maybeSingle();
+
+  if (conventionError) {
+    throw new Error(`We couldn't load convention info: ${conventionError.message}`);
+  }
+
+  if (!conventionRow) {
+    throw new Error('That convention is no longer available.');
+  }
+
+  const convention = conventionRow as ConventionTimezoneRow;
+  const timezone = convention.timezone ?? 'UTC';
+  const nowUtc = new Date();
+  const { day: localDay, resetAtIso, millisecondsUntilReset } = computeResetMetadata(
+    timezone,
+    nowUtc,
+  );
+
   const assignmentsPromise = supabase
     .from('daily_assignments')
     .select(
-      'id, day, position, task:daily_tasks(id, name, description, kind, requirement, metadata, is_active)'
+      'id, day, position, convention_id, task:daily_tasks(id, name, description, kind, requirement, metadata, is_active)'
     )
-    .eq('day', day)
+    .eq('day', localDay)
+    .eq('convention_id', conventionId)
     .order('position', { ascending: true });
 
   const progressPromise = supabase
     .from('user_daily_progress')
     .select('task_id, current_count, is_completed, completed_at')
     .eq('user_id', userId)
-    .eq('day', day);
+    .eq('day', localDay)
+    .eq('convention_id', conventionId);
 
   const streakPromise = supabase
     .from('user_daily_streaks')
     .select('current_streak, best_streak, last_completed_day')
     .eq('user_id', userId)
+    .eq('convention_id', conventionId)
     .maybeSingle();
 
   const [assignmentsResult, progressResult, streakResult] = await Promise.all([
@@ -150,11 +295,15 @@ export async function fetchDailyTasks({ day, userId }: FetchDailyTasksParams): P
     : { ...EMPTY_STREAK };
 
   return {
-    day,
+    day: localDay,
     tasks,
     totalCount,
     completedCount,
     remainingCount,
+    conventionId,
+    timezone,
+    resetAt: resetAtIso,
+    millisecondsUntilReset,
     streak,
   } satisfies DailyTasksSummary;
 }

--- a/src/features/daily-tasks/hooks.ts
+++ b/src/features/daily-tasks/hooks.ts
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+
+import { supabase } from '../../lib/supabase';
+import type { DailyTasksSummary, DailyTaskProgress } from './api/dailyTasks';
+import { fetchDailyTasks } from './api/dailyTasks';
+
+const DAILY_TASKS_QUERY_KEY = 'daily-tasks';
+
+export const dailyTasksQueryKey = (userId: string, day: string) =>
+  [DAILY_TASKS_QUERY_KEY, userId, day] as const;
+
+type ProgressPayload = {
+  task_id: string;
+  user_id: string;
+  day: string;
+  current_count: number;
+  is_completed: boolean;
+  completed_at: string | null;
+};
+
+const MILLISECONDS_IN_SECOND = 1000;
+const MILLISECONDS_IN_MINUTE = 60 * MILLISECONDS_IN_SECOND;
+const MILLISECONDS_IN_HOUR = 60 * MILLISECONDS_IN_MINUTE;
+
+function useDailyTicker(intervalMs = MILLISECONDS_IN_SECOND) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setNow(new Date());
+    }, intervalMs);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [intervalMs]);
+
+  return now;
+}
+
+function formatUtcDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getNextUtcMidnight(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1));
+}
+
+function formatCountdown(milliseconds: number): string {
+  const clamped = Math.max(milliseconds, 0);
+
+  const hours = Math.floor(clamped / MILLISECONDS_IN_HOUR);
+  const minutes = Math.floor((clamped % MILLISECONDS_IN_HOUR) / MILLISECONDS_IN_MINUTE);
+  const seconds = Math.floor((clamped % MILLISECONDS_IN_MINUTE) / MILLISECONDS_IN_SECOND);
+
+  const pad = (value: number) => value.toString().padStart(2, '0');
+
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+function useDailyTasksRealtime(userId: string | null, day: string, enabled: boolean) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!userId || !enabled) {
+      return;
+    }
+
+    const channelName = `daily-tasks:user:${userId}:${day}`;
+    const queryKey = dailyTasksQueryKey(userId, day);
+
+    const invalidate = () => {
+      void queryClient.invalidateQueries({ queryKey });
+    };
+
+    const channel = supabase
+      .channel(channelName)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'user_daily_progress',
+          filter: `user_id=eq.${userId}`,
+        },
+        (_payload: RealtimePostgresChangesPayload<ProgressPayload>) => {
+          invalidate();
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'daily_assignments',
+          filter: `day=eq.${day}`,
+        },
+        () => {
+          invalidate();
+        }
+      );
+
+    channel.subscribe((status, error) => {
+      if (status === 'CHANNEL_ERROR' && error) {
+        console.error('Daily tasks realtime channel error', error);
+      }
+    });
+
+    return () => {
+      channel
+        .unsubscribe()
+        .catch((unsubscribeError) => {
+          console.error('Failed to unsubscribe from daily tasks channel', unsubscribeError);
+        })
+        .finally(() => {
+          supabase.removeChannel(channel);
+        });
+    };
+  }, [userId, day, enabled, queryClient]);
+}
+
+function buildGuestKey(day: string): QueryKey {
+  return [DAILY_TASKS_QUERY_KEY, 'guest', day];
+}
+
+export function useDailyTasks(userId: string | null) {
+  const now = useDailyTicker();
+  const day = useMemo(() => formatUtcDay(now), [now]);
+  const nextResetAt = useMemo(() => getNextUtcMidnight(now), [now]);
+  const millisecondsUntilReset = Math.max(nextResetAt.getTime() - now.getTime(), 0);
+  const countdownLabel = formatCountdown(millisecondsUntilReset);
+
+  const enabled = Boolean(userId);
+  const queryKey = useMemo(
+    () => (userId ? dailyTasksQueryKey(userId, day) : buildGuestKey(day)),
+    [userId, day]
+  );
+
+  const query = useQuery<DailyTasksSummary, Error>({
+    queryKey,
+    enabled,
+    queryFn: () => fetchDailyTasks({ day, userId: userId! }),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    placeholderData: (previousData) => previousData,
+  });
+
+  useDailyTasksRealtime(userId, day, enabled);
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (!userId || !enabled) {
+      return;
+    }
+
+    if (millisecondsUntilReset <= 0) {
+      void queryClient.invalidateQueries({ queryKey: dailyTasksQueryKey(userId, day) });
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      void queryClient.invalidateQueries({ queryKey: dailyTasksQueryKey(userId, formatUtcDay(new Date())) });
+    }, millisecondsUntilReset + MILLISECONDS_IN_SECOND);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [userId, enabled, millisecondsUntilReset, queryClient, day]);
+
+  return {
+    ...query,
+    day,
+    countdown: countdownLabel,
+    resetAt: nextResetAt,
+    millisecondsUntilReset,
+  };
+}
+
+export type { DailyTasksSummary, DailyTaskProgress };

--- a/src/features/daily-tasks/hooks.ts
+++ b/src/features/daily-tasks/hooks.ts
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 
 import { supabase } from '../../lib/supabase';
-import type { DailyTasksSummary, DailyTaskProgress } from './api/dailyTasks';
+import type { DailyTasksSummary } from './api/dailyTasks';
 import { fetchDailyTasks } from './api/dailyTasks';
 
 const DAILY_TASKS_QUERY_KEY = 'daily-tasks';
@@ -157,5 +157,3 @@ export function useDailyTasks(userId: string | null, conventionId: string | null
     millisecondsUntilReset,
   };
 }
-
-export type { DailyTasksSummary, DailyTaskProgress };

--- a/src/features/daily-tasks/hooks.ts
+++ b/src/features/daily-tasks/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 
 import { supabase } from '../../lib/supabase';
@@ -8,28 +8,27 @@ import { fetchDailyTasks } from './api/dailyTasks';
 
 const DAILY_TASKS_QUERY_KEY = 'daily-tasks';
 
-export const dailyTasksQueryKey = (userId: string, day: string) =>
-  [DAILY_TASKS_QUERY_KEY, userId, day] as const;
+export const dailyTasksQueryKey = (userId: string, conventionId: string) =>
+  [DAILY_TASKS_QUERY_KEY, userId, conventionId] as const;
 
 type ProgressPayload = {
   task_id: string;
   user_id: string;
   day: string;
+  convention_id: string;
   current_count: number;
   is_completed: boolean;
   completed_at: string | null;
 };
 
 const MILLISECONDS_IN_SECOND = 1000;
-const MILLISECONDS_IN_MINUTE = 60 * MILLISECONDS_IN_SECOND;
-const MILLISECONDS_IN_HOUR = 60 * MILLISECONDS_IN_MINUTE;
 
-function useDailyTicker(intervalMs = MILLISECONDS_IN_SECOND) {
-  const [now, setNow] = useState(() => new Date());
+function useTicker(intervalMs = MILLISECONDS_IN_SECOND) {
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setNow(new Date());
+      setNow(Date.now());
     }, intervalMs);
 
     return () => {
@@ -40,36 +39,16 @@ function useDailyTicker(intervalMs = MILLISECONDS_IN_SECOND) {
   return now;
 }
 
-function formatUtcDay(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
-function getNextUtcMidnight(date: Date): Date {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1));
-}
-
-function formatCountdown(milliseconds: number): string {
-  const clamped = Math.max(milliseconds, 0);
-
-  const hours = Math.floor(clamped / MILLISECONDS_IN_HOUR);
-  const minutes = Math.floor((clamped % MILLISECONDS_IN_HOUR) / MILLISECONDS_IN_MINUTE);
-  const seconds = Math.floor((clamped % MILLISECONDS_IN_MINUTE) / MILLISECONDS_IN_SECOND);
-
-  const pad = (value: number) => value.toString().padStart(2, '0');
-
-  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
-}
-
-function useDailyTasksRealtime(userId: string | null, day: string, enabled: boolean) {
+function useDailyTasksRealtime(userId: string | null, conventionId: string | null, enabled: boolean) {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (!userId || !enabled) {
+    if (!userId || !conventionId || !enabled) {
       return;
     }
 
-    const channelName = `daily-tasks:user:${userId}:${day}`;
-    const queryKey = dailyTasksQueryKey(userId, day);
+    const channelName = `daily-tasks:user:${userId}:convention:${conventionId}`;
+    const queryKey = dailyTasksQueryKey(userId, conventionId);
 
     const invalidate = () => {
       void queryClient.invalidateQueries({ queryKey });
@@ -85,7 +64,11 @@ function useDailyTasksRealtime(userId: string | null, day: string, enabled: bool
           table: 'user_daily_progress',
           filter: `user_id=eq.${userId}`,
         },
-        (_payload: RealtimePostgresChangesPayload<ProgressPayload>) => {
+        (payload: RealtimePostgresChangesPayload<ProgressPayload>) => {
+          const row = (payload.new ?? {}) as Partial<ProgressPayload>;
+          if (row.convention_id !== conventionId) {
+            return;
+          }
           invalidate();
         }
       )
@@ -95,7 +78,7 @@ function useDailyTasksRealtime(userId: string | null, day: string, enabled: bool
           event: '*',
           schema: 'public',
           table: 'daily_assignments',
-          filter: `day=eq.${day}`,
+          filter: `convention_id=eq.${conventionId}`,
         },
         () => {
           invalidate();
@@ -118,63 +101,59 @@ function useDailyTasksRealtime(userId: string | null, day: string, enabled: bool
           supabase.removeChannel(channel);
         });
     };
-  }, [userId, day, enabled, queryClient]);
+  }, [userId, conventionId, enabled, queryClient]);
 }
 
-function buildGuestKey(day: string): QueryKey {
-  return [DAILY_TASKS_QUERY_KEY, 'guest', day];
-}
-
-export function useDailyTasks(userId: string | null) {
-  const now = useDailyTicker();
-  const day = useMemo(() => formatUtcDay(now), [now]);
-  const nextResetAt = useMemo(() => getNextUtcMidnight(now), [now]);
-  const millisecondsUntilReset = Math.max(nextResetAt.getTime() - now.getTime(), 0);
-  const countdownLabel = formatCountdown(millisecondsUntilReset);
-
-  const enabled = Boolean(userId);
-  const queryKey = useMemo(
-    () => (userId ? dailyTasksQueryKey(userId, day) : buildGuestKey(day)),
-    [userId, day]
-  );
+export function useDailyTasks(userId: string | null, conventionId: string | null) {
+  const now = useTicker();
+  const enabled = Boolean(userId && conventionId);
 
   const query = useQuery<DailyTasksSummary, Error>({
-    queryKey,
+    queryKey: userId && conventionId ? dailyTasksQueryKey(userId, conventionId) : [DAILY_TASKS_QUERY_KEY],
     enabled,
-    queryFn: () => fetchDailyTasks({ day, userId: userId! }),
+    queryFn: () => fetchDailyTasks({ userId: userId!, conventionId: conventionId! }),
     staleTime: 30_000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     placeholderData: (previousData) => previousData,
   });
 
-  useDailyTasksRealtime(userId, day, enabled);
+  useDailyTasksRealtime(userId, conventionId, enabled);
+
+  const resetAt = query.data?.resetAt ?? null;
+  const millisecondsUntilReset = useMemo(() => {
+    if (!resetAt) return 0;
+    return Math.max(new Date(resetAt).getTime() - now, 0);
+  }, [resetAt, now]);
+
+  const countdown = useMemo(() => {
+    const ms = millisecondsUntilReset;
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600)
+      .toString()
+      .padStart(2, '0');
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+    return `${hours}:${minutes}:${seconds}`;
+  }, [millisecondsUntilReset]);
 
   const queryClient = useQueryClient();
   useEffect(() => {
-    if (!userId || !enabled) {
+    if (!userId || !conventionId || !enabled) {
       return;
     }
 
     if (millisecondsUntilReset <= 0) {
-      void queryClient.invalidateQueries({ queryKey: dailyTasksQueryKey(userId, day) });
-      return;
+      void queryClient.invalidateQueries({ queryKey: dailyTasksQueryKey(userId, conventionId) });
     }
-
-    const timeout = setTimeout(() => {
-      void queryClient.invalidateQueries({ queryKey: dailyTasksQueryKey(userId, formatUtcDay(new Date())) });
-    }, millisecondsUntilReset + MILLISECONDS_IN_SECOND);
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [userId, enabled, millisecondsUntilReset, queryClient, day]);
+  }, [userId, conventionId, enabled, millisecondsUntilReset, queryClient]);
 
   return {
     ...query,
-    day,
-    countdown: countdownLabel,
-    resetAt: nextResetAt,
+    countdown,
+    resetAt,
     millisecondsUntilReset,
   };
 }

--- a/src/features/daily-tasks/index.ts
+++ b/src/features/daily-tasks/index.ts
@@ -1,0 +1,2 @@
+export * from './api/dailyTasks';
+export * from './hooks';

--- a/src/features/daily-tasks/index.ts
+++ b/src/features/daily-tasks/index.ts
@@ -1,2 +1,2 @@
-export * from './api/dailyTasks';
-export * from './hooks';
+export { useDailyTasks } from './hooks';
+export type { DailyTasksSummary, DailyTaskProgress } from './api/dailyTasks';

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -390,6 +390,7 @@ export interface DailyAssignmentsRow {
   id: string;
   day: string;
   task_id: string;
+  convention_id: string;
   position: number;
   created_at: string;
   updated_at: string;
@@ -399,6 +400,7 @@ export interface DailyAssignmentsInsert {
   id?: string;
   day: string;
   task_id: string;
+  convention_id: string;
   position: number;
   created_at?: string;
   updated_at?: string;
@@ -408,6 +410,7 @@ export interface DailyAssignmentsUpdate {
   id?: string;
   day?: string;
   task_id?: string;
+  convention_id?: string;
   position?: number;
   created_at?: string;
   updated_at?: string;
@@ -417,6 +420,7 @@ export interface UserDailyProgressRow {
   user_id: string;
   day: string;
   task_id: string;
+  convention_id: string;
   current_count: number;
   is_completed: boolean;
   completed_at: string | null;
@@ -428,6 +432,7 @@ export interface UserDailyProgressInsert {
   user_id: string;
   day: string;
   task_id: string;
+  convention_id: string;
   current_count?: number;
   is_completed?: boolean;
   completed_at?: string | null;
@@ -439,6 +444,7 @@ export interface UserDailyProgressUpdate {
   user_id?: string;
   day?: string;
   task_id?: string;
+  convention_id?: string;
   current_count?: number;
   is_completed?: boolean;
   completed_at?: string | null;
@@ -448,6 +454,7 @@ export interface UserDailyProgressUpdate {
 
 export interface UserDailyStreaksRow {
   user_id: string;
+  convention_id: string;
   current_streak: number;
   best_streak: number;
   last_completed_day: string | null;
@@ -457,6 +464,7 @@ export interface UserDailyStreaksRow {
 
 export interface UserDailyStreaksInsert {
   user_id: string;
+  convention_id: string;
   current_streak?: number;
   best_streak?: number;
   last_completed_day?: string | null;
@@ -466,6 +474,7 @@ export interface UserDailyStreaksInsert {
 
 export interface UserDailyStreaksUpdate {
   user_id?: string;
+  convention_id?: string;
   current_streak?: number;
   best_streak?: number;
   last_completed_day?: string | null;
@@ -549,6 +558,12 @@ export interface Database {
             columns: ['task_id'];
             referencedRelation: 'daily_tasks';
             referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'daily_assignments_convention_id_fkey';
+            columns: ['convention_id'];
+            referencedRelation: 'conventions';
+            referencedColumns: ['id'];
           }
         ];
       };
@@ -568,6 +583,12 @@ export interface Database {
             columns: ['task_id'];
             referencedRelation: 'daily_tasks';
             referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'user_daily_progress_convention_id_fkey';
+            columns: ['convention_id'];
+            referencedRelation: 'conventions';
+            referencedColumns: ['id'];
           }
         ];
       };
@@ -580,6 +601,12 @@ export interface Database {
             foreignKeyName: 'user_daily_streaks_user_id_fkey';
             columns: ['user_id'];
             referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'user_daily_streaks_convention_id_fkey';
+            columns: ['convention_id'];
+            referencedRelation: 'conventions';
             referencedColumns: ['id'];
           }
         ];
@@ -678,7 +705,9 @@ export interface Database {
     };
     Functions: {
       record_leaderboard_refresh: {
-        Args: Record<string, never>;
+        Args: {
+          convention_id: string;
+        };
         Returns: void;
       };
     };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -46,7 +46,10 @@ export type AchievementRecipientRole = 'catcher' | 'fursuit_owner' | 'any';
 export type AchievementTriggerEvent =
   | 'catch.created'
   | 'profile.updated'
-  | 'convention.checkin';
+  | 'convention.checkin'
+  | 'leaderboard.refreshed';
+
+export type DailyTaskKind = 'catch' | 'view_bio' | 'share' | 'leaderboard' | 'meta';
 
 export interface FursuitsRow {
   id: string;
@@ -347,6 +350,129 @@ export interface AchievementEventsUpdate {
   processed_at?: string | null;
 }
 
+export interface DailyTasksRow {
+  id: string;
+  name: string;
+  description: string;
+  kind: DailyTaskKind;
+  requirement: number;
+  metadata: Json;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DailyTasksInsert {
+  id?: string;
+  name: string;
+  description: string;
+  kind: DailyTaskKind;
+  requirement?: number;
+  metadata?: Json;
+  is_active?: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface DailyTasksUpdate {
+  id?: string;
+  name?: string;
+  description?: string;
+  kind?: DailyTaskKind;
+  requirement?: number;
+  metadata?: Json;
+  is_active?: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface DailyAssignmentsRow {
+  id: string;
+  day: string;
+  task_id: string;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DailyAssignmentsInsert {
+  id?: string;
+  day: string;
+  task_id: string;
+  position: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface DailyAssignmentsUpdate {
+  id?: string;
+  day?: string;
+  task_id?: string;
+  position?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface UserDailyProgressRow {
+  user_id: string;
+  day: string;
+  task_id: string;
+  current_count: number;
+  is_completed: boolean;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserDailyProgressInsert {
+  user_id: string;
+  day: string;
+  task_id: string;
+  current_count?: number;
+  is_completed?: boolean;
+  completed_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface UserDailyProgressUpdate {
+  user_id?: string;
+  day?: string;
+  task_id?: string;
+  current_count?: number;
+  is_completed?: boolean;
+  completed_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface UserDailyStreaksRow {
+  user_id: string;
+  current_streak: number;
+  best_streak: number;
+  last_completed_day: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UserDailyStreaksInsert {
+  user_id: string;
+  current_streak?: number;
+  best_streak?: number;
+  last_completed_day?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface UserDailyStreaksUpdate {
+  user_id?: string;
+  current_streak?: number;
+  best_streak?: number;
+  last_completed_day?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
 export interface Database {
   public: {
     Tables: {
@@ -406,6 +532,57 @@ export interface Database {
         Insert: AchievementsInsert;
         Update: AchievementsUpdate;
         Relationships: [];
+      };
+      daily_tasks: {
+        Row: DailyTasksRow;
+        Insert: DailyTasksInsert;
+        Update: DailyTasksUpdate;
+        Relationships: [];
+      };
+      daily_assignments: {
+        Row: DailyAssignmentsRow;
+        Insert: DailyAssignmentsInsert;
+        Update: DailyAssignmentsUpdate;
+        Relationships: [
+          {
+            foreignKeyName: 'daily_assignments_task_id_fkey';
+            columns: ['task_id'];
+            referencedRelation: 'daily_tasks';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+      user_daily_progress: {
+        Row: UserDailyProgressRow;
+        Insert: UserDailyProgressInsert;
+        Update: UserDailyProgressUpdate;
+        Relationships: [
+          {
+            foreignKeyName: 'user_daily_progress_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'user_daily_progress_task_id_fkey';
+            columns: ['task_id'];
+            referencedRelation: 'daily_tasks';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
+      user_daily_streaks: {
+        Row: UserDailyStreaksRow;
+        Insert: UserDailyStreaksInsert;
+        Update: UserDailyStreaksUpdate;
+        Relationships: [
+          {
+            foreignKeyName: 'user_daily_streaks_user_id_fkey';
+            columns: ['user_id'];
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          }
+        ];
       };
       user_achievements: {
         Row: UserAchievementsRow;
@@ -500,7 +677,10 @@ export interface Database {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      record_leaderboard_refresh: {
+        Args: Record<string, never>;
+        Returns: void;
+      };
     };
     Enums: {
       achievement_category: AchievementCategory;

--- a/supabase/functions/rotate-dailys/index.ts
+++ b/supabase/functions/rotate-dailys/index.ts
@@ -1,0 +1,275 @@
+/// <reference lib="deno.unstable" />
+// eslint-disable-next-line import/no-unresolved -- Deno edge functions import via remote URL
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const MIN_TASKS = 3;
+const MAX_TASKS = 5;
+const SEED_PREFIX = "dailys:";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const serviceRoleKey = Deno.env.get("SERVICE_ROLE_KEY") ??
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error(
+    "Missing SUPABASE_URL or SERVICE_ROLE_KEY environment variables",
+  );
+}
+
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+const textEncoder = new TextEncoder();
+
+type DailyTaskRow = {
+  id: string;
+  name: string;
+  description: string;
+  kind: string;
+  requirement: number;
+};
+
+type AssignmentWithTask = {
+  position: number;
+  task: DailyTaskRow;
+};
+
+type RotateOptions = {
+  day: string;
+  requestedCount?: number;
+  force: boolean;
+};
+
+function respondJson(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function sanitizeCount(countParam: string | null): number | undefined {
+  if (!countParam) return undefined;
+  const parsed = Number.parseInt(countParam, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < MIN_TASKS || parsed > MAX_TASKS) return undefined;
+  return parsed;
+}
+
+function isIsoDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function formatUtcDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+async function deriveSeed(
+  day: string,
+): Promise<{ seed: number; hashHex: string }> {
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    textEncoder.encode(`${SEED_PREFIX}${day}`),
+  );
+
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  const dataView = new DataView(hashBuffer);
+  const seed = dataView.getUint32(0, false); // take the first 32 bits as our seed
+
+  return { seed, hashHex };
+}
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let m = Math.imul(t ^ (t >>> 15), 1 | t);
+    m ^= m + Math.imul(m ^ (m >>> 7), 61 | m);
+    return ((m ^ (m >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffleInPlace<T>(items: T[], rng: () => number): void {
+  for (let i = items.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+}
+
+async function fetchAssignments(day: string): Promise<AssignmentWithTask[]> {
+  const { data, error } = await supabaseAdmin
+    .from("daily_assignments")
+    .select(
+      "position, task:daily_tasks (id, name, description, kind, requirement)",
+    )
+    .eq("day", day)
+    .order("position", { ascending: true });
+
+  if (error) {
+    throw new Error(`Unable to fetch daily assignments: ${error.message}`);
+  }
+
+  const assignments: AssignmentWithTask[] = [];
+  for (const row of data ?? []) {
+    const task = row.task as DailyTaskRow | null;
+    if (!task) continue;
+    assignments.push({
+      position: row.position as number,
+      task,
+    });
+  }
+
+  return assignments;
+}
+
+async function selectAssignments(day: string, requestedCount?: number) {
+  const { data: activeTasks, error } = await supabaseAdmin
+    .from("daily_tasks")
+    .select("id, name, description, kind, requirement")
+    .eq("is_active", true)
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(`Unable to fetch active daily tasks: ${error.message}`);
+  }
+
+  const tasks = (activeTasks ?? []) as DailyTaskRow[];
+  if (tasks.length < MIN_TASKS) {
+    throw new Error(
+      `Insufficient active daily tasks (${tasks.length}); need at least ${MIN_TASKS} to rotate`,
+    );
+  }
+
+  const { seed, hashHex } = await deriveSeed(day);
+  const rng = mulberry32(seed);
+
+  const maxAllowed = Math.min(MAX_TASKS, tasks.length);
+  const desiredCount = requestedCount
+    ? Math.min(maxAllowed, Math.max(MIN_TASKS, requestedCount))
+    : MIN_TASKS + Math.floor(rng() * (maxAllowed - MIN_TASKS + 1));
+
+  const tasksCopy = [...tasks];
+  shuffleInPlace(tasksCopy, rng);
+  const selected = tasksCopy.slice(0, desiredCount);
+
+  return { selected, desiredCount, hashHex };
+}
+
+async function storeAssignments(day: string, tasks: DailyTaskRow[]) {
+  const payload = tasks.map((task, index) => ({
+    day,
+    task_id: task.id,
+    position: index + 1,
+  }));
+
+  const { error: upsertError } = await supabaseAdmin
+    .from("daily_assignments")
+    .upsert(payload, { onConflict: "day,position" });
+
+  if (upsertError) {
+    throw new Error(
+      `Unable to upsert daily assignments: ${upsertError.message}`,
+    );
+  }
+
+  const { error: cleanupError } = await supabaseAdmin
+    .from("daily_assignments")
+    .delete()
+    .eq("day", day)
+    .gt("position", tasks.length);
+
+  if (cleanupError) {
+    throw new Error(
+      `Unable to cleanup extra daily assignments: ${cleanupError.message}`,
+    );
+  }
+}
+
+async function rotateDailyTasks({ day, requestedCount, force }: RotateOptions) {
+  const existing = await fetchAssignments(day);
+  if (!force && existing.length >= MIN_TASKS) {
+    return {
+      assignments: existing,
+      refreshed: false,
+      seedHash: null,
+    };
+  }
+
+  const { selected, desiredCount, hashHex } = await selectAssignments(
+    day,
+    requestedCount,
+  );
+
+  if (selected.length === 0) {
+    throw new Error("No tasks selected for assignment");
+  }
+
+  await storeAssignments(day, selected);
+
+  const finalAssignments = await fetchAssignments(day);
+  if (finalAssignments.length !== desiredCount) {
+    throw new Error("Mismatch between stored assignments and desired count");
+  }
+
+  return {
+    assignments: finalAssignments,
+    refreshed: true,
+    seedHash: hashHex,
+  };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "GET" && req.method !== "POST") {
+    return respondJson({ error: "Method not allowed" }, 405);
+  }
+
+  const url = new URL(req.url);
+  const dayParam = url.searchParams.get("day");
+  const countParam = url.searchParams.get("count");
+  const forceParam = url.searchParams.get("force");
+
+  const todayUtc = new Date();
+  const force = forceParam === "true";
+
+  let day = dayParam ? dayParam.trim() : formatUtcDay(todayUtc);
+  if (!isIsoDate(day)) {
+    return respondJson(
+      { error: "Invalid day parameter; expected YYYY-MM-DD" },
+      400,
+    );
+  }
+
+  const requestedCount = sanitizeCount(countParam);
+
+  try {
+    const result = await rotateDailyTasks({ day, requestedCount, force });
+    return respondJson({
+      day,
+      refreshed: result.refreshed,
+      assignments: result.assignments,
+      seed_hash: result.seedHash,
+    });
+  } catch (error) {
+    console.error("Failed rotating daily tasks", error);
+    return respondJson(
+      { error: (error as Error).message ?? "Unknown error" },
+      500,
+    );
+  }
+});

--- a/supabase/functions/rotate-dailys/index.ts
+++ b/supabase/functions/rotate-dailys/index.ts
@@ -87,20 +87,6 @@ function getDateFormatter(timezone: string) {
   return dateFormatterCache.get(timezone)!;
 }
 
-function getDateTimeFormatter(timezone: string) {
-  return new Intl.DateTimeFormat('en-US', {
-    timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-    timeZoneName: 'shortOffset',
-  });
-}
-
 function pad(value: number): string {
   return value.toString().padStart(2, '0');
 }
@@ -123,41 +109,6 @@ function getLocalDay(now: Date, timezone: string): {
     month,
     dayNumber,
   };
-}
-
-function getOffsetMilliseconds(timestamp: number, timezone: string): number {
-  const date = new Date(timestamp);
-  const formatter = getDateTimeFormatter(timezone);
-  const parts = formatter.formatToParts(date);
-  const timeZoneName = parts.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT';
-  const match = timeZoneName.match(/GMT([+-])(\d{2})(?::(\d{2}))?/);
-  if (!match) return 0;
-  const sign = match[1] === '+' ? 1 : -1;
-  const hours = Number(match[2]);
-  const minutes = Number(match[3] ?? '0');
-  return sign * ((hours * 60 + minutes) * 60 * 1000);
-}
-
-function zonedTimeToUtc(
-  timezone: string,
-  year: number,
-  month: number,
-  day: number,
-  hour = 0,
-  minute = 0,
-  second = 0,
-): Date {
-  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
-  let offset = getOffsetMilliseconds(utcTimestamp, timezone);
-  let adjusted = utcTimestamp - offset;
-
-  const newOffset = getOffsetMilliseconds(adjusted, timezone);
-  if (newOffset !== offset) {
-    offset = newOffset;
-    adjusted = utcTimestamp - offset;
-  }
-
-  return new Date(adjusted);
 }
 
 function sanitizeCount(countParam: string | null): number | undefined {

--- a/supabase/functions/rotate-dailys/index.ts
+++ b/supabase/functions/rotate-dailys/index.ts
@@ -44,10 +44,23 @@ type AssignmentWithTask = {
   task: DailyTaskRow;
 };
 
+type ConventionRow = {
+  id: string;
+  timezone: string;
+};
+
 type RotateOptions = {
-  day: string;
+  conventionId?: string;
   requestedCount?: number;
   force: boolean;
+};
+
+type ConventionResult = {
+  convention_id: string;
+  day: string;
+  refreshed: boolean;
+  assignments: AssignmentWithTask[];
+  seed_hash: string | null;
 };
 
 function respondJson(data: unknown, status = 200) {
@@ -55,6 +68,96 @@ function respondJson(data: unknown, status = 200) {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
+}
+
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getDateFormatter(timezone: string) {
+  if (!dateFormatterCache.has(timezone)) {
+    dateFormatterCache.set(
+      timezone,
+      new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }),
+    );
+  }
+  return dateFormatterCache.get(timezone)!;
+}
+
+function getDateTimeFormatter(timezone: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'shortOffset',
+  });
+}
+
+function pad(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+function getLocalDay(now: Date, timezone: string): {
+  day: string;
+  year: number;
+  month: number;
+  dayNumber: number;
+} {
+  const formatter = getDateFormatter(timezone);
+  const parts = formatter.formatToParts(now);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const year = Number(lookup.year);
+  const month = Number(lookup.month);
+  const dayNumber = Number(lookup.day);
+  return {
+    day: `${year}-${pad(month)}-${pad(dayNumber)}`,
+    year,
+    month,
+    dayNumber,
+  };
+}
+
+function getOffsetMilliseconds(timestamp: number, timezone: string): number {
+  const date = new Date(timestamp);
+  const formatter = getDateTimeFormatter(timezone);
+  const parts = formatter.formatToParts(date);
+  const timeZoneName = parts.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT';
+  const match = timeZoneName.match(/GMT([+-])(\d{2})(?::(\d{2}))?/);
+  if (!match) return 0;
+  const sign = match[1] === '+' ? 1 : -1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? '0');
+  return sign * ((hours * 60 + minutes) * 60 * 1000);
+}
+
+function zonedTimeToUtc(
+  timezone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+): Date {
+  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+  let offset = getOffsetMilliseconds(utcTimestamp, timezone);
+  let adjusted = utcTimestamp - offset;
+
+  const newOffset = getOffsetMilliseconds(adjusted, timezone);
+  if (newOffset !== offset) {
+    offset = newOffset;
+    adjusted = utcTimestamp - offset;
+  }
+
+  return new Date(adjusted);
 }
 
 function sanitizeCount(countParam: string | null): number | undefined {
@@ -65,20 +168,13 @@ function sanitizeCount(countParam: string | null): number | undefined {
   return parsed;
 }
 
-function isIsoDate(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value);
-}
-
-function formatUtcDay(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
 async function deriveSeed(
+  conventionId: string,
   day: string,
 ): Promise<{ seed: number; hashHex: string }> {
   const hashBuffer = await crypto.subtle.digest(
     "SHA-256",
-    textEncoder.encode(`${SEED_PREFIX}${day}`),
+    textEncoder.encode(`${SEED_PREFIX}${conventionId}:${day}`),
   );
 
   const hashArray = Array.from(new Uint8Array(hashBuffer));
@@ -86,7 +182,7 @@ async function deriveSeed(
     "",
   );
   const dataView = new DataView(hashBuffer);
-  const seed = dataView.getUint32(0, false); // take the first 32 bits as our seed
+  const seed = dataView.getUint32(0, false);
 
   return { seed, hashHex };
 }
@@ -108,12 +204,16 @@ function shuffleInPlace<T>(items: T[], rng: () => number): void {
   }
 }
 
-async function fetchAssignments(day: string): Promise<AssignmentWithTask[]> {
+async function fetchAssignments(
+  conventionId: string,
+  day: string,
+): Promise<AssignmentWithTask[]> {
   const { data, error } = await supabaseAdmin
     .from("daily_assignments")
     .select(
       "position, task:daily_tasks (id, name, description, kind, requirement)",
     )
+    .eq("convention_id", conventionId)
     .eq("day", day)
     .order("position", { ascending: true });
 
@@ -134,7 +234,11 @@ async function fetchAssignments(day: string): Promise<AssignmentWithTask[]> {
   return assignments;
 }
 
-async function selectAssignments(day: string, requestedCount?: number) {
+async function selectAssignments(
+  conventionId: string,
+  day: string,
+  requestedCount?: number,
+) {
   const { data: activeTasks, error } = await supabaseAdmin
     .from("daily_tasks")
     .select("id, name, description, kind, requirement")
@@ -152,7 +256,7 @@ async function selectAssignments(day: string, requestedCount?: number) {
     );
   }
 
-  const { seed, hashHex } = await deriveSeed(day);
+  const { seed, hashHex } = await deriveSeed(conventionId, day);
   const rng = mulberry32(seed);
 
   const maxAllowed = Math.min(MAX_TASKS, tasks.length);
@@ -167,16 +271,21 @@ async function selectAssignments(day: string, requestedCount?: number) {
   return { selected, desiredCount, hashHex };
 }
 
-async function storeAssignments(day: string, tasks: DailyTaskRow[]) {
+async function storeAssignments(
+  conventionId: string,
+  day: string,
+  tasks: DailyTaskRow[],
+) {
   const payload = tasks.map((task, index) => ({
     day,
+    convention_id: conventionId,
     task_id: task.id,
     position: index + 1,
   }));
 
   const { error: upsertError } = await supabaseAdmin
     .from("daily_assignments")
-    .upsert(payload, { onConflict: "day,position" });
+    .upsert(payload, { onConflict: "convention_id,day,position" });
 
   if (upsertError) {
     throw new Error(
@@ -187,6 +296,7 @@ async function storeAssignments(day: string, tasks: DailyTaskRow[]) {
   const { error: cleanupError } = await supabaseAdmin
     .from("daily_assignments")
     .delete()
+    .eq("convention_id", conventionId)
     .eq("day", day)
     .gt("position", tasks.length);
 
@@ -197,37 +307,90 @@ async function storeAssignments(day: string, tasks: DailyTaskRow[]) {
   }
 }
 
-async function rotateDailyTasks({ day, requestedCount, force }: RotateOptions) {
-  const existing = await fetchAssignments(day);
+async function fetchConventions(targetId?: string): Promise<ConventionRow[]> {
+  let query = supabaseAdmin
+    .from("conventions")
+    .select("id, timezone")
+    .not("timezone", "is", null);
+
+  if (targetId) {
+    query = query.eq("id", targetId);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(`Unable to fetch conventions: ${error.message}`);
+  }
+
+  return (data ?? []).map((row) => ({
+    id: (row as { id: string }).id,
+    timezone: ((row as { timezone?: string | null }).timezone ?? "UTC"),
+  }));
+}
+
+async function rotateConvention(
+  convention: ConventionRow,
+  requestedCount: number | undefined,
+  force: boolean,
+): Promise<ConventionResult> {
+  const nowUtc = new Date();
+  const localInfo = getLocalDay(nowUtc, convention.timezone);
+  const localDay = localInfo.day;
+
+  const existing = await fetchAssignments(convention.id, localDay);
+
   if (!force && existing.length >= MIN_TASKS) {
     return {
-      assignments: existing,
+      convention_id: convention.id,
+      day: localDay,
       refreshed: false,
-      seedHash: null,
+      assignments: existing,
+      seed_hash: null,
     };
   }
 
   const { selected, desiredCount, hashHex } = await selectAssignments(
-    day,
+    convention.id,
+    localDay,
     requestedCount,
   );
 
   if (selected.length === 0) {
-    throw new Error("No tasks selected for assignment");
+    throw new Error(`No tasks selected for convention ${convention.id}`);
   }
 
-  await storeAssignments(day, selected);
+  await storeAssignments(convention.id, localDay, selected);
 
-  const finalAssignments = await fetchAssignments(day);
+  const finalAssignments = await fetchAssignments(convention.id, localDay);
   if (finalAssignments.length !== desiredCount) {
     throw new Error("Mismatch between stored assignments and desired count");
   }
 
   return {
-    assignments: finalAssignments,
+    convention_id: convention.id,
+    day: localDay,
     refreshed: true,
-    seedHash: hashHex,
+    assignments: finalAssignments,
+    seed_hash: hashHex,
   };
+}
+
+async function rotateDailyTasks({
+  conventionId,
+  requestedCount,
+  force,
+}: RotateOptions): Promise<ConventionResult[]> {
+  const conventions = await fetchConventions(conventionId);
+  if (conventions.length === 0) {
+    throw new Error("No conventions available to rotate");
+  }
+
+  const results: ConventionResult[] = [];
+  for (const convention of conventions) {
+    const result = await rotateConvention(convention, requestedCount, force);
+    results.push(result);
+  }
+  return results;
 }
 
 Deno.serve(async (req) => {
@@ -240,36 +403,23 @@ Deno.serve(async (req) => {
   }
 
   const url = new URL(req.url);
-  const dayParam = url.searchParams.get("day");
+  const conventionParam = url.searchParams.get("convention_id");
   const countParam = url.searchParams.get("count");
   const forceParam = url.searchParams.get("force");
 
-  const todayUtc = new Date();
+  const requestedCount = sanitizeCount(countParam);
   const force = forceParam === "true";
 
-  let day = dayParam ? dayParam.trim() : formatUtcDay(todayUtc);
-  if (!isIsoDate(day)) {
-    return respondJson(
-      { error: "Invalid day parameter; expected YYYY-MM-DD" },
-      400,
-    );
-  }
-
-  const requestedCount = sanitizeCount(countParam);
-
   try {
-    const result = await rotateDailyTasks({ day, requestedCount, force });
-    return respondJson({
-      day,
-      refreshed: result.refreshed,
-      assignments: result.assignments,
-      seed_hash: result.seedHash,
+    const results = await rotateDailyTasks({
+      conventionId: conventionParam ?? undefined,
+      requestedCount,
+      force,
     });
+
+    return respondJson({ results });
   } catch (error) {
     console.error("Failed rotating daily tasks", error);
-    return respondJson(
-      { error: (error as Error).message ?? "Unknown error" },
-      500,
-    );
+    return respondJson({ error: (error as Error).message ?? "Unknown error" }, 500);
   }
 });

--- a/supabase/shared/achievements/processor.ts
+++ b/supabase/shared/achievements/processor.ts
@@ -11,7 +11,11 @@ export type Achievement = {
 
 export type AchievementEvent = {
   id: string;
-  event_type: "catch.created" | "profile.updated" | "convention.checkin";
+  event_type:
+    | "catch.created"
+    | "profile.updated"
+    | "convention.checkin"
+    | "leaderboard.refreshed";
   payload: Json;
   created_at: string;
   processed_at: string | null;
@@ -875,6 +879,10 @@ export function createAchievementProcessor({
       }
       case "convention.checkin": {
         result.awards = await processConventionCheckinEvent(achievementMap, event);
+        break;
+      }
+      case "leaderboard.refreshed": {
+        result.skipped = true;
         break;
       }
       default:


### PR DESCRIPTION
- Added per-convention timezone support for daily tasks, replacing the UTC-only reset logic.
- Updated Edge rotation, listener processing, and client screens to use convention_id-scoped assignments, progress, and streaks.
- Exposed convention selection in the UI so users see the correct daily lineup and streak countdown tied to each con.
- Introduced a “Reload standings” action that records leaderboard refreshes and satisfies the related daily task.