### PR TITLE
Enforce Players Only Registering Three Fursuits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.*
 # Local PRDs for feature development
 /docs
 CLAUDE.md
+.mcp.json

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -23,7 +23,7 @@ import { captureHandledException } from '../../../src/lib/sentry';
 import { generateUniqueCodeCandidate } from '../../../src/utils/code';
 import { loadUriAsUint8Array } from '../../../src/utils/files';
 import { colors, spacing, radius } from '../../../src/theme';
-import { MY_SUITS_QUERY_KEY, createMySuitsCountQueryOptions } from '../../../src/features/suits';
+import { MY_SUITS_QUERY_KEY, MY_SUITS_COUNT_QUERY_KEY, createMySuitsCountQueryOptions } from '../../../src/features/suits';
 import { MAX_FURSUITS_PER_USER } from '../../../src/constants/fursuits';
 import {
   CatchModeSwitch,
@@ -602,6 +602,7 @@ export default function AddFursuitScreen() {
       setSubmitError(null);
 
       queryClient.invalidateQueries({ queryKey: [MY_SUITS_QUERY_KEY, userId] });
+      void queryClient.invalidateQueries({ queryKey: [MY_SUITS_COUNT_QUERY_KEY, userId] });
       void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
 
       // Navigate immediately

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -23,7 +23,8 @@ import { captureHandledException } from '../../../src/lib/sentry';
 import { generateUniqueCodeCandidate } from '../../../src/utils/code';
 import { loadUriAsUint8Array } from '../../../src/utils/files';
 import { colors, spacing, radius } from '../../../src/theme';
-import { MY_SUITS_QUERY_KEY } from '../../../src/features/suits';
+import { MY_SUITS_QUERY_KEY, createMySuitsCountQueryOptions } from '../../../src/features/suits';
+import { MAX_FURSUITS_PER_USER } from '../../../src/constants/fursuits';
 import {
   CatchModeSwitch,
   type CatchMode,
@@ -98,6 +99,15 @@ export default function AddFursuitScreen() {
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
+
+  const {
+    data: suitCount = 0,
+  } = useQuery({
+    ...createMySuitsCountQueryOptions(userId!),
+    enabled: Boolean(userId),
+  });
+
+  const isAtFursuitLimit = suitCount >= MAX_FURSUITS_PER_USER;
 
   const [nameInput, setNameInput] = useState('');
   const [speciesInput, setSpeciesInput] = useState('');
@@ -340,6 +350,11 @@ export default function AddFursuitScreen() {
 
   const handleSubmit = async () => {
     if (!userId || isSubmitting) {
+      return;
+    }
+
+    if (isAtFursuitLimit) {
+      setSubmitError(`You can only have ${MAX_FURSUITS_PER_USER} fursuits. Delete an existing fursuit to add a new one.`);
       return;
     }
 
@@ -674,6 +689,20 @@ export default function AddFursuitScreen() {
             Then fill out a bio so every catcher knows how to say hello.
           </Text>
         </View>
+
+        {isAtFursuitLimit && (
+          <TailTagCard style={styles.limitBanner}>
+            <Text style={styles.limitBannerText}>
+              You have reached the maximum of {MAX_FURSUITS_PER_USER} fursuits. Delete an existing fursuit to add a new one.
+            </Text>
+            <TailTagButton
+              variant="outline"
+              onPress={() => router.push('/suits')}
+            >
+              Manage my suits
+            </TailTagButton>
+          </TailTagCard>
+        )}
 
         <TailTagCard>
           <View style={styles.fieldGroup}>
@@ -1073,6 +1102,14 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 15,
     color: 'rgba(203,213,225,0.9)',
+  },
+  limitBanner: {
+    gap: spacing.md,
+  },
+  limitBannerText: {
+    fontSize: 14,
+    color: '#fca5a5',
+    lineHeight: 20,
   },
   fieldGroup: {
     gap: spacing.sm,

--- a/app/(tabs)/suits/index.tsx
+++ b/app/(tabs)/suits/index.tsx
@@ -17,6 +17,7 @@ import {
   MY_SUITS_QUERY_KEY,
   MY_SUITS_STALE_TIME,
 } from "../../../src/features/suits";
+import { MAX_FURSUITS_PER_USER } from "../../../src/constants/fursuits";
 import type { FursuitSummary } from "../../../src/features/suits";
 import {
   PendingCatchesList,
@@ -193,6 +194,8 @@ export default function MySuitsScreen() {
   );
 
   const hasSuits = suits.length > 0;
+  const suitCount = suits.length;
+  const isAtFursuitLimit = suitCount >= MAX_FURSUITS_PER_USER;
   const combinedError = actionError ?? error?.message ?? null;
 
   return (
@@ -225,10 +228,14 @@ export default function MySuitsScreen() {
       <TailTagCard style={styles.cardSpacing}>
         <View style={styles.helperRow}>
           <Text style={styles.helperText}>
-            Add a new suit before you head to the floor.
+            {isAtFursuitLimit
+              ? `You have ${MAX_FURSUITS_PER_USER}/${MAX_FURSUITS_PER_USER} suits. Delete one to add another.`
+              : `Add a new suit before you head to the floor. (${suitCount}/${MAX_FURSUITS_PER_USER})`
+            }
           </Text>
           <TailTagButton
             onPress={() => router.push("/suits/add-fursuit")}
+            disabled={isAtFursuitLimit}
           >
             Add a fursuit
           </TailTagButton>

--- a/app/(tabs)/suits/index.tsx
+++ b/app/(tabs)/suits/index.tsx
@@ -15,6 +15,7 @@ import {
   FursuitCard,
   fetchMySuits,
   MY_SUITS_QUERY_KEY,
+  MY_SUITS_COUNT_QUERY_KEY,
   MY_SUITS_STALE_TIME,
 } from "../../../src/features/suits";
 import { MAX_FURSUITS_PER_USER } from "../../../src/constants/fursuits";
@@ -176,6 +177,11 @@ export default function MySuitsScreen() {
                   (current) =>
                     (current ?? []).filter((item) => item.id !== suit.id)
                 );
+
+                // Invalidate count cache so limit check updates immediately
+                void queryClient.invalidateQueries({
+                  queryKey: [MY_SUITS_COUNT_QUERY_KEY, userId],
+                });
               } catch (caught) {
                 const message =
                   caught instanceof Error

--- a/src/constants/fursuits.ts
+++ b/src/constants/fursuits.ts
@@ -1,0 +1,5 @@
+/**
+ * Maximum number of non-tutorial fursuits a user can create
+ * Tutorial fursuits do not count toward this limit
+ */
+export const MAX_FURSUITS_PER_USER = 3;

--- a/src/features/onboarding/api/onboarding.ts
+++ b/src/features/onboarding/api/onboarding.ts
@@ -13,6 +13,7 @@ import { emitGameplayEvent } from '../../events';
 
 import type { FursuitsInsert } from '../../../types/database';
 import { MAX_FURSUIT_COLORS } from '../../colors';
+import { MAX_FURSUITS_PER_USER } from '../../../constants/fursuits';
 
 const TUTORIAL_FURSUIT_NAME = 'TailTag Trainer';
 const TUTORIAL_FURSUIT_SPECIES = 'Fox';
@@ -174,6 +175,26 @@ export async function createQuickFursuit(options: {
 }): Promise<string> {
   const { userId, name, species, description, photo, colorIds } = options;
   const client = supabase as any;
+
+  // Check fursuit count limit
+  const { count, error: countError } = await client
+    .from('fursuits')
+    .select('id', { count: 'exact', head: true })
+    .eq('owner_id', userId)
+    .eq('is_tutorial', false);
+
+  if (countError) {
+    captureSupabaseError(countError, {
+      scope: 'onboarding.createQuickFursuit',
+      action: 'countExisting',
+      userId,
+    });
+    throw new Error(`We couldn't verify your fursuit count: ${countError.message}`);
+  }
+
+  if ((count ?? 0) >= MAX_FURSUITS_PER_USER) {
+    throw new Error(`You can only have ${MAX_FURSUITS_PER_USER} fursuits.`);
+  }
 
   let uploadedStoragePath: string | null = null;
   let avatarUrl: string | null = null;

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -6,9 +6,11 @@ import { mapFursuitColors, mapLatestFursuitBio } from './utils';
 import { captureSupabaseError } from '../../../lib/sentry';
 
 export const MY_SUITS_QUERY_KEY = 'my-suits';
+export const MY_SUITS_COUNT_QUERY_KEY = 'my-suits-count';
 export const MY_SUITS_STALE_TIME = 2 * 60_000;
 
 export const mySuitsQueryKey = (userId: string) => [MY_SUITS_QUERY_KEY, userId] as const;
+export const mySuitsCountQueryKey = (userId: string) => [MY_SUITS_COUNT_QUERY_KEY, userId] as const;
 
 export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
   const client = supabase as any;
@@ -119,6 +121,34 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
 export const createMySuitsQueryOptions = (userId: string) => ({
   queryKey: mySuitsQueryKey(userId),
   queryFn: () => fetchMySuits(userId),
+  staleTime: MY_SUITS_STALE_TIME,
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+});
+
+export async function fetchMySuitsCount(userId: string): Promise<number> {
+  const client = supabase as any;
+  const { count, error } = await client
+    .from('fursuits')
+    .select('id', { count: 'exact', head: true })
+    .eq('owner_id', userId)
+    .eq('is_tutorial', false);
+
+  if (error) {
+    captureSupabaseError(error, {
+      scope: 'suits.fetchMySuitsCount',
+      action: 'count',
+      userId,
+    });
+    throw new Error(`We couldn't count your suits: ${error.message}`);
+  }
+
+  return count ?? 0;
+}
+
+export const createMySuitsCountQueryOptions = (userId: string) => ({
+  queryKey: mySuitsCountQueryKey(userId),
+  queryFn: () => fetchMySuitsCount(userId),
   staleTime: MY_SUITS_STALE_TIME,
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,

--- a/src/features/suits/index.ts
+++ b/src/features/suits/index.ts
@@ -2,10 +2,14 @@ export { FursuitCard } from './components/FursuitCard';
 export { FursuitBioDetails } from './components/FursuitBioDetails';
 export {
   fetchMySuits,
+  fetchMySuitsCount,
   MY_SUITS_QUERY_KEY,
+  MY_SUITS_COUNT_QUERY_KEY,
   MY_SUITS_STALE_TIME,
   mySuitsQueryKey,
+  mySuitsCountQueryKey,
   createMySuitsQueryOptions,
+  createMySuitsCountQueryOptions,
 } from './api/mySuits';
 export type { FursuitSummary, FursuitBio } from './types';
 export {


### PR DESCRIPTION
Add database and client-side updates to enforce registering three suits to avoid users climbing the leaderboard by catching bogus fursuits

Resolves TAILTAG-13