### PR TITLE
Add catch counter for fursuits

### DIFF
--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -16,6 +16,7 @@ import {
   FursuitBioDetails,
   CAUGHT_SUITS_QUERY_KEY,
   mapLatestFursuitBio,
+  fursuitDetailQueryKey,
 } from "../../src/features/suits";
 import type { FursuitBio } from "../../src/features/suits";
 import {
@@ -45,11 +46,13 @@ type FursuitDetails = Pick<
   | "unique_code"
   | "owner_id"
   | "is_tutorial"
+  | "catch_count"
 > & { created_at: string | null; bio: FursuitBio | null };
 
 type CatchRecord = {
   id: string;
   caught_at: string | null;
+  catch_number: number | null;
 };
 
 export default function CatchScreen() {
@@ -65,9 +68,17 @@ export default function CatchScreen() {
     null
   );
   const [catchRecord, setCatchRecord] = useState<CatchRecord | null>(null);
+  const [catchNumber, setCatchNumber] = useState<number | null>(null);
   const [conversationPrompt, setConversationPrompt] = useState<string | null>(
     null
   );
+
+  const resetCatchState = () => {
+    setCaughtFursuit(null);
+    setCatchRecord(null);
+    setCatchNumber(null);
+    setConversationPrompt(null);
+  };
 
   const handleSubmit = async () => {
     if (!userId || isSubmitting) {
@@ -85,7 +96,7 @@ export default function CatchScreen() {
 
     setIsSubmitting(true);
     setSubmitError(null);
-    setConversationPrompt(null);
+    resetCatchState();
 
     try {
       const client = supabase as any;
@@ -101,6 +112,7 @@ export default function CatchScreen() {
           avatar_url,
           is_tutorial,
           unique_code,
+          catch_count,
           owner_id,
           created_at,
           species_entry:fursuit_species (
@@ -135,14 +147,17 @@ export default function CatchScreen() {
       }
 
       if (!fursuit) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError(
           "We couldn't find a fursuit with that code. Double-check the letters and try again."
         );
         return;
       }
+
+      const initialCatchCount =
+        typeof (fursuit as any)?.catch_count === "number"
+          ? (fursuit as any).catch_count
+          : 0;
 
       const normalizedFursuit: FursuitDetails = {
         id: fursuit.id,
@@ -153,6 +168,7 @@ export default function CatchScreen() {
           (fursuit as any)?.species_entry?.id ?? fursuit.species_id ?? null,
         avatar_url: fursuit.avatar_url ?? null,
         unique_code: fursuit.unique_code ?? null,
+        catch_count: initialCatchCount,
         owner_id: fursuit.owner_id,
         created_at: fursuit.created_at ?? null,
         bio: mapLatestFursuitBio((fursuit as any)?.fursuit_bios ?? null),
@@ -160,17 +176,13 @@ export default function CatchScreen() {
       };
 
       if (normalizedFursuit.is_tutorial) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError("Tutorial suits cannot be caught by scanning codes.");
         return;
       }
 
       if (normalizedFursuit.owner_id === userId) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError(
           "That tag belongs to one of your own suits. Trade codes with friends to grow your collection."
         );
@@ -209,9 +221,7 @@ export default function CatchScreen() {
       );
 
       if (playerConventionIds.size === 0) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError(
           "Opt into at least one convention in Settings before logging catches."
         );
@@ -219,9 +229,7 @@ export default function CatchScreen() {
       }
 
       if (suitConventionIds.size === 0) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError(
           "This suit has not opted into any conventions yet. Ask the owner to update their settings before logging the catch."
         );
@@ -233,9 +241,7 @@ export default function CatchScreen() {
       );
 
       if (sharedConventions.length === 0) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError(
           "You and this suit need to opt into the same convention before logging the catch."
         );
@@ -254,9 +260,7 @@ export default function CatchScreen() {
       }
 
       if (existingCatch) {
-        setCaughtFursuit(null);
-        setCatchRecord(null);
-        setConversationPrompt(null);
+        resetCatchState();
         setSubmitError(
           "You already caught this suit. Swap codes with another fursuiter to keep hunting."
         );
@@ -266,7 +270,7 @@ export default function CatchScreen() {
       const { data: insertedCatch, error: catchError } = await client
         .from("catches")
         .insert({ fursuit_id: normalizedFursuit.id, catcher_id: userId })
-        .select("id, caught_at")
+        .select("id, caught_at, catch_number")
         .single();
 
       if (catchError) {
@@ -274,9 +278,7 @@ export default function CatchScreen() {
           setSubmitError(
             "You already caught this suit. Swap codes with another fursuiter to keep hunting."
           );
-          setCaughtFursuit(null);
-          setCatchRecord(null);
-          setConversationPrompt(null);
+          resetCatchState();
           return;
         }
 
@@ -294,11 +296,55 @@ export default function CatchScreen() {
             .find((value) => value)
         : null;
 
-      setCaughtFursuit(normalizedFursuit);
-      setCatchRecord(insertedCatch ?? null);
+      const minimumCatchCount = initialCatchCount + 1;
+      let latestCatchCount = minimumCatchCount;
+
+      try {
+        const { data: latestFursuit, error: latestCatchError } = await client
+          .from("fursuits")
+          .select("catch_count")
+          .eq("id", normalizedFursuit.id)
+          .maybeSingle();
+
+        if (latestCatchError) {
+          throw latestCatchError;
+        }
+
+        if (latestFursuit && typeof latestFursuit.catch_count === "number") {
+          latestCatchCount = Math.max(
+            latestFursuit.catch_count,
+            minimumCatchCount
+          );
+        }
+      } catch (countError) {
+        console.warn("Failed to refresh catch count", countError);
+      }
+
+      const normalizedCatchRecord: CatchRecord | null = insertedCatch
+        ? {
+            id: insertedCatch.id,
+            caught_at: insertedCatch.caught_at ?? null,
+            catch_number:
+              typeof insertedCatch.catch_number === "number"
+                ? insertedCatch.catch_number
+                : null,
+          }
+        : null;
+
+      setCaughtFursuit({
+        ...normalizedFursuit,
+        catch_count: latestCatchCount,
+      });
+      setCatchRecord(normalizedCatchRecord);
+      setCatchNumber(
+        normalizedCatchRecord?.catch_number ?? latestCatchCount
+      );
       setConversationPrompt(promptCandidate ?? null);
       await triggerAchievementProcessor({ limit: 10, maxBatches: 1 });
       void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
+      queryClient.invalidateQueries({
+        queryKey: fursuitDetailQueryKey(normalizedFursuit.id),
+      });
       sharedConventions.forEach((conventionId) => {
         queryClient.invalidateQueries({
           queryKey: [CONVENTION_LEADERBOARD_QUERY_KEY, conventionId],
@@ -317,9 +363,7 @@ export default function CatchScreen() {
           ? caught.message
           : "We couldn't save that catch. Please try again.";
       setSubmitError(fallbackMessage);
-      setCaughtFursuit(null);
-      setCatchRecord(null);
-      setConversationPrompt(null);
+      resetCatchState();
     } finally {
       setIsSubmitting(false);
     }
@@ -330,11 +374,9 @@ export default function CatchScreen() {
     : null;
 
   const handleCatchAnother = () => {
-    setCaughtFursuit(null);
-    setCatchRecord(null);
+    resetCatchState();
     setSubmitError(null);
     setCodeInput("");
-    setConversationPrompt(null);
   };
 
   return (
@@ -392,6 +434,11 @@ export default function CatchScreen() {
         {caughtFursuit ? (
           <TailTagCard style={styles.cardSpacing}>
             <Text style={styles.sectionTitle}>Nice catch!</Text>
+            {catchNumber !== null ? (
+              <Text style={[styles.sectionBody, styles.sectionHighlight]}>
+                You were catcher #{catchNumber} for this suit!
+              </Text>
+            ) : null}
             <Text style={styles.sectionBody}>
               You just tagged {caughtFursuit.name}. Scroll through their bio
               below and trade codes to keep your streak growing.
@@ -501,6 +548,10 @@ const styles = StyleSheet.create({
     color: "rgba(203,213,225,0.9)",
     fontSize: 14,
     marginBottom: spacing.md,
+  },
+  sectionHighlight: {
+    color: colors.primary,
+    fontWeight: "600",
   },
   bioSpacing: {
     marginTop: spacing.md,

--- a/app/(tabs)/caught.tsx
+++ b/app/(tabs)/caught.tsx
@@ -101,7 +101,14 @@ export default function CaughtSuitsScreen() {
                 return null;
               }
 
-              const label = toDisplayDateTime(record.caught_at) ?? 'Caught just now';
+              const caughtLabel = toDisplayDateTime(record.caught_at) ?? 'Caught just now';
+              const pieces = [caughtLabel];
+
+              if (typeof record.catchNumber === 'number' && record.catchNumber > 0) {
+                pieces.push(`Catcher #${record.catchNumber}`);
+              }
+
+              const timelineLabel = pieces.join(' · ');
 
               return (
                 <View
@@ -113,7 +120,7 @@ export default function CaughtSuitsScreen() {
                     species={details.species}
                     avatarUrl={details.avatar_url}
                     uniqueCode={details.unique_code}
-                    timelineLabel={label}
+                    timelineLabel={timelineLabel}
                     codeLabel={undefined}
                     onPress={() => router.push({ pathname: '/fursuits/[id]', params: { id: details.id } })}
                   />

--- a/app/fursuits/[id].tsx
+++ b/app/fursuits/[id].tsx
@@ -32,6 +32,18 @@ const formatDate = (isoTimestamp: string | null) => {
   }).format(date);
 };
 
+const formatCatchSummary = (count: number) => {
+  if (!Number.isFinite(count) || count <= 0) {
+    return 'No catches yet';
+  }
+
+  if (count === 1) {
+    return 'Caught once';
+  }
+
+  return `Caught ${count} times`;
+};
+
 export default function FursuitDetailScreen() {
   const router = useRouter();
   const { session } = useAuth();
@@ -72,6 +84,7 @@ export default function FursuitDetailScreen() {
   };
 
   const addedDate = detail ? formatDate(detail.created_at) : null;
+  const catchSummary = detail ? formatCatchSummary(detail.catchCount) : null;
 
   return (
     <ScrollView style={styles.scroll} contentContainerStyle={styles.container}>
@@ -114,6 +127,14 @@ export default function FursuitDetailScreen() {
             ) : (
               <Text style={styles.message}>This fursuit does not have a bio yet.</Text>
             )}
+            {typeof detail.catchCount === 'number' ? (
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>
+                  {isOwner ? 'Catch stats' : 'Catch history'}
+                </Text>
+                <Text style={styles.sectionItem}>{catchSummary}</Text>
+              </View>
+            ) : null}
             {detail.conventions.length > 0 ? (
               <View style={styles.section}>
                 <Text style={styles.sectionTitle}>Convention appearances</Text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "expo-image-picker": "~17.0.8",
         "expo-linear-gradient": "~15.0.7",
         "expo-linking": "~8.0.8",
-        "expo-router": "~6.0.11",
+        "expo-router": "~6.0.12",
         "expo-status-bar": "~3.0.8",
         "p-retry": "^6.2.1",
         "react": "19.1.0",
@@ -8824,9 +8824,9 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.11.tgz",
-      "integrity": "sha512-/nXK73PIqD7DVtMO9ToAE2zZHZhRywdjt4EKQlqJ7uPG+dPq+kLwi/1VpMK9qr64EwvrXH7ekbnQfHHjmlAsAQ==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.12.tgz",
+      "integrity": "sha512-GBfMHAbHoPv7aCfHOEgFNxcadw4euPyI/SqHNNtw+Sm+JtvauHP34wi7Bg25JxatHQ8EdhxAj6w0D8D6QRnayg==",
       "license": "MIT",
       "dependencies": {
         "@expo/metro-runtime": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "expo-image-picker": "~17.0.8",
     "expo-linear-gradient": "~15.0.7",
     "expo-linking": "~8.0.8",
-    "expo-router": "~6.0.11",
+    "expo-router": "~6.0.12",
     "expo-status-bar": "~3.0.8",
     "p-retry": "^6.2.1",
     "react": "19.1.0",

--- a/src/features/suits/api/caughtSuits.ts
+++ b/src/features/suits/api/caughtSuits.ts
@@ -6,6 +6,7 @@ import { captureSupabaseError } from '../../../lib/sentry';
 export type CaughtRecord = {
   id: string;
   caught_at: string | null;
+  catchNumber: number | null;
   fursuit: FursuitSummary | null;
 };
 
@@ -22,12 +23,14 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
       `
       id,
       caught_at,
+      catch_number,
       fursuit:fursuits (
         id,
         name,
         species,
         species_id,
         avatar_url,
+        catch_count,
         is_tutorial,
         description,
         unique_code,
@@ -83,6 +86,8 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
             avatar_url: rawFursuit.avatar_url ?? null,
             description: rawFursuit.description ?? null,
             unique_code: rawFursuit.unique_code ?? null,
+            catchCount:
+              typeof rawFursuit.catch_count === 'number' ? rawFursuit.catch_count : 0,
             created_at: rawFursuit.created_at ?? null,
             conventions: [],
             bio: mapLatestFursuitBio(rawFursuit.fursuit_bios ?? null),
@@ -92,6 +97,8 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
       return {
         id: record.id,
         caught_at: record.caught_at ?? null,
+        catchNumber:
+          typeof record.catch_number === 'number' ? record.catch_number : null,
         fursuit,
       } satisfies CaughtRecord;
     })

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -22,6 +22,7 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       is_tutorial,
       description,
       unique_code,
+      catch_count,
       created_at,
       species_entry:fursuit_species (
         id,
@@ -97,6 +98,26 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
   const speciesName = speciesEntry?.name ?? data.species ?? null;
   const speciesId = speciesEntry?.id ?? data.species_id ?? null;
 
+  let resolvedCatchCount =
+    typeof data.catch_count === 'number' ? data.catch_count : 0;
+
+  if (resolvedCatchCount <= 0) {
+    const { count: fallbackCount, error: fallbackError } = await client
+      .from('catches')
+      .select('id', { head: true, count: 'exact' })
+      .eq('fursuit_id', data.id);
+
+    if (fallbackError) {
+      captureSupabaseError(fallbackError, {
+        scope: 'suits.fetchFursuitDetail.fallback',
+        action: 'count',
+        fursuitId,
+      });
+    } else if (typeof fallbackCount === 'number') {
+      resolvedCatchCount = fallbackCount;
+    }
+  }
+
   return {
     id: data.id,
     owner_id: data.owner_id,
@@ -106,6 +127,7 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     avatar_url: data.avatar_url ?? null,
     description: data.description ?? null,
     unique_code: data.unique_code ?? null,
+    catchCount: resolvedCatchCount,
     created_at: data.created_at ?? null,
     conventions,
     bio,

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -22,6 +22,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       avatar_url,
       description,
       unique_code,
+      catch_count,
       created_at,
       species_entry:fursuit_species (
         id,
@@ -93,6 +94,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       avatar_url: item.avatar_url ?? null,
       description: item.description ?? null,
       unique_code: item.unique_code ?? null,
+      catchCount: typeof item.catch_count === 'number' ? item.catch_count : 0,
       created_at: item.created_at ?? null,
       conventions,
       bio,

--- a/src/features/suits/types.ts
+++ b/src/features/suits/types.ts
@@ -24,6 +24,7 @@ export type FursuitSummary = {
   avatar_url: string | null;
   description: string | null;
   unique_code: string | null;
+  catchCount: number;
   created_at: string | null;
   conventions: ConventionSummary[];
   bio: FursuitBio | null;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -79,6 +79,7 @@ export type Database = {
         Row: {
           catcher_id: string;
           caught_at: string | null;
+          catch_number: number | null;
           fursuit_id: string;
           is_tutorial: boolean;
           id: string;
@@ -86,6 +87,7 @@ export type Database = {
         Insert: {
           catcher_id: string;
           caught_at?: string | null;
+          catch_number?: number | null;
           fursuit_id: string;
           is_tutorial?: boolean;
           id?: string;
@@ -93,6 +95,7 @@ export type Database = {
         Update: {
           catcher_id?: string;
           caught_at?: string | null;
+          catch_number?: number | null;
           fursuit_id?: string;
           is_tutorial?: boolean;
           id?: string;
@@ -350,6 +353,7 @@ export type Database = {
       fursuits: {
         Row: {
           avatar_url: string | null;
+          catch_count: number;
           created_at: string | null;
           description: string | null;
           id: string;
@@ -362,6 +366,7 @@ export type Database = {
         };
         Insert: {
           avatar_url?: string | null;
+          catch_count?: number;
           created_at?: string | null;
           description?: string | null;
           id?: string;
@@ -374,6 +379,7 @@ export type Database = {
         };
         Update: {
           avatar_url?: string | null;
+          catch_count?: number;
           created_at?: string | null;
           description?: string | null;
           id?: string;


### PR DESCRIPTION
# Catch counts are now first-class across the app and backend.
- Adds catch_count to our shared Supabase types and fursuit models (`src/types/database.ts`, `src/features/suits/types.ts`) so every suit payload carries its running total
- Includes the new field in the my-suits, caught-suits, and suit-detail queries and maps it into the client summaries `(src/features/suits/api/{mySuits,caughtSuits,fursuitDetails}.ts)`
- Shows “catcher #N” on the catch-confirmation screen, keeps state tidy between attempts, and invalidates the detail query so the owner sees the updated total immediately `(app/(tabs)/catch.tsx)`
- Renders a catch summary on the fursuit bio for owners and fans `(app/fursuits/[id].tsx)` and exposes catcher numbers in the caught-suits list `(app/(tabs)/caught.tsx)`
- Falls back to a direct catch count if the denormalised value ever comes back as zero (useful while the trigger is rolling out)
raises expo-router to the Expo-recommended version to silence compatibility warnings