### PR TITLE
Fix Achievement Processing UI Lag

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -16,6 +16,7 @@ import { TailTagCard } from "../../src/components/ui/TailTagCard";
 import { TailTagProgressBar } from "../../src/components/ui/TailTagProgressBar";
 import { useAuth } from "../../src/features/auth";
 import { supabase } from "../../src/lib/supabase";
+import { captureHandledException } from "../../src/lib/sentry";
 import {
   CONVENTIONS_QUERY_KEY,
   CONVENTIONS_STALE_TIME,
@@ -389,7 +390,7 @@ export default function HomeScreen() {
     return pieces.join(" · ");
   };
 
-  const handleReloadStandings = useCallback(async () => {
+  const handleReloadStandings = useCallback(() => {
     void refetchLeaderboard({ throwOnError: false });
     void refetchSuitLeaderboard({ throwOnError: false });
 
@@ -397,18 +398,19 @@ export default function HomeScreen() {
       return;
     }
 
-    const emitted = await emitGameplayEvent({
+    // Fire-and-forget: don't block UI on event emission
+    void emitGameplayEvent({
       type: "leaderboard_refreshed",
       conventionId: selectedConventionId,
       payload: {
         convention_id: selectedConventionId,
       },
+    }).catch((error) => {
+      captureHandledException(error, {
+        scope: "home.handleReloadStandings",
+        conventionId: selectedConventionId,
+      });
     });
-    if (!emitted) {
-      console.warn(
-        "Failed to enqueue leaderboard_refreshed event; daily task progress may be delayed",
-      );
-    }
     void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
   }, [
     refetchLeaderboard,

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -29,6 +29,7 @@ import { useAuth } from '../../src/features/auth';
 import type { ConventionSummary } from '../../src/features/conventions';
 import { ConventionToggle } from '../../src/components/conventions/ConventionToggle';
 import { supabase } from '../../src/lib/supabase';
+import { captureHandledException } from '../../src/lib/sentry';
 import { colors, spacing, radius } from '../../src/theme';
 import { loadUriAsUint8Array } from '../../src/utils/files';
 import { deriveStoragePathFromPublicUrl } from '../../src/utils/storage';
@@ -431,12 +432,19 @@ export default function SettingsScreen() {
       setSelectedAvatar(null);
       setShouldRemoveAvatar(false);
       setSaveMessage('Profile updated');
-      await emitGameplayEvent({
+
+      // Fire-and-forget: don't block UI on event emission
+      void emitGameplayEvent({
         type: 'profile_updated',
         payload: {
           has_avatar: Boolean(nextAvatarUrl),
           username_present: trimmedUsername.length > 0,
         },
+      }).catch((error) => {
+        captureHandledException(error, {
+          scope: 'settings.handleSave.profileUpdated',
+          userId,
+        });
       });
       void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
     } catch (caught) {

--- a/packages/achievement-rules/src/index.ts
+++ b/packages/achievement-rules/src/index.ts
@@ -1,5 +1,5 @@
-export * from "./constants";
-export * from "./types";
-export { catchRules, evaluateCatchAchievements } from "./rules/catch";
-export { profileRules, evaluateProfileAchievements } from "./rules/profile";
-export { simpleRules, evaluateSimpleEventAchievements } from "./rules/simple";
+export * from "./constants.ts";
+export * from "./types.ts";
+export { catchRules, evaluateCatchAchievements } from "./rules/catch.ts";
+export { profileRules, evaluateProfileAchievements } from "./rules/profile.ts";
+export { simpleRules, evaluateSimpleEventAchievements } from "./rules/simple.ts";

--- a/packages/achievement-rules/src/rules/catch.ts
+++ b/packages/achievement-rules/src/rules/catch.ts
@@ -1,5 +1,5 @@
-import { ACHIEVEMENT_RULE_IDS } from "../constants";
-import type { AwardCandidate, CatchEventContext, CatchRuleDefinition } from "../types";
+import { ACHIEVEMENT_RULE_IDS } from "../constants.ts";
+import type { AwardCandidate, CatchEventContext, CatchRuleDefinition } from "../types.ts";
 
 function baseCatchContext(context: CatchEventContext, extra?: Record<string, unknown>) {
   return {

--- a/packages/achievement-rules/src/rules/profile.ts
+++ b/packages/achievement-rules/src/rules/profile.ts
@@ -1,5 +1,5 @@
-import { ACHIEVEMENT_RULE_IDS } from "../constants";
-import type { AwardCandidate, ProfileEventContext, ProfileRuleDefinition } from "../types";
+import { ACHIEVEMENT_RULE_IDS } from "../constants.ts";
+import type { AwardCandidate, ProfileEventContext, ProfileRuleDefinition } from "../types.ts";
 
 const profileRules: ProfileRuleDefinition[] = [
   {

--- a/packages/achievement-rules/src/rules/simple.ts
+++ b/packages/achievement-rules/src/rules/simple.ts
@@ -1,5 +1,5 @@
-import { ACHIEVEMENT_RULE_IDS } from "../constants";
-import type { AwardCandidate, SimpleEventContext, SimpleRuleDefinition } from "../types";
+import { ACHIEVEMENT_RULE_IDS } from "../constants.ts";
+import type { AwardCandidate, SimpleEventContext, SimpleRuleDefinition } from "../types.ts";
 
 const simpleRules: SimpleRuleDefinition[] = [
   {

--- a/src/features/events/api/events.ts
+++ b/src/features/events/api/events.ts
@@ -113,6 +113,7 @@ export async function emitGameplayEvent(
   }
 
   const startTime = Date.now();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
     const idempotencyKey = input.idempotencyKey ?? generateIdempotencyKey();
@@ -140,12 +141,22 @@ export async function emitGameplayEvent(
 
     // Race between the invoke and a 5-second timeout
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         reject(new Error(`Event emission timed out after 5 seconds (type: ${type})`));
       }, 5000);
     });
 
+    // Suppress unhandled rejection if timeout wins the race
+    invokePromise.catch(() => {
+      // Intentionally empty - the error will be handled by the race loser
+    });
+
     const invokeResult = await Promise.race([invokePromise, timeoutPromise]);
+
+    // Clear the timeout since we got a result
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
     const { data, error } = invokeResult;
 
     const duration = Date.now() - startTime;
@@ -214,6 +225,11 @@ export async function emitGameplayEvent(
       awards,
     };
   } catch (error) {
+    // Clear the timeout on error path
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+
     const duration = Date.now() - startTime;
     console.error(`[emitGameplayEvent] Failed after ${duration}ms:`, {
       type,

--- a/src/features/events/api/events.ts
+++ b/src/features/events/api/events.ts
@@ -95,7 +95,7 @@ const normalizeOccurredAt = (input: GameplayEventInput["occurredAt"]) => {
 };
 
 /**
- * Emit a gameplay event into the Supabase → Cloudflare ingestion pipeline.
+ * Emit a gameplay event into the Supabase ingestion pipeline.
  * Returns `null` when the request fails so callers can degrade gracefully
  * without interrupting the primary UX flow (e.g. catching a suit).
  */
@@ -112,6 +112,8 @@ export async function emitGameplayEvent(
     return null;
   }
 
+  const startTime = Date.now();
+
   try {
     const idempotencyKey = input.idempotencyKey ?? generateIdempotencyKey();
 
@@ -123,14 +125,67 @@ export async function emitGameplayEvent(
       idempotency_key: idempotencyKey,
     };
 
-    const { data, error } = await supabase.functions.invoke<{
+    console.log(`[emitGameplayEvent] Starting event emission: ${type}`, {
+      conventionId: input.conventionId,
+      timestamp: new Date().toISOString(),
+    });
+
+    // Invoke the edge function with a timeout wrapper
+    const invokePromise = supabase.functions.invoke<{
       event_id: string;
       awards?: unknown;
-    }>("events-ingress", { body });
+    }>("events-ingress", {
+      body,
+    });
+
+    // Race between the invoke and a 5-second timeout
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Event emission timed out after 5 seconds (type: ${type})`));
+      }, 5000);
+    });
+
+    const invokeResult = await Promise.race([invokePromise, timeoutPromise]);
+    const { data, error } = invokeResult;
+
+    const duration = Date.now() - startTime;
 
     if (error) {
-      throw error;
+      // Extract the actual error message from the response body
+      let actualError = error.message;
+      try {
+        // @ts-ignore - context has the Response object
+        if (error.context && typeof error.context.json === 'function') {
+          const errorBody = await error.context.json();
+          actualError = errorBody.error || errorBody.message || error.message;
+          console.error(`[emitGameplayEvent] Edge function returned ${error.context.status} after ${duration}ms:`, {
+            type,
+            status: error.context.status,
+            errorBody,
+            actualError,
+          });
+        } else {
+          console.error(`[emitGameplayEvent] Edge function returned error after ${duration}ms:`, {
+            type,
+            error,
+            errorMessage: error.message,
+          });
+        }
+      } catch (parseError) {
+        console.error(`[emitGameplayEvent] Could not parse error response:`, {
+          type,
+          error,
+          parseError,
+        });
+      }
+      throw new Error(actualError);
     }
+
+    console.log(`[emitGameplayEvent] Completed in ${duration}ms:`, {
+      type,
+      success: true,
+      hasData: !!data,
+    });
 
     if (!data || typeof data.event_id !== "string") {
       throw new Error("events-ingress response missing event_id");
@@ -159,10 +214,19 @@ export async function emitGameplayEvent(
       awards,
     };
   } catch (error) {
+    const duration = Date.now() - startTime;
+    console.error(`[emitGameplayEvent] Failed after ${duration}ms:`, {
+      type,
+      error: error instanceof Error ? error.message : String(error),
+      isTimeout: error instanceof Error && error.message.includes('timed out'),
+    });
+
     captureHandledException(error, {
       scope: "events.emitGameplayEvent",
       type,
       conventionId: input.conventionId ?? null,
+      duration,
+      isTimeout: error instanceof Error && error.message.includes('timed out'),
     });
     return null;
   }

--- a/supabase/functions/events-ingress/index.ts
+++ b/supabase/functions/events-ingress/index.ts
@@ -202,6 +202,7 @@ async function handlePost(req: Request): Promise<Response> {
     occurred_at: occurredAt,
   };
 
+  const insertStart = Date.now();
   const { error: insertError } = await supabaseAdmin
     .from("events")
     .insert([eventRow]);
@@ -211,19 +212,29 @@ async function handlePost(req: Request): Promise<Response> {
     return jsonResponse(500, { error: "Failed to persist event" });
   }
 
-  let achievementResult = { awards: [] };
-  try {
-    achievementResult = await processAchievementsForEvent(supabaseAdmin, eventRow);
-  } catch (error) {
-    console.error("[events-ingress] synchronous achievement processing failed", {
-      event_id: eventId,
-      error,
-    });
-  }
+  const insertDuration = Date.now() - insertStart;
+  console.log(`[events-ingress] Event inserted in ${insertDuration}ms`, { event_id: eventId, type });
 
+  // Process achievements asynchronously (don't await)
+  // This will execute in the background
+  processAchievementsForEvent(supabaseAdmin, eventRow)
+    .then(() => {
+      console.log(`[events-ingress] Achievement processing completed for ${eventId}`);
+    })
+    .catch((error) => {
+      console.error("[events-ingress] async achievement processing failed", {
+        event_id: eventId,
+        error,
+      });
+    });
+
+  console.log(`[events-ingress] Returning response for event ${eventId}`);
+
+  // Return immediately with event_id
+  // Achievements will be delivered via Realtime subscriptions
   return jsonResponse(201, {
     event_id: eventId,
-    awards: achievementResult.awards,
+    awards: [], // Empty array since processing is async
   });
 }
 


### PR DESCRIPTION
This PR fixes a small bug I found where processing events for achievements and tasks was taking too long for a good user experience. This cleans up how they are processed on the edge network and how the UI responds to this feedback