### PR TITLE
Adjust catch screen button layout for small screens

### DIFF
--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -493,6 +493,7 @@ export default function CatchScreen() {
             onPress={handleSubmit}
             loading={isSubmitting}
             disabled={!userId || isSubmitting}
+            style={styles.fullWidthButton}
           >
             Record catch
           </TailTagButton>
@@ -540,11 +541,15 @@ export default function CatchScreen() {
               <TailTagButton
                 variant="outline"
                 onPress={() => router.push("/caught")}
-                style={styles.inlineButtonSpacing}
+                style={[styles.fullWidthButton, styles.stackedButtonSpacing]}
               >
                 View catches
               </TailTagButton>
-              <TailTagButton variant="ghost" onPress={handleCatchAnother}>
+              <TailTagButton
+                variant="ghost"
+                onPress={handleCatchAnother}
+                style={styles.fullWidthButton}
+              >
                 Catch another suit
               </TailTagButton>
             </View>
@@ -621,17 +626,20 @@ const styles = StyleSheet.create({
     marginTop: spacing.md,
   },
   buttonRow: {
-    flexDirection: "row",
+    flexDirection: "column",
     marginTop: spacing.md,
-    alignItems: "center",
+    alignItems: "stretch",
   },
-  inlineButtonSpacing: {
-    marginRight: spacing.md,
+  stackedButtonSpacing: {
+    marginBottom: spacing.sm,
   },
   codeInput: {
     textTransform: "uppercase",
     letterSpacing: 4,
     fontSize: 20,
+  },
+  fullWidthButton: {
+    width: "100%",
   },
   promptCard: {
     marginBottom: spacing.md,

--- a/src/features/onboarding/components/FursuitStep.tsx
+++ b/src/features/onboarding/components/FursuitStep.tsx
@@ -204,8 +204,10 @@ export function FursuitStep({ userId, onSkip, onComplete }: FursuitStepProps) {
 
         {!isExpanded ? (
           <View style={styles.ctaRow}>
-            <TailTagButton onPress={handleOpenForm}>Add my fursuit</TailTagButton>
-            <SkipButton onPress={onSkip} />
+            <TailTagButton style={styles.fullWidthCta} onPress={handleOpenForm}>
+              Add my fursuit
+            </TailTagButton>
+            <SkipButton style={styles.fullWidthCta} onPress={onSkip} />
           </View>
         ) : (
           <View style={styles.form}>
@@ -336,8 +338,13 @@ export function FursuitStep({ userId, onSkip, onComplete }: FursuitStepProps) {
             {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
 
             <View style={styles.formCtaRow}>
-              <SkipButton onPress={onSkip} disabled={isSubmitting} />
-              <TailTagButton onPress={handleSubmit} loading={isSubmitting} disabled={isSubmitting}>
+              <SkipButton onPress={onSkip} disabled={isSubmitting} style={styles.fullWidthCta} />
+              <TailTagButton
+                onPress={handleSubmit}
+                loading={isSubmitting}
+                disabled={isSubmitting}
+                style={styles.fullWidthCta}
+              >
                 Continue
               </TailTagButton>
             </View>
@@ -372,10 +379,11 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   ctaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: spacing.md,
+    flexDirection: 'column',
+    gap: spacing.sm,
+  },
+  fullWidthCta: {
+    alignSelf: 'stretch',
   },
   form: {
     gap: spacing.md,
@@ -477,9 +485,8 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   formCtaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: spacing.md,
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: spacing.sm,
   },
 });

--- a/src/features/onboarding/components/SkipButton.tsx
+++ b/src/features/onboarding/components/SkipButton.tsx
@@ -1,4 +1,4 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet, Text, type StyleProp, type ViewStyle } from 'react-native';
 
 import { colors, spacing } from '../../../theme';
 
@@ -6,9 +6,15 @@ type SkipButtonProps = {
   label?: string;
   onPress: () => void;
   disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
 };
 
-export function SkipButton({ label = 'Skip for now', onPress, disabled = false }: SkipButtonProps) {
+export function SkipButton({
+  label = 'Skip for now',
+  onPress,
+  disabled = false,
+  style,
+}: SkipButtonProps) {
   return (
     <Pressable
       accessibilityRole="button"
@@ -18,6 +24,7 @@ export function SkipButton({ label = 'Skip for now', onPress, disabled = false }
         styles.button,
         disabled ? styles.buttonDisabled : null,
         pressed && !disabled ? styles.buttonPressed : null,
+        style,
       ]}
     >
       <Text style={styles.text}>{label}</Text>
@@ -30,6 +37,8 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.md,
     borderRadius: 999,
+    alignItems: 'center',
+    alignSelf: 'stretch',
   },
   buttonPressed: {
     opacity: 0.85,
@@ -41,5 +50,6 @@ const styles = StyleSheet.create({
     color: colors.primary,
     fontSize: 14,
     fontWeight: '600',
+    textAlign: 'center',
   },
 });

--- a/src/features/onboarding/components/TutorialCatchStep.tsx
+++ b/src/features/onboarding/components/TutorialCatchStep.tsx
@@ -75,11 +75,12 @@ export function TutorialCatchStep({ userId, onComplete, onSkip }: TutorialCatchS
         {submitError ? <Text style={styles.error}>{submitError}</Text> : null}
 
         <View style={styles.ctaRow}>
-          <SkipButton onPress={onSkip} disabled={isSubmitting} />
+          <SkipButton onPress={onSkip} disabled={isSubmitting} style={styles.fullWidthCta} />
           <TailTagButton
             onPress={handleSubmit}
             loading={isSubmitting}
             disabled={isSubmitting}
+            style={styles.fullWidthCta}
           >
             Catch Trainer
           </TailTagButton>
@@ -113,10 +114,12 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   ctaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: spacing.md,
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: spacing.sm,
+  },
+  fullWidthCta: {
+    alignSelf: 'stretch',
   },
   error: {
     color: colors.destructive,


### PR DESCRIPTION
## Summary
- stack catch confirmation buttons vertically and make them full width to prevent overflow on smaller devices
- ensure the primary catch submission button also spans the available width within its card

## Testing
- npm run typecheck
- npm run lint
- npm run doctor *(fails: Expo doctor cannot reach Expo API in this environment; fetch failed / ENETUNREACH)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692220beec70832d84d32768917b33c4)