### PR TITLE
Add onboarding screens for new players

### DIFF
--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -37,7 +37,14 @@ import type { FursuitsRow } from '../../src/types/database';
 
 type FursuitDetails = Pick<
   FursuitsRow,
-  'id' | 'name' | 'species' | 'species_id' | 'avatar_url' | 'unique_code' | 'owner_id'
+  | 'id'
+  | 'name'
+  | 'species'
+  | 'species_id'
+  | 'avatar_url'
+  | 'unique_code'
+  | 'owner_id'
+  | 'is_tutorial'
 > & { created_at: string | null; bio: FursuitBio | null };
 
 type CatchRecord = {
@@ -86,6 +93,7 @@ export default function CatchScreen() {
           species,
           species_id,
           avatar_url,
+          is_tutorial,
           unique_code,
           owner_id,
           created_at,
@@ -113,6 +121,7 @@ export default function CatchScreen() {
         .eq('unique_code', normalizedCode)
         .order('version', { ascending: false, foreignTable: 'fursuit_bios' })
         .limit(1, { foreignTable: 'fursuit_bios' })
+        .eq('is_tutorial', false)
         .maybeSingle();
 
       if (fursuitError) {
@@ -137,7 +146,16 @@ export default function CatchScreen() {
         owner_id: fursuit.owner_id,
         created_at: fursuit.created_at ?? null,
         bio: mapLatestFursuitBio((fursuit as any)?.fursuit_bios ?? null),
+        is_tutorial: fursuit.is_tutorial === true,
       };
+
+      if (normalizedFursuit.is_tutorial) {
+        setCaughtFursuit(null);
+        setCatchRecord(null);
+        setConversationPrompt(null);
+        setSubmitError('Tutorial suits cannot be caught by scanning codes.');
+        return;
+      }
 
       if (normalizedFursuit.owner_id === userId) {
         setCaughtFursuit(null);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -419,11 +419,13 @@ export default function SettingsScreen() {
         }
       }
 
-      queryClient.setQueryData<ProfileSummary | null>(profileQueryKey, {
+      queryClient.setQueryData<ProfileSummary | null>(profileQueryKey, (current) => ({
         username: normalizedUsername,
         bio: normalizedBio,
         avatar_url: nextAvatarUrl,
-      });
+        is_new: current?.is_new ?? false,
+        onboarding_completed: current?.onboarding_completed ?? false,
+      }));
       setUsernameInput(trimmedUsername);
       setBioInput(trimmedBio);
       setSelectedAvatar(null);

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,9 +5,10 @@ import { useSegments, Stack, Redirect } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 
 import { AuthProvider, useAuth, usePrimeUserData } from "../src/features/auth";
+import { createProfileQueryOptions } from "../src/features/profile";
 import { colors } from "../src/theme";
 import { ToastProvider } from "../src/hooks/useToast";
 import { DailyTaskToastManager } from "../src/features/daily-tasks/components/DailyTaskToastManager";
@@ -36,6 +37,18 @@ function RootLayoutNav() {
   const { status, session } = useAuth();
   const segments = useSegments();
   const inAuthGroup = segments.length > 0 && segments[0] === "(auth)";
+  const inOnboardingFlow = segments.length > 0 && segments[0] === "onboarding";
+  const userId = session?.user.id ?? null;
+
+  const {
+    data: profile,
+    isLoading: isProfileLoading,
+    isFetching: isProfileFetching,
+    error: profileError,
+  } = useQuery({
+    ...createProfileQueryOptions(userId ?? ""),
+    enabled: Boolean(userId),
+  });
 
   usePrimeUserData(session?.user.id ?? null);
 
@@ -53,6 +66,27 @@ function RootLayoutNav() {
     return <Redirect href="/" />;
   }
 
+  const shouldGateOnboarding =
+    Boolean(session) &&
+    !profileError &&
+    (profile?.is_new === true || profile?.onboarding_completed !== true);
+
+  if (session && shouldGateOnboarding && !inOnboardingFlow) {
+    if ((isProfileLoading || isProfileFetching) && !profile && !profileError) {
+      return <LoadingScreen />;
+    }
+
+    return <Redirect href="/onboarding" />;
+  }
+
+  if (session && inOnboardingFlow && !shouldGateOnboarding && !isProfileLoading && !isProfileFetching) {
+    return <Redirect href="/" />;
+  }
+
+  if (session && inOnboardingFlow && (isProfileLoading || isProfileFetching) && !profileError) {
+    return <LoadingScreen />;
+  }
+
   // Normal app stack. Android back will "go back" automatically if there's history.
   return (
     <Stack
@@ -66,6 +100,9 @@ function RootLayoutNav() {
 
       {/* Main app (tabs) */}
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+
+      {/* Onboarding */}
+      <Stack.Screen name="onboarding/index" options={{ headerShown: false }} />
 
       {/* Standalone fursuit flows */}
       <Stack.Screen name="fursuits/[id]" options={{ headerShown: false }} />

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAuth } from '../../src/features/auth';
+import { createProfileQueryOptions, type ProfileSummary } from '../../src/features/profile';
+import { ProgressDots } from '../../src/features/onboarding/components/ProgressDots';
+import { WelcomeStep } from '../../src/features/onboarding/components/WelcomeStep';
+import { ConventionStep } from '../../src/features/onboarding/components/ConventionStep';
+import { FursuitStep } from '../../src/features/onboarding/components/FursuitStep';
+import { TutorialCatchStep } from '../../src/features/onboarding/components/TutorialCatchStep';
+import { AchievementStep } from '../../src/features/onboarding/components/AchievementStep';
+import { colors, spacing } from '../../src/theme';
+
+const STEPS = ['welcome', 'convention', 'fursuit', 'tutorial', 'achievement'] as const;
+type StepId = (typeof STEPS)[number];
+
+const stepIndex = (step: StepId) => STEPS.indexOf(step);
+
+const LoadingView = () => (
+  <View style={styles.loadingContainer}>
+    <ActivityIndicator size="large" color={colors.primary} />
+  </View>
+);
+
+export default function OnboardingScreen() {
+  const router = useRouter();
+  const { session } = useAuth();
+  const userId = session?.user.id ?? null;
+
+  const [currentStep, setCurrentStep] = useState<StepId>('welcome');
+  const [hasRegisteredFursuit, setHasRegisteredFursuit] = useState(false);
+  const [hasTutorialCatch, setHasTutorialCatch] = useState(false);
+
+  const profileQueryOptions = useMemo(
+    () => (userId ? createProfileQueryOptions(userId) : null),
+    [userId]
+  );
+
+  const {
+    data: profile,
+    isLoading,
+    isFetching,
+  } = useQuery<ProfileSummary | null, Error>({
+    ...(profileQueryOptions ?? {
+      queryKey: ['profile', 'guest'],
+      queryFn: async () => null,
+    }),
+    enabled: Boolean(userId),
+  });
+
+  useEffect(() => {
+    if (!userId) {
+      router.replace('/auth');
+      return;
+    }
+
+    if (profile?.onboarding_completed) {
+      router.replace('/');
+    }
+  }, [profile?.onboarding_completed, router, userId]);
+
+  const goToNextStep = useCallback(() => {
+    setCurrentStep((current) => {
+      const currentIdx = stepIndex(current);
+      const nextIdx = Math.min(currentIdx + 1, STEPS.length - 1);
+      return STEPS[nextIdx];
+    });
+  }, []);
+
+  const handleFinish = useCallback(() => {
+    router.replace('/');
+  }, [router]);
+
+  const currentIndex = stepIndex(currentStep);
+
+  if (!userId) {
+    return <LoadingView />;
+  }
+
+  if ((isLoading || isFetching) && !profile) {
+    return <LoadingView />;
+  }
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text style={styles.header}>New player onboarding</Text>
+      <ProgressDots currentIndex={currentIndex} total={STEPS.length} />
+
+      {currentStep === 'welcome' ? (
+        <WelcomeStep onContinue={goToNextStep} />
+      ) : currentStep === 'convention' ? (
+        <ConventionStep
+          userId={userId}
+          onComplete={() => {
+            goToNextStep();
+          }}
+        />
+      ) : currentStep === 'fursuit' ? (
+        <FursuitStep
+          userId={userId}
+          onSkip={() => {
+            setHasRegisteredFursuit(false);
+            goToNextStep();
+          }}
+          onComplete={({ created }) => {
+            setHasRegisteredFursuit(created);
+            goToNextStep();
+          }}
+        />
+      ) : currentStep === 'tutorial' ? (
+        <TutorialCatchStep
+          userId={userId}
+          onSkip={() => {
+            setHasTutorialCatch(false);
+            goToNextStep();
+          }}
+          onComplete={({ recorded }) => {
+            setHasTutorialCatch(recorded);
+            goToNextStep();
+          }}
+        />
+      ) : (
+        <AchievementStep
+          userId={userId}
+          hasTutorialCatch={hasTutorialCatch}
+          hasFursuit={hasRegisteredFursuit}
+          onFinish={handleFinish}
+        />
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  container: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  header: {
+    color: colors.foreground,
+    fontSize: 28,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/src/features/onboarding/api/onboarding.ts
+++ b/src/features/onboarding/api/onboarding.ts
@@ -206,32 +206,23 @@ export async function recordTutorialCatch(userId: string): Promise<void> {
   }
 }
 
-export async function ensureGettingStartedAchievement(userId: string): Promise<boolean> {
-  const { data, error } = await supabase.rpc('grant_getting_started_achievement', {
-    target_user_id: userId,
-  });
-
-  if (error) {
-    throw new Error(`We couldn't grant the Getting Started achievement: ${error.message}`);
-  }
-
-  return Boolean(data);
-}
+type FinishOnboardingResult = {
+  profile_updated: boolean;
+  achievement_unlocked: boolean;
+};
 
 export async function completeOnboarding(userId: string): Promise<void> {
-  const client = supabase as any;
-  const { error } = await client
-    .from('profiles')
-    .update({
-      onboarding_completed: true,
-      is_new: false,
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', userId);
+  const { data, error } = await supabase.rpc('finish_onboarding', {
+    target_user_id: userId,
+  });
 
   if (error) {
     throw new Error(`We couldn't finish onboarding: ${error.message}`);
   }
 
-  await ensureGettingStartedAchievement(userId);
+  const result = (data ?? null) as FinishOnboardingResult | null;
+
+  if (!result || result.profile_updated !== true) {
+    throw new Error('We could not confirm your onboarding progress. Please try again.');
+  }
 }

--- a/src/features/onboarding/api/onboarding.ts
+++ b/src/features/onboarding/api/onboarding.ts
@@ -1,0 +1,237 @@
+import { supabase } from '../../../lib/supabase';
+import { FURSUIT_BUCKET, MAX_IMAGE_SIZE } from '../../../constants/storage';
+import { UNIQUE_CODE_ATTEMPTS, UNIQUE_INSERT_ATTEMPTS } from '../../../constants/codes';
+import { generateUniqueCodeCandidate } from '../../../utils/code';
+import { loadUriAsUint8Array } from '../../../utils/files';
+
+import type { FursuitsInsert } from '../../../types/database';
+
+const TUTORIAL_FURSUIT_NAME = 'TailTag Trainer';
+const TUTORIAL_FURSUIT_SPECIES = 'Fox';
+const TUTORIAL_FURSUIT_DESCRIPTION = 'Practice suit used during onboarding';
+
+export const GETTING_STARTED_ACHIEVEMENT_KEY = 'getting_started';
+
+export type FursuitPhotoCandidate = {
+  uri: string;
+  mimeType: string;
+  fileName: string;
+  fileSize: number;
+};
+
+const generateAvailableFursuitCode = async (): Promise<string> => {
+  const client = supabase as any;
+
+  for (let attempt = 0; attempt < UNIQUE_CODE_ATTEMPTS; attempt += 1) {
+    const candidate = generateUniqueCodeCandidate();
+    const { data, error } = await client
+      .from('fursuits')
+      .select('id')
+      .eq('unique_code', candidate)
+      .limit(1);
+
+    if (error) {
+      throw new Error(`We couldn't generate a tag code right now: ${error.message}`);
+    }
+
+    if (!data || data.length === 0) {
+      return candidate;
+    }
+  }
+
+  throw new Error("We couldn't generate a unique tag code. Please try again.");
+};
+
+const uploadFursuitPhoto = async (userId: string, photo: FursuitPhotoCandidate) => {
+  if (photo.fileSize > MAX_IMAGE_SIZE) {
+    throw new Error('Suit photos must be 5MB or smaller.');
+  }
+
+  const extension = photo.fileName.split('.').pop()?.toLowerCase() ?? 'jpg';
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const storagePath = `${userId}/${uniqueSuffix}.${extension}`;
+
+  const fileBytes = await loadUriAsUint8Array(photo.uri);
+
+  const { error: uploadError } = await supabase.storage.from(FURSUIT_BUCKET).upload(storagePath, fileBytes, {
+    contentType: photo.mimeType,
+    upsert: true,
+  });
+
+  if (uploadError) {
+    throw uploadError;
+  }
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from(FURSUIT_BUCKET).getPublicUrl(storagePath);
+
+  return { storagePath, publicUrl };
+};
+
+const ensureTutorialFursuitForUser = async (userId: string) => {
+  const client = supabase as any;
+  const { data: existing, error: fetchError } = await client
+    .from('fursuits')
+    .select('id')
+    .eq('owner_id', userId)
+    .eq('is_tutorial', true)
+    .maybeSingle();
+
+  if (fetchError) {
+    throw new Error(`We couldn't look up the tutorial suit: ${fetchError.message}`);
+  }
+
+  if (existing?.id) {
+    return existing.id as string;
+  }
+
+  for (let attempt = 0; attempt < UNIQUE_INSERT_ATTEMPTS; attempt += 1) {
+    const tutorialCode = await generateAvailableFursuitCode();
+    const { data: inserted, error: insertError } = await client
+      .from('fursuits')
+      .insert({
+        owner_id: userId,
+        name: TUTORIAL_FURSUIT_NAME,
+        species: TUTORIAL_FURSUIT_SPECIES,
+        species_id: null,
+        avatar_url: null,
+        unique_code: tutorialCode,
+        description: TUTORIAL_FURSUIT_DESCRIPTION,
+        is_tutorial: true,
+      })
+      .select('id')
+      .single();
+
+    if (!insertError && inserted?.id) {
+      return inserted.id as string;
+    }
+
+    if (insertError?.code !== '23505') {
+      throw new Error(`We couldn't prepare the tutorial suit: ${insertError?.message ?? 'Unknown error'}`);
+    }
+  }
+
+  throw new Error("We couldn't prepare the tutorial suit: ran out of attempts.");
+};
+
+export async function createQuickFursuit(options: {
+  userId: string;
+  name: string;
+  species: string;
+  description: string | null;
+  photo: FursuitPhotoCandidate | null;
+}): Promise<string> {
+  const { userId, name, species, description, photo } = options;
+  const client = supabase as any;
+
+  let uploadedStoragePath: string | null = null;
+  let avatarUrl: string | null = null;
+
+  try {
+    if (photo) {
+      const uploaded = await uploadFursuitPhoto(userId, photo);
+      uploadedStoragePath = uploaded.storagePath;
+      avatarUrl = uploaded.publicUrl;
+    }
+
+    const normalizedName = name.trim();
+    const normalizedSpecies = species.trim();
+    const normalizedDescription = description?.trim() ?? null;
+
+    if (!normalizedName) {
+      throw new Error('Give your fursuit a name before saving.');
+    }
+
+    if (!normalizedSpecies) {
+      throw new Error('Add a species so other players know who you are.');
+    }
+
+    for (let attempt = 0; attempt < UNIQUE_INSERT_ATTEMPTS; attempt += 1) {
+      const uniqueCode = await generateAvailableFursuitCode();
+      const payload: FursuitsInsert = {
+        owner_id: userId,
+        name: normalizedName,
+        species: normalizedSpecies,
+        species_id: null,
+        avatar_url: avatarUrl,
+        unique_code: uniqueCode,
+        description: normalizedDescription,
+        is_tutorial: false,
+      };
+
+      const { data: inserted, error } = await client.from('fursuits').insert(payload).select('id').single();
+
+      if (!error && inserted?.id) {
+        return inserted.id;
+      }
+
+      if (error?.code !== '23505') {
+        throw error ?? new Error("We couldn't save that fursuit. Please try again.");
+      }
+    }
+
+    throw new Error("We couldn't save that fursuit. Please try again.");
+  } catch (caught) {
+    if (uploadedStoragePath) {
+      const { error: cleanupError } = await supabase.storage
+        .from(FURSUIT_BUCKET)
+        .remove([uploadedStoragePath]);
+
+      if (cleanupError) {
+        console.warn('Failed to clean up onboarding fursuit photo after error', cleanupError);
+      }
+    }
+
+    throw caught;
+  }
+}
+
+export async function recordTutorialCatch(userId: string): Promise<void> {
+  const client = supabase as any;
+  const tutorialFursuitId = await ensureTutorialFursuitForUser(userId);
+  const { error } = await client
+    .from('catches')
+    .insert({
+      catcher_id: userId,
+      fursuit_id: tutorialFursuitId,
+      caught_at: new Date().toISOString(),
+      is_tutorial: true,
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (error && error.code !== '23505') {
+    throw new Error(`We couldn't record your practice catch: ${error.message}`);
+  }
+}
+
+export async function ensureGettingStartedAchievement(userId: string): Promise<boolean> {
+  const { data, error } = await supabase.rpc('grant_getting_started_achievement', {
+    target_user_id: userId,
+  });
+
+  if (error) {
+    throw new Error(`We couldn't grant the Getting Started achievement: ${error.message}`);
+  }
+
+  return Boolean(data);
+}
+
+export async function completeOnboarding(userId: string): Promise<void> {
+  const client = supabase as any;
+  const { error } = await client
+    .from('profiles')
+    .update({
+      onboarding_completed: true,
+      is_new: false,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', userId);
+
+  if (error) {
+    throw new Error(`We couldn't finish onboarding: ${error.message}`);
+  }
+
+  await ensureGettingStartedAchievement(userId);
+}

--- a/src/features/onboarding/components/AchievementStep.tsx
+++ b/src/features/onboarding/components/AchievementStep.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { TailTagButton } from '../../../components/ui/TailTagButton';
+import { TailTagCard } from '../../../components/ui/TailTagCard';
+import { completeOnboarding } from '../../onboarding';
+import { achievementsStatusQueryKey } from '../../achievements';
+import { profileQueryKey, type ProfileSummary } from '../../profile';
+import { colors, spacing } from '../../../theme';
+
+type AchievementStepProps = {
+  userId: string;
+  hasTutorialCatch: boolean;
+  hasFursuit: boolean;
+  onFinish: () => void;
+};
+
+export function AchievementStep({
+  userId,
+  hasTutorialCatch,
+  hasFursuit,
+  onFinish,
+}: AchievementStepProps) {
+  const queryClient = useQueryClient();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const handleFinish = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await completeOnboarding(userId);
+
+      queryClient.setQueryData<ProfileSummary | null>(profileQueryKey(userId), (current) => ({
+        username: current?.username ?? null,
+        bio: current?.bio ?? null,
+        avatar_url: current?.avatar_url ?? null,
+        onboarding_completed: true,
+        is_new: false,
+      }));
+
+      await queryClient.invalidateQueries({ queryKey: profileQueryKey(userId) });
+      await queryClient.invalidateQueries({ queryKey: achievementsStatusQueryKey(userId) });
+      onFinish();
+    } catch (caught) {
+      const message =
+        caught instanceof Error
+          ? caught.message
+          : 'We could not finish onboarding right now. Please try again.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TailTagCard>
+        <Text style={styles.eyebrow}>Step 5</Text>
+        <Text style={styles.title}>Achievement unlocked!</Text>
+        <Text style={styles.body}>
+          You&apos;re ready to explore TailTag. The Getting Started achievement is now yours—check the
+          achievements screen to see how to earn more.
+        </Text>
+
+        <View style={styles.summary}>
+          <Text style={styles.summaryTitle}>What you accomplished</Text>
+          <View style={styles.summaryItem}>
+            <View style={[styles.dot, styles.dotPrimary]} />
+            <Text style={styles.summaryText}>Joined your first convention</Text>
+          </View>
+          <View style={styles.summaryItem}>
+            <View style={[styles.dot, hasFursuit ? styles.dotPrimary : styles.dotMuted]} />
+            <Text style={styles.summaryText}>
+              {hasFursuit ? 'Registered a fursuit' : 'You can add a fursuit anytime'}
+            </Text>
+          </View>
+          <View style={styles.summaryItem}>
+            <View style={[styles.dot, hasTutorialCatch ? styles.dotPrimary : styles.dotMuted]} />
+            <Text style={styles.summaryText}>
+              {hasTutorialCatch ? 'Completed the tutorial catch' : 'Tutorial catch skipped'}
+            </Text>
+          </View>
+        </View>
+
+        {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
+
+        <TailTagButton onPress={handleFinish} loading={isSubmitting} disabled={isSubmitting}>
+          Finish Onboarding
+        </TailTagButton>
+      </TailTagCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  eyebrow: {
+    color: colors.primary,
+    fontSize: 13,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginBottom: spacing.xs,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  body: {
+    color: 'rgba(226,232,240,0.85)',
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: spacing.lg,
+  },
+  summary: {
+    backgroundColor: 'rgba(15,23,42,0.65)',
+    borderRadius: 18,
+    padding: spacing.md,
+    gap: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  summaryTitle: {
+    color: colors.foreground,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  summaryItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  summaryText: {
+    color: 'rgba(226,232,240,0.85)',
+    fontSize: 14,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: 'rgba(148,163,184,0.4)',
+  },
+  dotPrimary: {
+    backgroundColor: colors.primary,
+  },
+  dotMuted: {
+    backgroundColor: 'rgba(148,163,184,0.4)',
+  },
+  error: {
+    color: colors.destructive,
+    fontSize: 14,
+    marginBottom: spacing.sm,
+  },
+});

--- a/src/features/onboarding/components/ConventionStep.tsx
+++ b/src/features/onboarding/components/ConventionStep.tsx
@@ -1,0 +1,221 @@
+import { useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { TailTagButton } from '../../../components/ui/TailTagButton';
+import { TailTagCard } from '../../../components/ui/TailTagCard';
+import { TailTagInput } from '../../../components/ui/TailTagInput';
+import {
+  createConventionsQueryOptions,
+  optInToConvention,
+  PROFILE_CONVENTIONS_QUERY_KEY,
+  type ConventionSummary,
+} from '../../conventions';
+import { ConventionToggle } from '../../../components/conventions/ConventionToggle';
+import { colors, spacing } from '../../../theme';
+
+type ConventionStepProps = {
+  userId: string;
+  onComplete: (conventionIds: string[]) => void;
+};
+
+export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
+  const queryClient = useQueryClient();
+  const [searchInput, setSearchInput] = useState('');
+  const [selectedConventionIds, setSelectedConventionIds] = useState<Set<string>>(new Set());
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const conventionsQueryOptions = useMemo(() => createConventionsQueryOptions(), []);
+  const {
+    data: conventions = [],
+    error,
+    isLoading,
+    refetch,
+  } = useQuery<ConventionSummary[], Error>({
+    ...conventionsQueryOptions,
+    refetchOnMount: true,
+  });
+
+  const filteredConventions = useMemo(() => {
+    if (searchInput.trim().length === 0) {
+      return conventions;
+    }
+
+    const normalized = searchInput.trim().toLowerCase();
+    return conventions.filter((convention) => {
+      const haystack = `${convention.name} ${convention.location ?? ''}`.toLowerCase();
+      return haystack.includes(normalized);
+    });
+  }, [conventions, searchInput]);
+
+  const toggleConvention = (conventionId: string) => {
+    setSelectedConventionIds((current) => {
+      const next = new Set(current);
+      if (next.has(conventionId)) {
+        next.delete(conventionId);
+      } else {
+        next.add(conventionId);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selectedConventionIds.size === 0 || isSubmitting) {
+      setSubmitError('Select at least one convention to continue.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const selections = [...selectedConventionIds];
+
+      await Promise.all(selections.map((conventionId) => optInToConvention(userId, conventionId)));
+
+      queryClient.setQueryData<string[] | undefined>(
+        [PROFILE_CONVENTIONS_QUERY_KEY, userId],
+        (current = []) => {
+          const merged = new Set(current);
+          selections.forEach((id) => merged.add(id));
+          return [...merged];
+        }
+      );
+
+      onComplete(selections);
+    } catch (caught) {
+      const message =
+        caught instanceof Error
+          ? caught.message
+          : 'We could not save your convention picks. Please try again.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TailTagCard>
+        <Text style={styles.eyebrow}>Step 2</Text>
+        <Text style={styles.title}>Choose your first convention</Text>
+        <Text style={styles.body}>
+          Pick at least one convention so other players know where they can find you. You can change
+          this later in settings.
+        </Text>
+
+        <TailTagInput
+          placeholder="Search conventions"
+          value={searchInput}
+          onChangeText={setSearchInput}
+          editable={!isLoading && !isSubmitting}
+          style={styles.search}
+        />
+
+        <View style={styles.listHeader}>
+          <Text style={styles.listHeaderText}>Active conventions</Text>
+          <TailTagButton size="sm" variant="outline" onPress={() => refetch()} disabled={isLoading}>
+            Refresh
+          </TailTagButton>
+        </View>
+
+        <ScrollView
+          style={styles.list}
+          contentContainerStyle={styles.listContent}
+          nestedScrollEnabled
+          scrollEnabled
+        >
+          {isLoading ? (
+            <Text style={styles.message}>Loading conventions…</Text>
+          ) : error ? (
+            <Text style={styles.error}>{error.message}</Text>
+          ) : filteredConventions.length === 0 ? (
+            <Text style={styles.message}>No conventions matched your search yet.</Text>
+          ) : (
+            filteredConventions.map((convention) => {
+              const selected = selectedConventionIds.has(convention.id);
+              return (
+                <View key={convention.id} style={styles.listItem}>
+                  <ConventionToggle
+                    convention={convention}
+                    selected={selected}
+                    pending={isSubmitting}
+                    disabled={isSubmitting}
+                    onToggle={() => toggleConvention(convention.id)}
+                  />
+                </View>
+              );
+            })
+          )}
+        </ScrollView>
+
+        {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
+
+        <TailTagButton onPress={handleSubmit} loading={isSubmitting} disabled={isSubmitting}>
+          Continue
+        </TailTagButton>
+      </TailTagCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  eyebrow: {
+    color: colors.primary,
+    fontSize: 13,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginBottom: spacing.xs,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  body: {
+    color: 'rgba(226,232,240,0.85)',
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: spacing.md,
+  },
+  search: {
+    marginBottom: spacing.md,
+  },
+  listHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
+  listHeaderText: {
+    color: colors.foreground,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  list: {
+    maxHeight: 320,
+    marginBottom: spacing.md,
+  },
+  listContent: {
+    gap: spacing.sm,
+  },
+  listItem: {
+    marginBottom: spacing.sm,
+  },
+  message: {
+    color: 'rgba(148,163,184,0.85)',
+    fontSize: 15,
+  },
+  error: {
+    color: colors.destructive,
+    fontSize: 14,
+    marginBottom: spacing.sm,
+  },
+});

--- a/src/features/onboarding/components/FursuitStep.tsx
+++ b/src/features/onboarding/components/FursuitStep.tsx
@@ -1,0 +1,298 @@
+import { useState } from 'react';
+import {
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import * as ImagePicker from 'expo-image-picker';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { TailTagButton } from '../../../components/ui/TailTagButton';
+import { TailTagCard } from '../../../components/ui/TailTagCard';
+import { TailTagInput } from '../../../components/ui/TailTagInput';
+import { SkipButton } from './SkipButton';
+import { createQuickFursuit, type FursuitPhotoCandidate } from '../../onboarding';
+import { MY_SUITS_QUERY_KEY } from '../../suits';
+import { colors, radius, spacing } from '../../../theme';
+
+type FursuitStepProps = {
+  userId: string;
+  onSkip: () => void;
+  onComplete: (options: { created: boolean }) => void;
+};
+
+export function FursuitStep({ userId, onSkip, onComplete }: FursuitStepProps) {
+  const queryClient = useQueryClient();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [nameInput, setNameInput] = useState('');
+  const [speciesInput, setSpeciesInput] = useState('');
+  const [descriptionInput, setDescriptionInput] = useState('');
+  const [selectedPhoto, setSelectedPhoto] = useState<FursuitPhotoCandidate | null>(null);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleOpenForm = () => {
+    setIsExpanded(true);
+  };
+
+  const handlePickPhoto = async () => {
+    try {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+      if (status !== 'granted') {
+        setPhotoError('We need media access to attach a suit photo.');
+        return;
+      }
+
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: 'images',
+        allowsEditing: true,
+        aspect: [1, 1],
+        quality: 0.85,
+      });
+
+      if (result.canceled) {
+        return;
+      }
+
+      const asset = result.assets?.[0];
+
+      if (!asset) {
+        setPhotoError('No photo selected.');
+        return;
+      }
+
+      setSelectedPhoto({
+        uri: asset.uri,
+        mimeType: asset.mimeType ?? 'image/jpeg',
+        fileName: asset.fileName ?? `fursuit-${Date.now()}.jpg`,
+        fileSize: asset.fileSize ?? 0,
+      });
+      setPhotoError(null);
+    } catch (caught) {
+      const message =
+        caught instanceof Error
+          ? caught.message
+          : 'We could not open your photo library. Please try again.';
+      setPhotoError(message);
+    }
+  };
+
+  const handleClearPhoto = () => {
+    setSelectedPhoto(null);
+    setPhotoError(null);
+  };
+
+  const resetForm = () => {
+    setNameInput('');
+    setSpeciesInput('');
+    setDescriptionInput('');
+    setSelectedPhoto(null);
+    setPhotoError(null);
+    setSubmitError(null);
+  };
+
+  const handleSubmit = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    const trimmedName = nameInput.trim();
+    const trimmedSpecies = speciesInput.trim();
+    const trimmedDescription = descriptionInput.trim();
+
+    if (!trimmedName) {
+      setSubmitError('Give your fursuit a name before saving.');
+      return;
+    }
+
+    if (!trimmedSpecies) {
+      setSubmitError('Add a suit species so others know who to call out.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await createQuickFursuit({
+        userId,
+        name: trimmedName,
+        species: trimmedSpecies,
+        description: trimmedDescription.length > 0 ? trimmedDescription : null,
+        photo: selectedPhoto,
+      });
+
+      queryClient.invalidateQueries({ queryKey: [MY_SUITS_QUERY_KEY, userId] });
+
+      resetForm();
+      onComplete({ created: true });
+    } catch (caught) {
+      const message =
+        caught instanceof Error
+          ? caught.message
+          : 'We could not save that suit right now. Please try again.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      style={styles.container}
+    >
+      <TailTagCard>
+        <Text style={styles.eyebrow}>Step 3</Text>
+        <Text style={styles.title}>Add a fursuit (optional)</Text>
+        <Text style={styles.body}>
+          TailTag suits are how other players recognize you. Add one now or skip and come back later.
+        </Text>
+
+        {!isExpanded ? (
+          <View style={styles.ctaRow}>
+            <TailTagButton onPress={handleOpenForm}>Add my fursuit</TailTagButton>
+            <SkipButton onPress={onSkip} />
+          </View>
+        ) : (
+          <View style={styles.form}>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Suit name</Text>
+              <TailTagInput
+                value={nameInput}
+                onChangeText={setNameInput}
+                placeholder="e.g. Trainer Fox"
+                editable={!isSubmitting}
+              />
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Species</Text>
+              <TailTagInput
+                value={speciesInput}
+                onChangeText={setSpeciesInput}
+                placeholder="Fox, Dragon, Husky…"
+                editable={!isSubmitting}
+              />
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Description (optional)</Text>
+              <TailTagInput
+                value={descriptionInput}
+                onChangeText={setDescriptionInput}
+                placeholder="Share a quick intro or fun fact"
+                editable={!isSubmitting}
+                multiline
+                numberOfLines={3}
+                style={styles.descriptionInput}
+              />
+            </View>
+
+            <View style={styles.photoSection}>
+              <Text style={styles.label}>Suit photo (optional)</Text>
+              {selectedPhoto ? (
+                <View style={styles.photoPreview}>
+                  <Image source={{ uri: selectedPhoto.uri }} style={styles.photo} />
+                  <TailTagButton variant="outline" size="sm" onPress={handleClearPhoto} disabled={isSubmitting}>
+                    Remove photo
+                  </TailTagButton>
+                </View>
+              ) : (
+                <TailTagButton variant="outline" size="sm" onPress={handlePickPhoto} disabled={isSubmitting}>
+                  Choose photo
+                </TailTagButton>
+              )}
+              {photoError ? <Text style={styles.error}>{photoError}</Text> : null}
+            </View>
+
+            {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
+
+            <View style={styles.formCtaRow}>
+              <SkipButton onPress={onSkip} disabled={isSubmitting} />
+              <TailTagButton onPress={handleSubmit} loading={isSubmitting} disabled={isSubmitting}>
+                Continue
+              </TailTagButton>
+            </View>
+          </View>
+        )}
+      </TailTagCard>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  eyebrow: {
+    color: colors.primary,
+    fontSize: 13,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginBottom: spacing.xs,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  body: {
+    color: 'rgba(226,232,240,0.85)',
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: spacing.lg,
+  },
+  ctaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+  form: {
+    gap: spacing.md,
+  },
+  fieldGroup: {
+    gap: spacing.xs,
+  },
+  label: {
+    color: colors.foreground,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  descriptionInput: {
+    height: 90,
+    textAlignVertical: 'top',
+  },
+  photoSection: {
+    gap: spacing.sm,
+  },
+  photoPreview: {
+    gap: spacing.sm,
+    alignItems: 'flex-start',
+  },
+  photo: {
+    width: 140,
+    height: 140,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: 'rgba(148,163,184,0.2)',
+  },
+  error: {
+    color: colors.destructive,
+    fontSize: 14,
+  },
+  formCtaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+});

--- a/src/features/onboarding/components/ProgressDots.tsx
+++ b/src/features/onboarding/components/ProgressDots.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, View } from 'react-native';
+
+import { colors, spacing } from '../../../theme';
+
+type ProgressDotsProps = {
+  currentIndex: number;
+  total: number;
+};
+
+export function ProgressDots({ currentIndex, total }: ProgressDotsProps) {
+  return (
+    <View style={styles.container}>
+      {Array.from({ length: total }, (_item, index) => {
+        const isActive = index === currentIndex;
+        return <View key={index} style={[styles.dot, isActive ? styles.dotActive : null]} />;
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    marginBottom: spacing.lg,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: 'rgba(148,163,184,0.35)',
+  },
+  dotActive: {
+    backgroundColor: colors.primary,
+  },
+});

--- a/src/features/onboarding/components/SkipButton.tsx
+++ b/src/features/onboarding/components/SkipButton.tsx
@@ -1,0 +1,45 @@
+import { Pressable, StyleSheet, Text } from 'react-native';
+
+import { colors, spacing } from '../../../theme';
+
+type SkipButtonProps = {
+  label?: string;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+export function SkipButton({ label = 'Skip for now', onPress, disabled = false }: SkipButtonProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.button,
+        disabled ? styles.buttonDisabled : null,
+        pressed && !disabled ? styles.buttonPressed : null,
+      ]}
+    >
+      <Text style={styles.text}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: 999,
+  },
+  buttonPressed: {
+    opacity: 0.85,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  text: {
+    color: colors.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/src/features/onboarding/components/TutorialCatchStep.tsx
+++ b/src/features/onboarding/components/TutorialCatchStep.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { TailTagButton } from '../../../components/ui/TailTagButton';
+import { TailTagCard } from '../../../components/ui/TailTagCard';
+import { TailTagInput } from '../../../components/ui/TailTagInput';
+import { SkipButton } from './SkipButton';
+import { recordTutorialCatch } from '../../onboarding';
+import { colors, spacing } from '../../../theme';
+import { normalizeUniqueCodeInput } from '../../../utils/code';
+
+type TutorialCatchStepProps = {
+  userId: string;
+  onComplete: (options: { recorded: boolean }) => void;
+  onSkip: () => void;
+};
+
+export function TutorialCatchStep({ userId, onComplete, onSkip }: TutorialCatchStepProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [codeInput, setCodeInput] = useState('');
+
+  const normalizedCode = useMemo(() => normalizeUniqueCodeInput(codeInput), [codeInput]);
+  const isCodeValid = normalizedCode === 'TEST';
+
+  const handleSubmit = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    if (!isCodeValid) {
+      setSubmitError('Enter the practice code TEST to continue.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await recordTutorialCatch(userId);
+      onComplete({ recorded: true });
+    } catch (caught) {
+      const message =
+        caught instanceof Error
+          ? caught.message
+          : "We couldn't log the practice catch. Please try again.";
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TailTagCard>
+        <Text style={styles.eyebrow}>Step 4</Text>
+        <Text style={styles.title}>Practice your first catch</Text>
+        <Text style={styles.body}>
+          Meet TailTag Trainer, our tutorial suit. Enter the practice code <Text style={styles.code}>TEST</Text>{" "}
+          to simulate a scan and see how catches are logged. You can skip if you already feel confident.
+        </Text>
+
+        <TailTagInput
+          value={codeInput}
+          onChangeText={(value) => {
+            setCodeInput(value);
+            setSubmitError(null);
+          }}
+          autoCapitalize="characters"
+          autoCorrect={false}
+          placeholder="Enter TEST"
+          editable={!isSubmitting}
+        />
+
+        {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
+
+        <View style={styles.ctaRow}>
+          <SkipButton onPress={onSkip} disabled={isSubmitting} />
+          <TailTagButton
+            onPress={handleSubmit}
+            loading={isSubmitting}
+            disabled={isSubmitting}
+          >
+            Catch Trainer
+          </TailTagButton>
+        </View>
+      </TailTagCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  eyebrow: {
+    color: colors.primary,
+    fontSize: 13,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginBottom: spacing.xs,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  body: {
+    color: 'rgba(226,232,240,0.85)',
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: spacing.lg,
+  },
+  ctaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+  error: {
+    color: colors.destructive,
+    fontSize: 14,
+    marginBottom: spacing.sm,
+  },
+  code: {
+    color: colors.primary,
+    fontWeight: '700',
+  },
+});

--- a/src/features/onboarding/components/WelcomeStep.tsx
+++ b/src/features/onboarding/components/WelcomeStep.tsx
@@ -1,0 +1,73 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { TailTagButton } from '../../../components/ui/TailTagButton';
+import { TailTagCard } from '../../../components/ui/TailTagCard';
+import { colors, spacing } from '../../../theme';
+
+type WelcomeStepProps = {
+  onContinue: () => void;
+};
+
+export function WelcomeStep({ onContinue }: WelcomeStepProps) {
+  return (
+    <View style={styles.container}>
+      <TailTagCard>
+        <Text style={styles.eyebrow}>Welcome to TailTag</Text>
+        <Text style={styles.title}>Ready to start tagging?</Text>
+        <Text style={styles.body}>
+          TailTag is a friendly scavenger hunt for fursuiters and fans. Opt into conventions, tag suits,
+          and complete achievements to climb the leaderboard.
+        </Text>
+
+        <View style={styles.captionBlock}>
+          <Text style={styles.captionTitle}>How onboarding works</Text>
+          <Text style={styles.captionBody}>
+            Pick a convention, optionally register a suit, try a tutorial catch, then claim your first
+            achievement.
+          </Text>
+        </View>
+
+        <TailTagButton onPress={onContinue}>Let&apos;s Go</TailTagButton>
+      </TailTagCard>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  eyebrow: {
+    color: colors.primary,
+    fontSize: 14,
+    letterSpacing: 3,
+    textTransform: 'uppercase',
+    marginBottom: spacing.xs,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: spacing.sm,
+  },
+  body: {
+    color: 'rgba(226,232,240,0.85)',
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  captionBlock: {
+    marginTop: spacing.lg,
+    marginBottom: spacing.lg,
+    gap: 6,
+  },
+  captionTitle: {
+    color: colors.foreground,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  captionBody: {
+    color: 'rgba(203,213,225,0.85)',
+    fontSize: 15,
+    lineHeight: 21,
+  },
+});

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -2,7 +2,6 @@ export {
   createQuickFursuit,
   recordTutorialCatch,
   completeOnboarding,
-  ensureGettingStartedAchievement,
   type FursuitPhotoCandidate,
   GETTING_STARTED_ACHIEVEMENT_KEY,
 } from './api/onboarding';

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,0 +1,8 @@
+export {
+  createQuickFursuit,
+  recordTutorialCatch,
+  completeOnboarding,
+  ensureGettingStartedAchievement,
+  type FursuitPhotoCandidate,
+  GETTING_STARTED_ACHIEVEMENT_KEY,
+} from './api/onboarding';

--- a/src/features/profile/api/profile.ts
+++ b/src/features/profile/api/profile.ts
@@ -4,6 +4,8 @@ export type ProfileSummary = {
   username: string | null;
   bio: string | null;
   avatar_url: string | null;
+  is_new: boolean;
+  onboarding_completed: boolean;
 };
 
 export const PROFILE_QUERY_KEY = 'profile';
@@ -15,7 +17,7 @@ export async function fetchProfile(userId: string): Promise<ProfileSummary | nul
   const client = supabase as any;
   const { data, error } = await client
     .from('profiles')
-    .select('username, bio, avatar_url')
+    .select('username, bio, avatar_url, is_new, onboarding_completed')
     .eq('id', userId)
     .maybeSingle();
 
@@ -31,6 +33,8 @@ export async function fetchProfile(userId: string): Promise<ProfileSummary | nul
     username: data.username ?? null,
     bio: data.bio ?? null,
     avatar_url: data.avatar_url ?? null,
+    is_new: data.is_new === true,
+    onboarding_completed: data.onboarding_completed === true,
   };
 }
 

--- a/src/features/suits/api/caughtSuits.ts
+++ b/src/features/suits/api/caughtSuits.ts
@@ -27,6 +27,8 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
         species,
         species_id,
         avatar_url,
+        is_tutorial,
+        description,
         unique_code,
         created_at,
         species_entry:fursuit_species (
@@ -58,29 +60,36 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
     throw new Error(`We couldn't load your catches: ${error.message}`);
   }
 
-  return (data ?? []).map((record: any) => {
-    const fursuit = record.fursuit
-      ? ({
-          id: record.fursuit.id,
-          name: record.fursuit.name,
-          species:
-            (record.fursuit.species_entry?.name ?? record.fursuit.species) ?? null,
-          speciesId:
-            (record.fursuit.species_entry?.id ?? record.fursuit.species_id) ?? null,
-          avatar_url: record.fursuit.avatar_url ?? null,
-          unique_code: record.fursuit.unique_code ?? null,
-          created_at: record.fursuit.created_at ?? null,
-          conventions: [],
-          bio: mapLatestFursuitBio(record.fursuit.fursuit_bios ?? null),
-        } satisfies FursuitSummary)
-      : null;
+  return (data ?? [])
+    .map((record: any) => {
+      const rawFursuit = record.fursuit;
 
-    return {
-      id: record.id,
-      caught_at: record.caught_at ?? null,
-      fursuit,
-    } satisfies CaughtRecord;
-  });
+      if (rawFursuit?.is_tutorial) {
+        return null;
+      }
+
+      const fursuit = rawFursuit
+        ? ({
+            id: rawFursuit.id,
+            name: rawFursuit.name,
+            species: (rawFursuit.species_entry?.name ?? rawFursuit.species) ?? null,
+            speciesId: (rawFursuit.species_entry?.id ?? rawFursuit.species_id) ?? null,
+            avatar_url: rawFursuit.avatar_url ?? null,
+            description: rawFursuit.description ?? null,
+            unique_code: rawFursuit.unique_code ?? null,
+            created_at: rawFursuit.created_at ?? null,
+            conventions: [],
+            bio: mapLatestFursuitBio(rawFursuit.fursuit_bios ?? null),
+          } satisfies FursuitSummary)
+        : null;
+
+      return {
+        id: record.id,
+        caught_at: record.caught_at ?? null,
+        fursuit,
+      } satisfies CaughtRecord;
+    })
+    .filter((entry: CaughtRecord | null): entry is CaughtRecord => Boolean(entry));
 }
 
 export const createCaughtSuitsQueryOptions = (userId: string) => ({

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -18,6 +18,8 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       species,
       species_id,
       avatar_url,
+      is_tutorial,
+      description,
       unique_code,
       created_at,
       species_entry:fursuit_species (
@@ -57,6 +59,7 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     `
     )
     .eq('id', fursuitId)
+    .eq('is_tutorial', false)
     .maybeSingle();
 
   if (error) {
@@ -91,6 +94,7 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     species: speciesName,
     speciesId: speciesId,
     avatar_url: data.avatar_url ?? null,
+    description: data.description ?? null,
     unique_code: data.unique_code ?? null,
     created_at: data.created_at ?? null,
     conventions,

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -19,6 +19,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       species,
       species_id,
       avatar_url,
+      description,
       unique_code,
       created_at,
       species_entry:fursuit_species (
@@ -53,6 +54,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
     `
     )
     .eq('owner_id', userId)
+    .eq('is_tutorial', false)
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -83,6 +85,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       species: speciesName,
       speciesId: speciesId,
       avatar_url: item.avatar_url ?? null,
+      description: item.description ?? null,
       unique_code: item.unique_code ?? null,
       created_at: item.created_at ?? null,
       conventions,

--- a/src/features/suits/types.ts
+++ b/src/features/suits/types.ts
@@ -22,6 +22,7 @@ export type FursuitSummary = {
   species: string | null;
   speciesId: string | null;
   avatar_url: string | null;
+  description: string | null;
   unique_code: string | null;
   created_at: string | null;
   conventions: ConventionSummary[];

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -80,18 +80,21 @@ export type Database = {
           catcher_id: string;
           caught_at: string | null;
           fursuit_id: string;
+          is_tutorial: boolean;
           id: string;
         };
         Insert: {
           catcher_id: string;
           caught_at?: string | null;
           fursuit_id: string;
+          is_tutorial?: boolean;
           id?: string;
         };
         Update: {
           catcher_id?: string;
           caught_at?: string | null;
           fursuit_id?: string;
+          is_tutorial?: boolean;
           id?: string;
         };
         Relationships: [
@@ -348,7 +351,9 @@ export type Database = {
         Row: {
           avatar_url: string | null;
           created_at: string | null;
+          description: string | null;
           id: string;
+          is_tutorial: boolean;
           name: string;
           owner_id: string;
           species: string | null;
@@ -358,7 +363,9 @@ export type Database = {
         Insert: {
           avatar_url?: string | null;
           created_at?: string | null;
+          description?: string | null;
           id?: string;
+          is_tutorial?: boolean;
           name: string;
           owner_id: string;
           species?: string | null;
@@ -368,7 +375,9 @@ export type Database = {
         Update: {
           avatar_url?: string | null;
           created_at?: string | null;
+          description?: string | null;
           id?: string;
+          is_tutorial?: boolean;
           name?: string;
           owner_id?: string;
           species?: string | null;
@@ -431,6 +440,8 @@ export type Database = {
           bio: string | null;
           created_at: string | null;
           id: string;
+          is_new: boolean;
+          onboarding_completed: boolean;
           updated_at: string | null;
           username: string | null;
         };
@@ -439,6 +450,8 @@ export type Database = {
           bio?: string | null;
           created_at?: string | null;
           id: string;
+          is_new?: boolean;
+          onboarding_completed?: boolean;
           updated_at?: string | null;
           username?: string | null;
         };
@@ -447,6 +460,8 @@ export type Database = {
           bio?: string | null;
           created_at?: string | null;
           id?: string;
+          is_new?: boolean;
+          onboarding_completed?: boolean;
           updated_at?: string | null;
           username?: string | null;
         };
@@ -583,6 +598,12 @@ export type Database = {
           convention_id: string;
         };
         Returns: undefined;
+      };
+      grant_getting_started_achievement: {
+        Args: {
+          target_user_id?: string | null;
+        };
+        Returns: boolean;
       };
     };
     Enums: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -605,6 +605,12 @@ export type Database = {
         };
         Returns: boolean;
       };
+      finish_onboarding: {
+        Args: {
+          target_user_id?: string | null;
+        };
+        Returns: Json;
+      };
     };
     Enums: {
       achievement_category:


### PR DESCRIPTION
# Onboarding Flow, Tutorial Catch, and RLS‑Safe Achievement Unlock

## Summary
- Adds a guided onboarding flow for new users with gating:
  - Join a convention
  - Optionally add a fursuit
  - Tutorial catch requiring code entry (“TEST”)
  - “Getting Started” achievement unlock
- Persists onboarding state on profile and blocks main tabs until completed.

## Motivation
- Help new users understand TailTag without guesswork.
- Drive early engagement with conventions and fursuit profiles.
- Provide an early sense of progress via a global achievement.

## Key Changes
- Onboarding gating and route:
  - Adds gating in `app/_layout.tsx` using `profiles.is_new` and `profiles.onboarding_completed`.
  - New flow screen `app/onboarding/index.tsx` orchestrates steps and state.

- Onboarding UI components:
  - `src/features/onboarding/components/WelcomeStep.tsx`
  - `src/features/onboarding/components/ConventionStep.tsx` (search/select + opt‑in via `profile_conventions`)
  - `src/features/onboarding/components/FursuitStep.tsx` (quick add; optional photo upload)
  - `src/features/onboarding/components/TutorialCatchStep.tsx` (requires code “TEST”)
  - `src/features/onboarding/components/AchievementStep.tsx`
  - Shared: `ProgressDots.tsx`, `SkipButton.tsx`

- Onboarding services:
  - `src/features/onboarding/api/onboarding.ts`
    - `createQuickFursuit`: simple per‑user suit creation using existing code generator + storage.
    - `recordTutorialCatch`: creates a per‑user `is_tutorial` suit if missing, then inserts a tutorial catch.
    - `ensureGettingStartedAchievement`: calls a privileged RPC to grant the achievement.
    - `completeOnboarding`: updates profile flags and triggers the achievement unlock.

- Achievement unlock (RLS‑safe):
  - Adds RPC `grant_getting_started_achievement` and uses it instead of direct inserts into `user_achievements`.

- Data model updates (typed client + queries):
  - `profiles`: add `is_new`, `onboarding_completed` to client types and fetch (`src/features/profile/api/profile.ts`).
  - `catches`: add `is_tutorial` to client types.
  - `fursuits`: add `description`, `is_tutorial` to client types.
  - Queries adjusted to exclude tutorial suits where appropriate:
    - `src/features/suits/api/mySuits.ts` filters `is_tutorial = false`
    - `src/features/suits/api/fursuitDetails.ts` filters `is_tutorial = false`
    - `src/features/suits/api/caughtSuits.ts` filters out tutorial suits from list
    - `app/(tabs)/catch.tsx` prevents scanning tutorial suits by code

## User Experience
- New users are redirected to onboarding until completion.
- Tutorial catch mimics real play: users must enter the practice code “TEST” to proceed.
- On completion, the app marks `onboarding_completed = true` and unlocks “Getting Started.”

## Database Changes
Run these in Supabase SQL editor.

Schema updates:
```sql
ALTER TABLE profiles
  ADD COLUMN IF NOT EXISTS onboarding_completed boolean NOT NULL DEFAULT false,
  ADD COLUMN IF NOT EXISTS is_new boolean NOT NULL DEFAULT true;

UPDATE profiles
SET onboarding_completed = true,
    is_new = false
WHERE onboarding_completed IS DISTINCT FROM true
   OR is_new IS DISTINCT FROM false;

ALTER TABLE catches
  ADD COLUMN IF NOT EXISTS is_tutorial boolean NOT NULL DEFAULT false;

ALTER TABLE fursuits
  ADD COLUMN IF NOT EXISTS description text,
  ADD COLUMN IF NOT EXISTS is_tutorial boolean NOT NULL DEFAULT false;

INSERT INTO achievements (key, name, description, category, recipient_role, trigger_event, is_active)
VALUES (
  'getting_started',
  'Getting Started',
  'Complete the TailTag onboarding flow',
  'meta',
  'any',
  'profile.updated',
  true
)
ON CONFLICT (key) DO UPDATE
SET name = EXCLUDED.name,
    description = EXCLUDED.description,
    category = EXCLUDED.category,
    recipient_role = EXCLUDED.recipient_role,
    trigger_event = EXCLUDED.trigger_event,
    is_active = EXCLUDED.is_active;
```

Privileged RPC (RLS‑safe unlock):
```sql
create or replace function public.grant_getting_started_achievement(
  target_user_id uuid default auth.uid()
)
returns boolean
language plpgsql
security definer
set search_path = public
as $$
declare
  effective_user uuid := coalesce(target_user_id, auth.uid());
  achievement_row_id uuid;
  inserted boolean := false;
begin
  if effective_user is null then
    raise exception using message = 'Missing authenticated user.';
  end if;

  if auth.uid() is distinct from effective_user then
    raise exception using message = 'You can only unlock this achievement for yourself.';
  end if;

  select id
    into achievement_row_id
  from achievements
  where key = 'getting_started'
  limit 1;

  if achievement_row_id is null then
    raise exception using message = 'Getting Started achievement is not configured.';
  end if;

  insert into user_achievements (user_id, achievement_id, unlocked_at)
  values (effective_user, achievement_row_id, now())
  on conflict (user_id, achievement_id) do nothing;

  inserted := found;
  return inserted;
end;
$$;

grant execute on function public.grant_getting_started_achievement(uuid) to authenticated;
```

Client types (already included in this PR):
- `src/types/database.ts`: added fields for `profiles`, `catches`, `fursuits`, and RPC signature for `grant_getting_started_achievement`.

## Testing Plan
- Sign in with a user having `is_new = true`, `onboarding_completed = false`; confirm redirect to `/onboarding`.
- Convention step: select at least one; verify rows in `profile_conventions`.
- Optional fursuit: add minimal suit (name + species); verify `fursuits` row (and storage upload if photo).
- Tutorial catch: enter “TEST”; verify a per‑user tutorial suit (`is_tutorial = true`) and a `catches` row with `is_tutorial = true`.
- Finish: verify profile flags updated and `grant_getting_started_achievement` returns success; confirm “Getting Started” unlocked.
- Regression checks:
  - My Suits does not show the tutorial suit.
  - Catch tab cannot scan tutorial suits by code.
  - Caught list does not show tutorial suits.

## Performance & Risk
- Minimal overhead; adds one profile query at app load, and simple filters in existing queries.
- RPC is idempotent and lightweight.

## Follow-Ups
- Add analytics events for step completion.
- Confetti animation for unlock screen.
- Optional: “Replay tutorial” entry in settings.
