### PR TITLE
Convention Geo-Based Verification

### DIFF
--- a/admin/app/(dashboard)/conventions/[id]/location/page.tsx
+++ b/admin/app/(dashboard)/conventions/[id]/location/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+
+import { Card } from '@/components/card';
+import { ConventionGeofenceForm } from '@/components/convention-geofence-form';
+import { fetchConvention } from '@/lib/data';
+
+export default async function ConventionLocationPage({ params }: { params: { id: string } }) {
+  const { convention } = await fetchConvention(params.id);
+
+  if (!convention) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-4">
+      <Link
+        href={`/conventions/${params.id}`}
+        className="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:opacity-80"
+      >
+        <ArrowLeft size={14} /> Back to convention
+      </Link>
+
+      <Card title="Geo-fence & verification" subtitle="Define the area that counts as on-site">
+        <ConventionGeofenceForm
+          conventionId={convention.id}
+          name={convention.name}
+          location={convention.location}
+          latitude={convention.latitude}
+          longitude={convention.longitude}
+          radiusMeters={convention.geofence_radius_meters}
+          geofenceEnabled={Boolean(convention.geofence_enabled)}
+          verificationRequired={Boolean(convention.location_verification_required)}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/admin/app/(dashboard)/conventions/[id]/location/page.tsx
+++ b/admin/app/(dashboard)/conventions/[id]/location/page.tsx
@@ -31,7 +31,6 @@ export default async function ConventionLocationPage({ params }: { params: { id:
           longitude={convention.longitude}
           radiusMeters={convention.geofence_radius_meters}
           geofenceEnabled={Boolean(convention.geofence_enabled)}
-          verificationRequired={Boolean(convention.location_verification_required)}
         />
       </Card>
     </div>

--- a/admin/app/(dashboard)/conventions/[id]/page.tsx
+++ b/admin/app/(dashboard)/conventions/[id]/page.tsx
@@ -1,5 +1,6 @@
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { Users, MapPin, CalendarRange, SlidersHorizontal } from 'lucide-react';
+import { Users, MapPin, CalendarRange, SlidersHorizontal, ArrowUpRight } from 'lucide-react';
 
 import { Card } from '@/components/card';
 import { Table } from '@/components/table';
@@ -45,6 +46,33 @@ export default async function ConventionDetail({ params }: { params: { id: strin
           featureTagScan={config.featureTagScan}
           featureStaffMode={config.featureStaffMode}
         />
+      </Card>
+
+      <Card
+        title="Geo-fence"
+        subtitle="Manage on-site verification boundaries"
+        actions={
+          <Link
+            href={`/conventions/${convention.id}/location`}
+            className="inline-flex items-center gap-1 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold text-slate-100 transition hover:border-primary"
+          >
+            Manage map <ArrowUpRight size={14} />
+          </Link>
+        }
+      >
+        <div className="grid gap-3 md:grid-cols-3">
+          <Info icon={<MapPin size={14} />} label="Status">
+            {convention.geofence_enabled ? 'Enabled' : 'Disabled'}
+          </Info>
+          <Info icon={<MapPin size={14} />} label="Radius">
+            {convention.geofence_radius_meters
+              ? `${convention.geofence_radius_meters}m`
+              : 'Not configured'}
+          </Info>
+          <Info icon={<MapPin size={14} />} label="Verification">
+            {convention.location_verification_required ? 'Required on opt-in' : 'Optional'}
+          </Info>
+        </div>
       </Card>
 
       <Card title="Staff assignments" subtitle="People assigned to this convention">

--- a/admin/app/(dashboard)/conventions/actions.ts
+++ b/admin/app/(dashboard)/conventions/actions.ts
@@ -71,6 +71,14 @@ export async function updateConventionGeofenceAction(input: {
   const { profile } = await assertAdminAction([...CONFIG_ROLES]);
   const supabase = createServiceRoleClient();
 
+  type GeofenceSettings = {
+    latitude: number | null;
+    longitude: number | null;
+    geofence_radius_meters: number | null;
+    geofence_enabled: boolean;
+    location_verification_required: boolean;
+  };
+
   const { data: current } = await supabase
     .from('conventions')
     .select(
@@ -85,7 +93,14 @@ export async function updateConventionGeofenceAction(input: {
     .eq('id', input.conventionId)
     .single();
 
-  const before = current ?? {};
+  const before: GeofenceSettings =
+    (current as GeofenceSettings | null) ?? {
+      latitude: null,
+      longitude: null,
+      geofence_radius_meters: null,
+      geofence_enabled: false,
+      location_verification_required: false,
+    };
 
   const sanitizedRadius = input.radiusMeters ? Math.round(input.radiusMeters) : null;
   if (sanitizedRadius && (sanitizedRadius < 100 || sanitizedRadius > 10000)) {

--- a/admin/app/(dashboard)/conventions/actions.ts
+++ b/admin/app/(dashboard)/conventions/actions.ts
@@ -60,3 +60,71 @@ export async function updateConventionConfigAction(input: {
   revalidatePath('/conventions');
   revalidatePath(`/conventions/${input.conventionId}`);
 }
+
+export async function updateConventionGeofenceAction(input: {
+  conventionId: string;
+  latitude: number | null;
+  longitude: number | null;
+  radiusMeters: number | null;
+  geofenceEnabled: boolean;
+  verificationRequired: boolean;
+}) {
+  const { profile } = await assertAdminAction([...CONFIG_ROLES]);
+  const supabase = createServiceRoleClient();
+
+  const { data: current } = await supabase
+    .from('conventions')
+    .select(
+      [
+        'latitude',
+        'longitude',
+        'geofence_radius_meters',
+        'geofence_enabled',
+        'location_verification_required',
+      ].join(', ')
+    )
+    .eq('id', input.conventionId)
+    .single();
+
+  const before = current ?? {};
+
+  const sanitizedRadius = input.radiusMeters ? Math.round(input.radiusMeters) : null;
+  if (sanitizedRadius && (sanitizedRadius < 100 || sanitizedRadius > 10000)) {
+    throw new Error('Radius must be between 100m and 10,000m.');
+  }
+
+  const nextLatitude = input.geofenceEnabled ? input.latitude : null;
+  const nextLongitude = input.geofenceEnabled ? input.longitude : null;
+  const nextRadius = input.geofenceEnabled ? sanitizedRadius ?? before.geofence_radius_meters ?? 500 : null;
+
+  if (input.geofenceEnabled) {
+    if (nextLatitude === null || nextLongitude === null) {
+      throw new Error('Latitude and longitude are required when enabling the geofence.');
+    }
+    if (!nextRadius) {
+      throw new Error('Radius is required when enabling the geofence.');
+    }
+  }
+
+  const payload = {
+    latitude: nextLatitude,
+    longitude: nextLongitude,
+    geofence_radius_meters: nextRadius,
+    geofence_enabled: input.geofenceEnabled,
+    location_verification_required: input.geofenceEnabled ? input.verificationRequired : false,
+  };
+
+  await supabase.from('conventions').update(payload).eq('id', input.conventionId);
+
+  await logAudit({
+    actorId: profile.id,
+    action: 'update_convention_geofence',
+    entityType: 'convention',
+    entityId: input.conventionId,
+    diff: { before, after: payload },
+  });
+
+  revalidatePath('/conventions');
+  revalidatePath(`/conventions/${input.conventionId}`);
+  revalidatePath(`/conventions/${input.conventionId}/location`);
+}

--- a/admin/app/(dashboard)/conventions/actions.ts
+++ b/admin/app/(dashboard)/conventions/actions.ts
@@ -67,7 +67,6 @@ export async function updateConventionGeofenceAction(input: {
   longitude: number | null;
   radiusMeters: number | null;
   geofenceEnabled: boolean;
-  verificationRequired: boolean;
 }) {
   const { profile } = await assertAdminAction([...CONFIG_ROLES]);
   const supabase = createServiceRoleClient();
@@ -111,7 +110,7 @@ export async function updateConventionGeofenceAction(input: {
     longitude: nextLongitude,
     geofence_radius_meters: nextRadius,
     geofence_enabled: input.geofenceEnabled,
-    location_verification_required: input.geofenceEnabled ? input.verificationRequired : false,
+    location_verification_required: input.geofenceEnabled,
   };
 
   await supabase.from('conventions').update(payload).eq('id', input.conventionId);

--- a/admin/app/api/geocode/route.ts
+++ b/admin/app/api/geocode/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q');
+  if (!query) {
+    return NextResponse.json({ error: 'Missing query' }, { status: 400 });
+  }
+
+  const token = process.env.MAPBOX_ACCESS_TOKEN;
+  if (!token) {
+    return NextResponse.json({ error: 'Mapbox token not configured' }, { status: 500 });
+  }
+
+  const endpoint = new URL(
+    `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(query)}.json`
+  );
+  endpoint.searchParams.set('access_token', token);
+  endpoint.searchParams.set('limit', '5');
+
+  const response = await fetch(endpoint.toString(), {
+    headers: {
+      'User-Agent': 'tailtag-admin',
+    },
+    next: { revalidate: 0 },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: `Geocoding failed (${response.status})` },
+      { status: response.status }
+    );
+  }
+
+  const payload = await response.json();
+  const results =
+    payload?.features?.map((feature: any) => ({
+      id: feature.id,
+      name: feature.text ?? feature.place_name,
+      place: feature.place_name ?? feature.text,
+      latitude: feature.center?.[1] ?? null,
+      longitude: feature.center?.[0] ?? null,
+    })) ?? [];
+
+  return NextResponse.json({ results });
+}

--- a/admin/components/convention-geofence-form.tsx
+++ b/admin/components/convention-geofence-form.tsx
@@ -1,0 +1,416 @@
+'use client';
+
+import { useEffect, useMemo, useState, useTransition } from 'react';
+
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+import { updateConventionGeofenceAction } from '@/app/(dashboard)/conventions/actions';
+
+type Props = {
+  conventionId: string;
+  name: string;
+  location: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  radiusMeters: number | null;
+  geofenceEnabled: boolean;
+  verificationRequired: boolean;
+};
+
+type GeocodeResult = {
+  id: string;
+  name: string;
+  place: string;
+  latitude: number | null;
+  longitude: number | null;
+};
+
+type MapModule = {
+  Map: any;
+  Marker: any;
+  Source: any;
+  Layer: any;
+  maplibregl: any;
+};
+
+const DEFAULT_VIEW = {
+  latitude: 37.7749,
+  longitude: -122.4194,
+  zoom: 3,
+};
+
+export function ConventionGeofenceForm({
+  conventionId,
+  name,
+  location,
+  latitude: initialLatitude,
+  longitude: initialLongitude,
+  radiusMeters,
+  geofenceEnabled,
+  verificationRequired,
+}: Props) {
+  const initialView = useMemo(
+    () => ({
+      latitude: initialLatitude ?? DEFAULT_VIEW.latitude,
+      longitude: initialLongitude ?? DEFAULT_VIEW.longitude,
+      zoom: initialLatitude && initialLongitude ? 14 : DEFAULT_VIEW.zoom,
+    }),
+    [initialLatitude, initialLongitude]
+  );
+
+  const [latitude, setLatitude] = useState<number | null>(initialLatitude);
+  const [longitude, setLongitude] = useState<number | null>(initialLongitude);
+  const [radius, setRadius] = useState<number>(radiusMeters ?? 500);
+  const [enabled, setEnabled] = useState<boolean>(geofenceEnabled);
+  const [requireVerification, setRequireVerification] = useState<boolean>(verificationRequired);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<GeocodeResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [viewState, setViewState] = useState(initialView);
+
+  const mapModule = useMapLibre();
+  const Map = mapModule?.Map;
+  const Marker = mapModule?.Marker;
+  const Source = mapModule?.Source;
+  const Layer = mapModule?.Layer;
+
+  useEffect(() => {
+    if (latitude !== null && longitude !== null) {
+      setViewState((prev) => ({
+        ...prev,
+        latitude,
+        longitude,
+        zoom: 14,
+      }));
+    }
+  }, [latitude, longitude]);
+
+  useEffect(() => {
+    if (!enabled && requireVerification) {
+      setRequireVerification(false);
+    }
+  }, [enabled, requireVerification]);
+
+  const geofenceFeature = useMemo(() => {
+    if (!enabled || latitude === null || longitude === null) {
+      return null;
+    }
+    return buildCircleFeature(latitude, longitude, radius);
+  }, [enabled, latitude, longitude, radius]);
+
+  const handleSearch = async () => {
+    const query = searchQuery.trim();
+    if (!query) {
+      setSearchResults([]);
+      return;
+    }
+
+    setIsSearching(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/geocode?q=${encodeURIComponent(query)}`);
+      if (!response.ok) {
+        throw new Error('Geocoding failed. Check MAPBOX_ACCESS_TOKEN.');
+      }
+      const payload = await response.json();
+      setSearchResults(payload.results ?? []);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Unable to search for that place.');
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const selectResult = (result: GeocodeResult) => {
+    if (result.latitude === null || result.longitude === null) {
+      return;
+    }
+    setLatitude(result.latitude);
+    setLongitude(result.longitude);
+    setViewState({
+      latitude: result.latitude,
+      longitude: result.longitude,
+      zoom: 14,
+    });
+    setSearchResults([]);
+  };
+
+  const handleMapClick = (coords: { lat: number; lng: number }) => {
+    if (!enabled) return;
+    setLatitude(coords.lat);
+    setLongitude(coords.lng);
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setMessage(null);
+    setError(null);
+    startTransition(async () => {
+      try {
+        await updateConventionGeofenceAction({
+          conventionId,
+          latitude,
+          longitude,
+          radiusMeters: radius,
+          geofenceEnabled: enabled,
+          verificationRequired: requireVerification,
+        });
+        setMessage('Geofence saved.');
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Unable to save geofence.');
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="flex items-center gap-2 text-sm text-slate-200">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) => setEnabled(event.target.checked)}
+            className="h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary"
+          />
+          Enable geofence for this convention
+        </label>
+        <label className="flex items-center gap-2 text-sm text-slate-200">
+          <input
+            type="checkbox"
+            checked={requireVerification}
+            onChange={(event) => setRequireVerification(event.target.checked)}
+            disabled={!enabled}
+            className="h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary disabled:opacity-40"
+          />
+          Require location verification on opt-in
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm text-slate-200">Search for a venue</label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                void handleSearch();
+              }
+            }}
+            placeholder="Orange County Convention Center"
+            disabled={!enabled}
+            className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-slate-100 outline-none focus:border-primary disabled:opacity-50"
+          />
+          <button
+            type="button"
+            disabled={!enabled || isSearching}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-primary disabled:opacity-50"
+            onClick={() => void handleSearch()}
+          >
+            {isSearching ? 'Searching…' : 'Search'}
+          </button>
+        </div>
+        {searchResults.length > 0 ? (
+          <div className="rounded-lg border border-border bg-background/70">
+            {searchResults.map((result) => (
+              <button
+                type="button"
+                key={result.id}
+                onClick={() => selectResult(result)}
+                className="w-full border-b border-border/60 px-3 py-2 text-left text-sm text-slate-100 last:border-none hover:bg-white/5"
+              >
+                <span className="font-semibold">{result.name}</span>
+                <br />
+                <span className="text-xs text-muted">{result.place}</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between text-sm">
+          <div>
+            <p className="font-semibold text-slate-100">{name}</p>
+            <p className="text-xs text-muted">{location ?? 'Location TBD'}</p>
+          </div>
+          <div className="text-right text-xs text-muted">
+            {latitude !== null && longitude !== null ? (
+              <>
+                {latitude.toFixed(5)}, {longitude.toFixed(5)}
+              </>
+            ) : (
+              'Tap the map to drop a pin'
+            )}
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-background/70 p-2">
+          {Map && mapModule?.maplibregl ? (
+            <Map
+              reuseMaps
+              mapLib={mapModule.maplibregl}
+              initialViewState={initialView}
+              viewState={viewState}
+              onMove={(event: any) => setViewState(event.viewState)}
+              onClick={(event: any) => handleMapClick(event.lngLat)}
+              style={{ width: '100%', height: 360 }}
+              mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+            >
+              {latitude !== null && longitude !== null && enabled ? (
+                <>
+                  {Source && Layer && geofenceFeature ? (
+                    <Source id="geofence" type="geojson" data={geofenceFeature}>
+                      <Layer
+                        id="geofence-fill"
+                        type="fill"
+                        paint={{ 'fill-color': '#2563eb', 'fill-opacity': 0.15 }}
+                      />
+                      <Layer
+                        id="geofence-line"
+                        type="line"
+                        paint={{ 'line-color': '#60a5fa', 'line-width': 2, 'line-opacity': 0.8 }}
+                      />
+                    </Source>
+                  ) : null}
+                  {Marker ? (
+                    <Marker latitude={latitude} longitude={longitude} anchor="bottom">
+                      <div className="rounded-full bg-primary px-2 py-1 text-xs font-semibold text-slate-900 shadow">
+                        Pin
+                      </div>
+                    </Marker>
+                  ) : null}
+                </>
+              ) : null}
+            </Map>
+          ) : (
+            <div className="flex h-72 items-center justify-center text-sm text-muted">
+              Loading map…
+            </div>
+          )}
+        </div>
+        <p className="text-xs text-muted">
+          Use the search bar or click anywhere on the map to position the pin. The radius preview updates automatically.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm text-slate-200">Geo-fence radius: {radius} meters</label>
+        <input
+          type="range"
+          min={100}
+          max={5000}
+          step={50}
+          value={radius}
+          onChange={(event) => setRadius(Number(event.target.value))}
+          disabled={!enabled}
+          className="w-full accent-primary disabled:opacity-40"
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label className="text-sm text-slate-200">Latitude</label>
+          <input
+            type="number"
+            step="0.00001"
+            value={latitude ?? ''}
+            onChange={(event) => setLatitude(event.target.value === '' ? null : Number(event.target.value))}
+            disabled={!enabled}
+            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-slate-100 outline-none focus:border-primary disabled:opacity-40"
+          />
+        </div>
+        <div>
+          <label className="text-sm text-slate-200">Longitude</label>
+          <input
+            type="number"
+            step="0.00001"
+            value={longitude ?? ''}
+            onChange={(event) => setLongitude(event.target.value === '' ? null : Number(event.target.value))}
+            disabled={!enabled}
+            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-slate-100 outline-none focus:border-primary disabled:opacity-40"
+          />
+        </div>
+      </div>
+      <p className="text-xs text-muted">
+        Coordinates update automatically from the map pin. Edit them manually for minor adjustments if needed.
+      </p>
+
+      <div className="flex flex-col gap-3 border-t border-border/70 pt-4 md:flex-row md:items-center md:justify-between">
+        <div className="text-xs text-muted">
+          {error ? (
+            <span className="text-red-400">{error}</span>
+          ) : message ? (
+            <span className="text-primary">{message}</span>
+          ) : (
+            'Changes impact player opt-ins immediately.'
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={isPending || (enabled && (latitude === null || longitude === null))}
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-accent disabled:opacity-50"
+        >
+          {isPending ? 'Saving…' : 'Save geofence'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function useMapLibre(): MapModule | null {
+  const [module, setModule] = useState<MapModule | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all([import('react-map-gl/maplibre'), import('maplibre-gl')]).then(([mapGl, maplibre]) => {
+      if (mounted) {
+        setModule({
+          Map: mapGl.default,
+          Marker: mapGl.Marker,
+          Source: mapGl.Source,
+          Layer: mapGl.Layer,
+          maplibregl: maplibre.default,
+        });
+      }
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return module;
+}
+
+function buildCircleFeature(latitude: number, longitude: number, radiusMeters: number) {
+  const segments = 96;
+  const coordinates: [number, number][] = [];
+  const earthRadius = 6378137;
+  const latRad = (latitude * Math.PI) / 180;
+
+  for (let i = 0; i <= segments; i++) {
+    const angle = (i / segments) * 2 * Math.PI;
+    const dx = radiusMeters * Math.cos(angle);
+    const dy = radiusMeters * Math.sin(angle);
+
+    const pointLat = latitude + (dy / earthRadius) * (180 / Math.PI);
+    const pointLng =
+      longitude + (dx / (earthRadius * Math.cos(latRad))) * (180 / Math.PI);
+    coordinates.push([pointLng, pointLat]);
+  }
+
+  return {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: { type: 'Polygon', coordinates: [coordinates] },
+        properties: {},
+      },
+    ],
+  };
+}

--- a/admin/components/convention-geofence-form.tsx
+++ b/admin/components/convention-geofence-form.tsx
@@ -14,7 +14,6 @@ type Props = {
   longitude: number | null;
   radiusMeters: number | null;
   geofenceEnabled: boolean;
-  verificationRequired: boolean;
 };
 
 type GeocodeResult = {
@@ -47,7 +46,6 @@ export function ConventionGeofenceForm({
   longitude: initialLongitude,
   radiusMeters,
   geofenceEnabled,
-  verificationRequired,
 }: Props) {
   const initialView = useMemo(
     () => ({
@@ -62,7 +60,6 @@ export function ConventionGeofenceForm({
   const [longitude, setLongitude] = useState<number | null>(initialLongitude);
   const [radius, setRadius] = useState<number>(radiusMeters ?? 500);
   const [enabled, setEnabled] = useState<boolean>(geofenceEnabled);
-  const [requireVerification, setRequireVerification] = useState<boolean>(verificationRequired);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<GeocodeResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -86,12 +83,6 @@ export function ConventionGeofenceForm({
       essential: true,
     });
   }, [latitude, longitude]);
-
-  useEffect(() => {
-    if (!enabled && requireVerification) {
-      setRequireVerification(false);
-    }
-  }, [enabled, requireVerification]);
 
   const geofenceFeature = useMemo(() => {
     if (!enabled || latitude === null || longitude === null) {
@@ -150,7 +141,6 @@ export function ConventionGeofenceForm({
           longitude,
           radiusMeters: radius,
           geofenceEnabled: enabled,
-          verificationRequired: requireVerification,
         });
         setMessage('Geofence saved.');
       } catch (caught) {
@@ -161,7 +151,7 @@ export function ConventionGeofenceForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-2">
         <label className="flex items-center gap-2 text-sm text-slate-200">
           <input
             type="checkbox"
@@ -171,16 +161,9 @@ export function ConventionGeofenceForm({
           />
           Enable geofence for this convention
         </label>
-        <label className="flex items-center gap-2 text-sm text-slate-200">
-          <input
-            type="checkbox"
-            checked={requireVerification}
-            onChange={(event) => setRequireVerification(event.target.checked)}
-            disabled={!enabled}
-            className="h-4 w-4 rounded border-border bg-background text-primary focus:ring-primary disabled:opacity-40"
-          />
-          Require location verification on opt-in
-        </label>
+        <p className="text-xs text-muted">
+          When enabled, players must pass on-site location verification before they can join this convention.
+        </p>
       </div>
 
       <div className="space-y-2">

--- a/admin/components/convention-geofence-form.tsx
+++ b/admin/components/convention-geofence-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState, useTransition } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
 
 import 'maplibre-gl/dist/maplibre-gl.css';
 
@@ -69,7 +69,7 @@ export function ConventionGeofenceForm({
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
-  const [viewState, setViewState] = useState(initialView);
+  const mapRef = useRef<any>(null);
 
   const mapModule = useMapLibre();
   const Map = mapModule?.Map;
@@ -78,14 +78,13 @@ export function ConventionGeofenceForm({
   const Layer = mapModule?.Layer;
 
   useEffect(() => {
-    if (latitude !== null && longitude !== null) {
-      setViewState((prev) => ({
-        ...prev,
-        latitude,
-        longitude,
-        zoom: 14,
-      }));
-    }
+    if (!mapRef.current) return;
+    if (latitude === null || longitude === null) return;
+    mapRef.current.flyTo?.({
+      center: [longitude, latitude],
+      zoom: 14,
+      essential: true,
+    });
   }, [latitude, longitude]);
 
   useEffect(() => {
@@ -130,11 +129,6 @@ export function ConventionGeofenceForm({
     }
     setLatitude(result.latitude);
     setLongitude(result.longitude);
-    setViewState({
-      latitude: result.latitude,
-      longitude: result.longitude,
-      zoom: 14,
-    });
     setSearchResults([]);
   };
 
@@ -252,11 +246,10 @@ export function ConventionGeofenceForm({
         <div className="rounded-xl border border-border bg-background/70 p-2">
           {Map && mapModule?.maplibregl ? (
             <Map
+              ref={mapRef}
               reuseMaps
               mapLib={mapModule.maplibregl}
               initialViewState={initialView}
-              viewState={viewState}
-              onMove={(event: any) => setViewState(event.viewState)}
               onClick={(event: any) => handleMapClick(event.lngLat)}
               style={{ width: '100%', height: 360 }}
               mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"

--- a/admin/lib/data.ts
+++ b/admin/lib/data.ts
@@ -86,7 +86,23 @@ export async function fetchConventions() {
   const supabase = createServiceRoleClient();
   const { data, error } = await supabase
     .from('conventions')
-    .select('id, name, slug, start_date, end_date, location, timezone, config')
+    .select(
+      [
+        'id',
+        'name',
+        'slug',
+        'start_date',
+        'end_date',
+        'location',
+        'timezone',
+        'config',
+        'latitude',
+        'longitude',
+        'geofence_radius_meters',
+        'geofence_enabled',
+        'location_verification_required',
+      ].join(', ')
+    )
     .order('start_date', { ascending: false });
   if (error) {
     throw error;
@@ -110,7 +126,23 @@ export async function fetchConvention(conventionId: string) {
   // TODO: Create event_staff table in database
   const convention = await supabase
     .from('conventions')
-    .select('id, name, slug, start_date, end_date, location, timezone, config')
+    .select(
+      [
+        'id',
+        'name',
+        'slug',
+        'start_date',
+        'end_date',
+        'location',
+        'timezone',
+        'config',
+        'latitude',
+        'longitude',
+        'geofence_radius_meters',
+        'geofence_enabled',
+        'location_verification_required',
+      ].join(', ')
+    )
     .eq('id', conventionId)
     .single();
 

--- a/admin/lib/data.ts
+++ b/admin/lib/data.ts
@@ -16,6 +16,8 @@ type PlayerSearchResult = {
   created_at: string;
 };
 
+type ConventionRow = Database['public']['Tables']['conventions']['Row'];
+
 export async function fetchDashboardSummary() {
   const supabase = createServiceRoleClient();
   const [players, suspended, conventions, pendingReports] = await Promise.all([
@@ -82,7 +84,7 @@ export async function fetchPlayerProfile(userId: string) {
   return { profile, moderationSummary, actions };
 }
 
-export async function fetchConventions() {
+export async function fetchConventions(): Promise<ConventionRow[]> {
   const supabase = createServiceRoleClient();
   const { data, error } = await supabase
     .from('conventions')
@@ -107,7 +109,7 @@ export async function fetchConventions() {
   if (error) {
     throw error;
   }
-  return data;
+  return ((data ?? []) as unknown) as ConventionRow[];
 }
 
 type EventStaffAssignment = {
@@ -120,11 +122,14 @@ type EventStaffAssignment = {
   profiles?: { username?: string | null; avatar_url?: string | null; role?: string | null } | { username?: string | null; avatar_url?: string | null; role?: string | null }[];
 };
 
-export async function fetchConvention(conventionId: string) {
+export async function fetchConvention(conventionId: string): Promise<{
+  convention: ConventionRow | null;
+  staff: EventStaffAssignment[];
+}> {
   const supabase = createServiceRoleClient();
 
   // TODO: Create event_staff table in database
-  const convention = await supabase
+  const { data: conventionData, error: conventionError } = await supabase
     .from('conventions')
     .select(
       [
@@ -146,6 +151,10 @@ export async function fetchConvention(conventionId: string) {
     .eq('id', conventionId)
     .single();
 
+  if (conventionError) {
+    throw conventionError;
+  }
+
   const staffQuery = await supabase
     .from('event_staff')
     .select(
@@ -156,7 +165,9 @@ export async function fetchConvention(conventionId: string) {
 
   const staff = (staffQuery.data ?? []) as EventStaffAssignment[];
 
-  return { convention: convention.data, staff };
+  const convention = (conventionData ?? null) as unknown as ConventionRow | null;
+
+  return { convention, staff };
 }
 
 export async function fetchAuditLogs(limit = 50) {

--- a/admin/lib/data.ts
+++ b/admin/lib/data.ts
@@ -151,7 +151,7 @@ export async function fetchConvention(conventionId: string): Promise<{
     .eq('id', conventionId)
     .single();
 
-  if (conventionError) {
+  if (conventionError && conventionError.code !== 'PGRST116') {
     throw conventionError;
   }
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -12,9 +12,11 @@
         "@supabase/supabase-js": "^2.58.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.468.0",
+        "maplibre-gl": "^4.4.0",
         "next": "14.2.16",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-map-gl": "^7.1.5"
       },
       "devDependencies": {
         "@types/react": "18.3.11",
@@ -260,6 +262,89 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -627,12 +712,53 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
+      }
+    },
+    "node_modules/@types/mapbox-gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz",
+      "integrity": "sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.10.2",
@@ -642,6 +768,12 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
     },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
@@ -675,6 +807,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -1344,6 +1485,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -1502,6 +1652,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -1693,6 +1852,25 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
       }
     },
     "node_modules/call-bind": {
@@ -2104,6 +2282,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2502,6 +2686,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2774,6 +2959,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3020,6 +3217,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3059,6 +3262,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3089,6 +3304,21 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.3.10",
@@ -3150,6 +3380,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/globals": {
@@ -3314,6 +3582,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3369,6 +3657,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -3543,6 +3840,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3673,6 +3979,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
@@ -3834,6 +4152,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -3922,6 +4249,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -3951,6 +4284,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3959,6 +4298,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -4066,6 +4414,48 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4117,7 +4507,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4138,6 +4527,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4576,6 +4971,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4789,6 +5197,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4810,6 +5224,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4841,6 +5261,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -4874,6 +5300,55 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-map-gl": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.1.9.tgz",
+      "integrity": "sha512-KsCc8Gyn05wVGlHZoopaiiCr0RCAQ6LDISo5sEy1/pV/d7RlozkF946tiX7IgyijJQMRujHol5QdwUPESjh73w==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1",
+        "@types/mapbox-gl": ">=1.0.0"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0 <5.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-map-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/react-map-gl/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
       "license": "MIT"
     },
     "node_modules/read-cache": {
@@ -4984,6 +5459,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5057,6 +5541,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -5184,6 +5674,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5296,11 +5801,83 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5613,6 +6190,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5755,6 +6341,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5927,6 +6519,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -5951,6 +6558,21 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -6034,6 +6656,17 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/admin/package.json
+++ b/admin/package.json
@@ -15,7 +15,9 @@
     "lucide-react": "^0.468.0",
     "next": "14.2.16",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-map-gl": "^7.1.5",
+    "maplibre-gl": "^4.4.0"
   },
   "devDependencies": {
     "@types/react": "18.3.11",

--- a/admin/types/database.ts
+++ b/admin/types/database.ts
@@ -282,8 +282,13 @@ export type Database = {
           config: Json
           created_at: string
           end_date: string | null
+          geofence_enabled: boolean
+          geofence_radius_meters: number | null
           id: string
+          latitude: number | null
           location: string | null
+          location_verification_required: boolean
+          longitude: number | null
           name: string
           slug: string
           start_date: string | null
@@ -294,8 +299,13 @@ export type Database = {
           config?: Json
           created_at?: string
           end_date?: string | null
+          geofence_enabled?: boolean
+          geofence_radius_meters?: number | null
           id?: string
+          latitude?: number | null
           location?: string | null
+          location_verification_required?: boolean
+          longitude?: number | null
           name: string
           slug: string
           start_date?: string | null
@@ -306,8 +316,13 @@ export type Database = {
           config?: Json
           created_at?: string
           end_date?: string | null
+          geofence_enabled?: boolean
+          geofence_radius_meters?: number | null
           id?: string
+          latitude?: number | null
           location?: string | null
+          location_verification_required?: boolean
+          longitude?: number | null
           name?: string
           slug?: string
           start_date?: string | null
@@ -928,17 +943,35 @@ export type Database = {
         Row: {
           convention_id: string
           created_at: string
+          override_actor_id: string | null
+          override_at: string | null
+          override_reason: string | null
           profile_id: string
+          verified_at: string | null
+          verified_location: Json | null
+          verification_method: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Insert: {
           convention_id: string
           created_at?: string
+          override_actor_id?: string | null
+          override_at?: string | null
+          override_reason?: string | null
           profile_id: string
+          verified_at?: string | null
+          verified_location?: Json | null
+          verification_method?: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Update: {
           convention_id?: string
           created_at?: string
+          override_actor_id?: string | null
+          override_at?: string | null
+          override_reason?: string | null
           profile_id?: string
+          verified_at?: string | null
+          verified_location?: Json | null
+          verification_method?: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Relationships: [
           {
@@ -966,6 +999,9 @@ export type Database = {
           id: string
           is_new: boolean
           is_suspended: boolean
+          location_permission_granted_at: string | null
+          location_permission_requested_at: string | null
+          location_permission_status: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed: boolean
           role: Database["public"]["Enums"]["user_role"]
           suspended_until: string | null
@@ -981,6 +1017,9 @@ export type Database = {
           id: string
           is_new?: boolean
           is_suspended?: boolean
+          location_permission_granted_at?: string | null
+          location_permission_requested_at?: string | null
+          location_permission_status?: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed?: boolean
           role?: Database["public"]["Enums"]["user_role"]
           suspended_until?: string | null
@@ -996,6 +1035,9 @@ export type Database = {
           id?: string
           is_new?: boolean
           is_suspended?: boolean
+          location_permission_granted_at?: string | null
+          location_permission_requested_at?: string | null
+          location_permission_status?: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed?: boolean
           role?: Database["public"]["Enums"]["user_role"]
           suspended_until?: string | null
@@ -1057,6 +1099,54 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "nfc_tags"
             referencedColumns: ["uid"]
+          },
+        ]
+      }
+      verification_attempts: {
+        Row: {
+          convention_id: string | null
+          created_at: string | null
+          distance_meters: number | null
+          error_code: string | null
+          gps_accuracy: number | null
+          id: string
+          profile_id: string | null
+          verified: boolean
+        }
+        Insert: {
+          convention_id?: string | null
+          created_at?: string | null
+          distance_meters?: number | null
+          error_code?: string | null
+          gps_accuracy?: number | null
+          id?: string
+          profile_id?: string | null
+          verified: boolean
+        }
+        Update: {
+          convention_id?: string | null
+          created_at?: string | null
+          distance_meters?: number | null
+          error_code?: string | null
+          gps_accuracy?: number | null
+          id?: string
+          profile_id?: string | null
+          verified?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "verification_attempts_convention_id_fkey"
+            columns: ["convention_id"]
+            isOneToOne: false
+            referencedRelation: "conventions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "verification_attempts_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1571,6 +1661,16 @@ export type Database = {
         Returns: Database["public"]["Enums"]["user_role"]
       }
       grant_achievements_batch: { Args: { awards: Json }; Returns: Json }
+      opt_in_to_convention: {
+        Args: {
+          p_convention_id: string
+          p_override_reason?: string | null
+          p_profile_id: string
+          p_verification_method?: string
+          p_verified_location?: Json | null
+        }
+        Returns: void
+      }
       is_admin: { Args: { user_id: string }; Returns: boolean }
       is_event_staff: {
         Args: { convention_id: string; user_id: string }
@@ -1618,6 +1718,16 @@ export type Database = {
       refresh_fursuit_popularity: {
         Args: { convention_uuid?: string }
         Returns: undefined
+      }
+      verify_convention_location: {
+        Args: {
+          p_accuracy: number
+          p_convention_id: string
+          p_profile_id: string
+          p_user_lat: number
+          p_user_lng: number
+        }
+        Returns: Json
       }
       search_players: {
         Args: {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -27,7 +27,7 @@ import {
   PROFILE_CONVENTIONS_QUERY_KEY,
 } from '../../src/features/conventions';
 import { useAuth } from '../../src/features/auth';
-import type { ConventionSummary } from '../../src/features/conventions';
+import type { ConventionSummary, VerifiedLocation } from '../../src/features/conventions';
 import { ConventionToggle } from '../../src/components/conventions/ConventionToggle';
 import { supabase } from '../../src/lib/supabase';
 import { captureHandledException } from '../../src/lib/sentry';
@@ -487,7 +487,7 @@ export default function SettingsScreen() {
   ]);
 
   const handleToggleProfileConvention = useCallback(
-    async (conventionId: string, isSelected: boolean) => {
+    async (conventionId: string, nextSelected: boolean, verifiedLocation?: VerifiedLocation | null) => {
       if (!userId) {
         return;
       }
@@ -506,13 +506,18 @@ export default function SettingsScreen() {
       });
 
       try {
-        if (isSelected) {
+        if (!nextSelected) {
           await optOutOfConvention(userId, conventionId);
           queryClient.setQueryData<string[]>(profileConventionQueryKey, (current) =>
             (current ?? []).filter((value) => value !== conventionId)
           );
         } else {
-          await optInToConvention({ profileId: userId, conventionId });
+          await optInToConvention({
+            profileId: userId,
+            conventionId,
+            verifiedLocation: verifiedLocation ?? undefined,
+            verificationMethod: verifiedLocation ? 'gps' : 'none',
+          });
           queryClient.setQueryData<string[]>(profileConventionQueryKey, (current) => {
             const next = new Set(current ?? []);
             next.add(conventionId);
@@ -815,7 +820,11 @@ export default function SettingsScreen() {
                       convention={convention}
                       selected={isSelected}
                       pending={isPending}
-                      onToggle={() => handleToggleProfileConvention(convention.id, isSelected)}
+                      profileId={userId ?? undefined}
+                      enableVerification
+                      onToggle={(conventionId, nextSelected, verifiedLocation) =>
+                        handleToggleProfileConvention(conventionId, nextSelected, verifiedLocation)
+                      }
                     />
                   );
                 })}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -821,7 +821,6 @@ export default function SettingsScreen() {
                       selected={isSelected}
                       pending={isPending}
                       profileId={userId ?? undefined}
-                      enableVerification
                       onToggle={(conventionId, nextSelected, verifiedLocation) =>
                         handleToggleProfileConvention(conventionId, nextSelected, verifiedLocation)
                       }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -506,22 +506,22 @@ export default function SettingsScreen() {
       });
 
       try {
-       if (isSelected) {
-         await optOutOfConvention(userId, conventionId);
-         queryClient.setQueryData<string[]>(profileConventionQueryKey, (current) =>
-           (current ?? []).filter((value) => value !== conventionId)
-         );
-       } else {
-         await optInToConvention(userId, conventionId);
-         queryClient.setQueryData<string[]>(profileConventionQueryKey, (current) => {
-           const next = new Set(current ?? []);
-           next.add(conventionId);
-           return Array.from(next);
-         });
-       }
+        if (isSelected) {
+          await optOutOfConvention(userId, conventionId);
+          queryClient.setQueryData<string[]>(profileConventionQueryKey, (current) =>
+            (current ?? []).filter((value) => value !== conventionId)
+          );
+        } else {
+          await optInToConvention({ profileId: userId, conventionId });
+          queryClient.setQueryData<string[]>(profileConventionQueryKey, (current) => {
+            const next = new Set(current ?? []);
+            next.add(conventionId);
+            return Array.from(next);
+          });
+        }
         void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
         void queryClient.invalidateQueries({ queryKey: [CONVENTION_LEADERBOARD_QUERY_KEY, conventionId] });
-     } catch (caught) {
+      } catch (caught) {
         const fallbackMessage =
           caught instanceof Error
             ? caught.message

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -250,7 +250,7 @@ export default function AddFursuitScreen() {
   const conventionsLoadError = conventionsError?.message ?? profileConventionsError?.message ?? null;
 
   const handleConventionToggle = useCallback(
-    (conventionId: string) => {
+    (conventionId: string, nextSelected: boolean) => {
       if (!profileConventionIdSet.has(conventionId)) {
         return;
       }
@@ -258,10 +258,10 @@ export default function AddFursuitScreen() {
       setSelectedConventionIds((current) => {
         const next = new Set(current);
 
-        if (next.has(conventionId)) {
-          next.delete(conventionId);
-        } else {
+        if (nextSelected) {
           next.add(conventionId);
+        } else {
+          next.delete(conventionId);
         }
 
         return next;
@@ -1061,7 +1061,9 @@ export default function AddFursuitScreen() {
                             : 'Tap to assign'
                           : 'Opt in via Settings'
                       }
-                      onToggle={() => handleConventionToggle(convention.id)}
+                      onToggle={(conventionId, nextSelected) =>
+                        handleConventionToggle(conventionId, nextSelected)
+                      }
                     />
                   );
                 })}

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -608,7 +608,7 @@ export default function EditFursuitScreen() {
   const disableForm = isLoading || !detail || !isOwner || isSubmitting;
 
   const handleConventionToggle = useCallback(
-    (conventionId: string) => {
+    (conventionId: string, nextSelected: boolean) => {
       if (disableForm || !profileConventionIdSet.has(conventionId)) {
         return;
       }
@@ -616,10 +616,10 @@ export default function EditFursuitScreen() {
       setSelectedConventionIds((current) => {
         const next = new Set(current);
 
-        if (next.has(conventionId)) {
-          next.delete(conventionId);
-        } else {
+        if (nextSelected) {
           next.add(conventionId);
+        } else {
+          next.delete(conventionId);
         }
 
         return next;
@@ -982,7 +982,9 @@ export default function EditFursuitScreen() {
                                 : 'Tap to assign'
                               : 'Opt in via Settings'
                           }
-                          onToggle={() => handleConventionToggle(convention.id)}
+                          onToggle={(conventionId, nextSelected) =>
+                            handleConventionToggle(conventionId, nextSelected)
+                          }
                         />
                       );
                     })}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-image-picker": "~17.0.9",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.10",
+        "expo-location": "~17.0.1",
         "expo-router": "~6.0.17",
         "expo-status-bar": "~3.0.9",
         "p-retry": "^6.2.1",
@@ -8687,6 +8688,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-location": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-17.0.1.tgz",
+      "integrity": "sha512-m+OzotzlAXO3ZZ1uqW5GC25nXW868zN+ROyBA1V4VF6jGay1ZEs4URPglCVUDzZby2F5wt24cMzqDKw2IX6nRw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-manifests": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.10.tgz",
@@ -8804,6 +8814,7 @@
       "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.17.tgz",
       "integrity": "sha512-2n0lTidH2H+dOjk/Lu+krKIgK7b1qQ3O/9RWmf9P5IEuFiu7BSUgSDc+g69bUEElTnca8FR+zPTyk15kMXHrXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/metro-runtime": "^6.1.2",
         "@expo/schema-utils": "^0.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,18 @@
         "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.90.2",
         "base64-arraybuffer": "^1.0.2",
-        "expo": "~54.0.27",
+        "expo": "~54.0.28",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.11",
         "expo-crypto": "~15.0.8",
         "expo-dev-client": "~6.0.20",
         "expo-file-system": "~19.0.20",
         "expo-font": "~14.0.10",
-        "expo-image-picker": "~17.0.9",
+        "expo-image-picker": "~17.0.10",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.10",
-        "expo-location": "~17.0.1",
-        "expo-router": "~6.0.17",
+        "expo-location": "~19.0.8",
+        "expo-router": "~6.0.18",
         "expo-status-bar": "~3.0.9",
         "p-retry": "^6.2.1",
         "react": "19.1.0",
@@ -1854,15 +1854,15 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "12.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.11.tgz",
-      "integrity": "sha512-bGKNCbHirwgFlcOJHXpsAStQvM0nU3cmiobK0o07UkTfcUxl9q9lOQQh2eoMGqpm6Vs1IcwBpYye6thC3Nri/w==",
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.12.tgz",
+      "integrity": "sha512-X2MW86+ulLpMGvdgfvpl2EOBAKUlwvnvoPwdaZeeyWufGopn1nTUeh4C9gMsplDaP1kXv9sLXVhOoUoX6g9PvQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
         "@expo/config-plugins": "~54.0.3",
-        "@expo/config-types": "^54.0.9",
-        "@expo/json-file": "^10.0.7",
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "^10.0.8",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -1967,9 +1967,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "54.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.9.tgz",
-      "integrity": "sha512-Llf4jwcrAnrxgE5WCdAOxtMf8FGwS4Sk0SSgI0NnIaSyCnmOCAm80GPFvsK778Oj19Ub4tSyzdqufPyeQPksWw==",
+      "version": "54.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
+      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
       "license": "MIT"
     },
     "node_modules/@expo/devcert": {
@@ -2376,17 +2376,17 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "54.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.10.tgz",
-      "integrity": "sha512-AkSTwaWbMMDOiV4RRy4Mv6MZEOW5a7BZlgtrWxvzs6qYKRxKLKH/qqAuKe0bwGepF1+ws9oIX5nQjtnXRwezvQ==",
+      "version": "54.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.11.tgz",
+      "integrity": "sha512-Bmht6VW9w6Wk49EFqkMzYpICV++Q3Kuqh2KygjH/e5mj/9wHSCWLkmJYmUn0XaOo4bm6BwOp/hO3r5YNKP3AeQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~12.0.11",
-        "@expo/env": "~2.0.7",
-        "@expo/json-file": "~10.0.7",
+        "@expo/config": "~12.0.12",
+        "@expo/env": "~2.0.8",
+        "@expo/json-file": "~10.0.8",
         "@expo/metro": "~54.1.0",
         "@expo/spawn-async": "^1.7.2",
         "browserslist": "^4.25.0",
@@ -8422,20 +8422,20 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "54.0.27",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.27.tgz",
-      "integrity": "sha512-50BcJs8eqGwRiMUoWwphkRGYtKFS2bBnemxLzy0lrGVA1E6F4Q7L5h3WT6w1ehEZybtOVkfJu4Z6GWo2IJcpEA==",
+      "version": "54.0.28",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.28.tgz",
+      "integrity": "sha512-VTZcFsLdDUTuJIElAM8ilnlYA9nnnGSMrGw12JZxLK1ifKbIZ5O0kkdoRhyEJ+Gn/+XHE+N+dB9ZDAlarNYu5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.18",
-        "@expo/config": "~12.0.11",
+        "@expo/cli": "54.0.19",
+        "@expo/config": "~12.0.12",
         "@expo/config-plugins": "~54.0.3",
         "@expo/devtools": "0.1.8",
         "@expo/fingerprint": "0.15.4",
         "@expo/metro": "~54.1.0",
-        "@expo/metro-config": "54.0.10",
+        "@expo/metro-config": "54.0.11",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~54.0.8",
@@ -8635,9 +8635,9 @@
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.9.tgz",
-      "integrity": "sha512-v40HcX1fXDlNdc5y88ygvGyZU/QrcybBajYgVVLaWrXXGBqqC8Yu8jOHR99BtIdljiQ6JfYfxbeDp1woiyUrTA==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
+      "integrity": "sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==",
       "license": "MIT",
       "dependencies": {
         "expo-image-loader": "~6.0.0"
@@ -8689,9 +8689,9 @@
       }
     },
     "node_modules/expo-location": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-17.0.1.tgz",
-      "integrity": "sha512-m+OzotzlAXO3ZZ1uqW5GC25nXW868zN+ROyBA1V4VF6jGay1ZEs4URPglCVUDzZby2F5wt24cMzqDKw2IX6nRw==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -8810,11 +8810,10 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "6.0.17",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.17.tgz",
-      "integrity": "sha512-2n0lTidH2H+dOjk/Lu+krKIgK7b1qQ3O/9RWmf9P5IEuFiu7BSUgSDc+g69bUEElTnca8FR+zPTyk15kMXHrXg==",
+      "version": "6.0.18",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-6.0.18.tgz",
+      "integrity": "sha512-bPCTXLO68D8zg8sEl2LObiM9UlMOxfuMoXfe3XdHCJgBufWejKxdDiP3T2aRmwWaIswzi3Odk4Q2GXBoD3L5PQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/metro-runtime": "^6.1.2",
         "@expo/schema-utils": "^0.1.8",
@@ -8855,7 +8854,7 @@
         "react-native-safe-area-context": ">= 5.4.0",
         "react-native-screens": "*",
         "react-native-web": "*",
-        "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
+        "react-server-dom-webpack": "~19.0.2 || ~19.1.3 || ~19.2.2"
       },
       "peerDependenciesMeta": {
         "@react-navigation/drawer": {
@@ -9107,21 +9106,21 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.18",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.18.tgz",
-      "integrity": "sha512-hN4kolUXLah9T8DQJ8ue1ZTvRNbeNJOEOhLBak6EU7h90FKfjLA32nz99jRnHmis+aF+9qsrQG9yQx9eCSVDcg==",
+      "version": "54.0.19",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.19.tgz",
+      "integrity": "sha512-Za+Ena29uYkq2c1Lbh+r3VrooR/mW7c9dahoH4WvL1T9ttbfAeu7sJmCuWZo88bZ4bFsOpE5fYne71DK11iSrQ==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~12.0.11",
+        "@expo/config": "~12.0.12",
         "@expo/config-plugins": "~54.0.3",
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.0.8",
         "@expo/image-utils": "^0.8.8",
         "@expo/json-file": "^10.0.8",
         "@expo/metro": "~54.1.0",
-        "@expo/metro-config": "~54.0.10",
+        "@expo/metro-config": "~54.0.11",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.9",
         "@expo/plist": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "expo-image-picker": "~17.0.9",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.10",
+    "expo-location": "~17.0.1",
     "expo-router": "~6.0.17",
     "expo-status-bar": "~3.0.9",
     "p-retry": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
     "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.90.2",
     "base64-arraybuffer": "^1.0.2",
-    "expo": "~54.0.27",
+    "expo": "~54.0.28",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.11",
     "expo-crypto": "~15.0.8",
     "expo-dev-client": "~6.0.20",
     "expo-file-system": "~19.0.20",
     "expo-font": "~14.0.10",
-    "expo-image-picker": "~17.0.9",
+    "expo-image-picker": "~17.0.10",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.10",
-    "expo-location": "~17.0.1",
-    "expo-router": "~6.0.17",
+    "expo-location": "~19.0.8",
+    "expo-router": "~6.0.18",
     "expo-status-bar": "~3.0.9",
     "p-retry": "^6.2.1",
     "react": "19.1.0",
@@ -63,7 +63,9 @@
   "expo": {
     "doctor": {
       "reactNativeDirectoryCheck": {
-        "exclude": ["react-native-nfc-manager"]
+        "exclude": [
+          "react-native-nfc-manager"
+        ]
       }
     }
   }

--- a/src/components/conventions/ConventionToggle.tsx
+++ b/src/components/conventions/ConventionToggle.tsx
@@ -16,7 +16,6 @@ export type ConventionToggleProps = {
   disabled?: boolean;
   badgeText?: string;
   profileId?: string;
-  enableVerification?: boolean;
   onToggle: (conventionId: string, nextSelected: boolean, verifiedLocation?: VerifiedLocation | null) => void;
 };
 
@@ -27,18 +26,13 @@ export function ConventionToggle({
   disabled = false,
   badgeText,
   profileId,
-  enableVerification = false,
   onToggle,
 }: ConventionToggleProps) {
   const requiresVerification =
-    enableVerification &&
     Boolean(profileId) &&
     Boolean(convention.location_verification_required) &&
     Boolean(convention.geofence_enabled);
-  const { status, requestPermission, isLoading: isRequestingPermission } = useLocationPermission(
-    profileId,
-    enableVerification
-  );
+  const { status, requestPermission, isLoading: isRequestingPermission } = useLocationPermission(profileId);
   const { verifyLocation, isVerifying } = useGeoVerification();
   const [showPermissionModal, setShowPermissionModal] = useState(false);
   const [verificationError, setVerificationError] = useState<string | null>(null);

--- a/src/components/conventions/ConventionToggle.tsx
+++ b/src/components/conventions/ConventionToggle.tsx
@@ -1,7 +1,12 @@
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
 
-import type { ConventionSummary } from '../../features/conventions';
+import type { ConventionSummary, VerifiedLocation } from '../../features/conventions';
 import { formatConventionDateRange } from '../../features/conventions/utils';
+import { useLocationPermission } from '@/features/conventions/hooks/useLocationPermission';
+import { useGeoVerification } from '@/features/conventions/hooks/useGeoVerification';
+import { LocationPermissionModal } from '@/features/conventions/components/LocationPermissionModal';
+import { VerificationErrorModal } from '@/features/conventions/components/VerificationErrorModal';
 import { colors, spacing, radius } from '../../theme';
 
 export type ConventionToggleProps = {
@@ -10,7 +15,9 @@ export type ConventionToggleProps = {
   pending: boolean;
   disabled?: boolean;
   badgeText?: string;
-  onToggle: () => void;
+  profileId?: string;
+  enableVerification?: boolean;
+  onToggle: (conventionId: string, nextSelected: boolean, verifiedLocation?: VerifiedLocation | null) => void;
 };
 
 export function ConventionToggle({
@@ -19,48 +26,118 @@ export function ConventionToggle({
   pending,
   disabled = false,
   badgeText,
+  profileId,
+  enableVerification = false,
   onToggle,
 }: ConventionToggleProps) {
+  const requiresVerification =
+    enableVerification &&
+    Boolean(profileId) &&
+    Boolean(convention.location_verification_required) &&
+    Boolean(convention.geofence_enabled);
+  const { status, requestPermission, isLoading: isRequestingPermission } = useLocationPermission(
+    profileId,
+    enableVerification
+  );
+  const { verifyLocation, isVerifying } = useGeoVerification();
+  const [showPermissionModal, setShowPermissionModal] = useState(false);
+  const [verificationError, setVerificationError] = useState<string | null>(null);
   const dateRange = formatConventionDateRange(convention.start_date ?? null, convention.end_date ?? null);
-  const shouldDisable = disabled || pending;
+  const shouldDisable = disabled || pending || isVerifying || isRequestingPermission;
   const showDisabledBadge = !selected && !pending && disabled;
 
+  const handlePress = async () => {
+    // Opt-out: no verification required
+    if (selected) {
+      onToggle(convention.id, false, null);
+      return;
+    }
+
+    // No verification required -> toggle immediately
+    if (!requiresVerification) {
+      onToggle(convention.id, true, null);
+      return;
+    }
+
+    // Ensure permission
+    if (status !== 'granted') {
+      const granted = await requestPermission();
+      if (!granted) {
+        setShowPermissionModal(true);
+        return;
+      }
+    }
+
+    // Verify location
+    if (!profileId) {
+      setVerificationError('Unable to verify location without profile.');
+      return;
+    }
+
+    const result = await verifyLocation(convention.id, profileId);
+    if (result.verified) {
+      onToggle(convention.id, true, result.location);
+    } else {
+      setVerificationError(result.error ?? 'Location verification failed.');
+    }
+  };
+
   return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityState={{ disabled: shouldDisable, selected }}
-      onPress={onToggle}
-      disabled={shouldDisable}
-      style={({ pressed }) => [
-        styles.conventionRow,
-        selected && styles.conventionRowSelected,
-        shouldDisable && styles.conventionRowDisabled,
-        pressed && !shouldDisable ? styles.conventionRowPressed : null,
-      ]}
-    >
-      <View style={styles.conventionInfo}>
-        <Text style={styles.conventionName}>{convention.name}</Text>
-        {convention.location ? (
-          <Text style={styles.conventionMetaText}>{convention.location}</Text>
-        ) : null}
-        {dateRange ? <Text style={styles.conventionMetaText}>{dateRange}</Text> : null}
-      </View>
-      <View
-        style={[
-          styles.conventionBadge,
-          selected && styles.conventionBadgeActive,
-          showDisabledBadge ? styles.conventionBadgeDisabled : null,
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ disabled: shouldDisable, selected }}
+        onPress={handlePress}
+        disabled={shouldDisable}
+        style={({ pressed }) => [
+          styles.conventionRow,
+          selected && styles.conventionRowSelected,
+          shouldDisable && styles.conventionRowDisabled,
+          pressed && !shouldDisable ? styles.conventionRowPressed : null,
         ]}
       >
-        {pending ? (
-          <ActivityIndicator size="small" color={colors.foreground} />
-        ) : (
-          <Text numberOfLines={1} style={styles.conventionBadgeText}>
-            {badgeText ?? (selected ? 'Assigned' : 'Tap to assign')}
-          </Text>
-        )}
-      </View>
-    </Pressable>
+        <View style={styles.conventionInfo}>
+          <Text style={styles.conventionName}>{convention.name}</Text>
+          {convention.location ? (
+            <Text style={styles.conventionMetaText}>{convention.location}</Text>
+          ) : null}
+          {dateRange ? <Text style={styles.conventionMetaText}>{dateRange}</Text> : null}
+          {requiresVerification ? (
+            <Text style={styles.verificationText}>Location required</Text>
+          ) : null}
+        </View>
+        <View
+          style={[
+            styles.conventionBadge,
+            selected && styles.conventionBadgeActive,
+            showDisabledBadge ? styles.conventionBadgeDisabled : null,
+          ]}
+        >
+          {pending || isVerifying ? (
+            <ActivityIndicator size="small" color={colors.foreground} />
+          ) : (
+            <Text numberOfLines={1} style={styles.conventionBadgeText}>
+              {badgeText ?? (selected ? 'Assigned' : 'Tap to assign')}
+            </Text>
+          )}
+        </View>
+      </Pressable>
+
+      <LocationPermissionModal
+        visible={showPermissionModal}
+        onClose={() => setShowPermissionModal(false)}
+      />
+      <VerificationErrorModal
+        visible={Boolean(verificationError)}
+        error={verificationError}
+        convention={convention}
+        onClose={() => setVerificationError(null)}
+        onRetry={() => {
+          setVerificationError(null);
+          void handlePress();
+        }}
+      />
+    </>
   );
 }
 
@@ -99,6 +176,12 @@ const styles = StyleSheet.create({
   conventionMetaText: {
     color: 'rgba(148,163,184,0.9)',
     fontSize: 13,
+  },
+  verificationText: {
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: '600',
+    marginTop: 2,
   },
   conventionBadge: {
     borderRadius: radius.lg,

--- a/src/features/conventions/api/conventions.ts
+++ b/src/features/conventions/api/conventions.ts
@@ -10,6 +10,25 @@ export type ConventionSummary = {
   start_date: string | null;
   end_date: string | null;
   timezone: string;
+  latitude: number | null;
+  longitude: number | null;
+  geofence_radius_meters: number | null;
+  geofence_enabled: boolean;
+  location_verification_required: boolean;
+};
+
+export type VerifiedLocation = {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+};
+
+export type OptInParams = {
+  profileId: string;
+  conventionId: string;
+  verifiedLocation?: VerifiedLocation | null;
+  verificationMethod?: 'none' | 'gps' | 'manual_override' | 'grandfathered';
+  overrideReason?: string | null;
 };
 
 export const CONVENTIONS_QUERY_KEY = 'conventions';
@@ -20,7 +39,22 @@ export async function fetchConventions(): Promise<ConventionSummary[]> {
   const client = supabase as any;
   const { data, error } = await client
     .from('conventions')
-    .select('id, slug, name, location, start_date, end_date, timezone')
+    .select(
+      [
+        'id',
+        'slug',
+        'name',
+        'location',
+        'start_date',
+        'end_date',
+        'timezone',
+        'latitude',
+        'longitude',
+        'geofence_radius_meters',
+        'geofence_enabled',
+        'location_verification_required',
+      ].join(', ')
+    )
     .order('start_date', { ascending: true, nullsFirst: false })
     .order('name', { ascending: true });
 
@@ -40,6 +74,11 @@ export async function fetchConventions(): Promise<ConventionSummary[]> {
     start_date: convention.start_date ?? null,
     end_date: convention.end_date ?? null,
     timezone: convention.timezone ?? 'UTC',
+    latitude: convention.latitude ?? null,
+    longitude: convention.longitude ?? null,
+    geofence_radius_meters: convention.geofence_radius_meters ?? null,
+    geofence_enabled: Boolean(convention.geofence_enabled),
+    location_verification_required: Boolean(convention.location_verification_required),
   }));
 }
 
@@ -70,14 +109,29 @@ export async function fetchProfileConventionIds(profileId: string): Promise<stri
   return (data ?? []).map((row: any) => row.convention_id);
 }
 
-export async function optInToConvention(profileId: string, conventionId: string): Promise<void> {
+export async function optInToConvention(params: OptInParams): Promise<void> {
+  const {
+    profileId,
+    conventionId,
+    verifiedLocation = null,
+    verificationMethod = verifiedLocation ? 'gps' : 'none',
+    overrideReason = null,
+  } = params;
+
   const client = supabase as any;
-  const { error } = await client
-    .from('profile_conventions')
-    .upsert(
-      { profile_id: profileId, convention_id: conventionId },
-      { onConflict: 'profile_id, convention_id' }
-    );
+  const { error } = await client.rpc('opt_in_to_convention', {
+    p_profile_id: profileId,
+    p_convention_id: conventionId,
+    p_verified_location: verifiedLocation
+      ? {
+          lat: verifiedLocation.latitude,
+          lng: verifiedLocation.longitude,
+          accuracy: verifiedLocation.accuracy,
+        }
+      : null,
+    p_verification_method: verificationMethod,
+    p_override_reason: overrideReason,
+  });
 
   if (error) {
     captureSupabaseError(error, {
@@ -96,6 +150,7 @@ export async function optInToConvention(profileId: string, conventionId: string)
     payload: {
       profile_id: profileId,
       convention_id: conventionId,
+      verification_method: verificationMethod,
     },
   }).catch((error) => {
     captureHandledException(error, {

--- a/src/features/conventions/api/geoVerification.ts
+++ b/src/features/conventions/api/geoVerification.ts
@@ -1,0 +1,36 @@
+import { supabase } from '../../../lib/supabase';
+
+export type LocationVerificationRequest = {
+  profileId: string;
+  conventionId: string;
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+};
+
+export type LocationVerificationResponse = {
+  verified: boolean;
+  distance_meters: number | null;
+  convention_name: string;
+  geofence_radius_meters: number;
+  effective_radius_meters: number | null;
+  error?: string;
+};
+
+export async function verifyConventionLocation(
+  params: LocationVerificationRequest
+): Promise<LocationVerificationResponse> {
+  const { data, error } = await supabase.rpc('verify_convention_location', {
+    p_profile_id: params.profileId,
+    p_convention_id: params.conventionId,
+    p_user_lat: params.latitude,
+    p_user_lng: params.longitude,
+    p_accuracy: params.accuracy,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data as LocationVerificationResponse;
+}

--- a/src/features/conventions/components/LocationPermissionModal.tsx
+++ b/src/features/conventions/components/LocationPermissionModal.tsx
@@ -1,0 +1,84 @@
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import * as Linking from 'expo-linking';
+import { Ionicons } from '@expo/vector-icons';
+
+import { TailTagCard } from '@/components/ui/TailTagCard';
+import { TailTagButton } from '@/components/ui/TailTagButton';
+import { colors, spacing } from '@/theme';
+
+type LocationPermissionModalProps = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export function LocationPermissionModal({ visible, onClose }: LocationPermissionModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.cardWrapper} onPress={(event) => event.stopPropagation()}>
+          <TailTagCard>
+            <View style={styles.iconRow}>
+              <Ionicons name="location-outline" size={48} color={colors.primary} />
+            </View>
+            <Text style={styles.title}>Location permission required</Text>
+            <Text style={styles.body}>
+              TailTag needs your location once to verify you are at the convention. We do not track
+              you during the event.
+            </Text>
+
+            <View style={styles.actions}>
+              <TailTagButton onPress={openSettings}>
+                Open Settings
+              </TailTagButton>
+              <TailTagButton variant="ghost" onPress={onClose}>
+                Cancel
+              </TailTagButton>
+            </View>
+          </TailTagCard>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+async function openSettings() {
+  await Linking.openSettings();
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  cardWrapper: {
+    width: '100%',
+  },
+  iconRow: {
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+    textAlign: 'center',
+  },
+  body: {
+    color: 'rgba(148,163,184,0.9)',
+    fontSize: 14,
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+  actions: {
+    gap: spacing.sm,
+  },
+});

--- a/src/features/conventions/components/VerificationErrorModal.tsx
+++ b/src/features/conventions/components/VerificationErrorModal.tsx
@@ -1,0 +1,105 @@
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { TailTagCard } from '@/components/ui/TailTagCard';
+import { TailTagButton } from '@/components/ui/TailTagButton';
+import { colors, spacing } from '@/theme';
+import type { ConventionSummary } from '../api/conventions';
+
+type VerificationErrorModalProps = {
+  visible: boolean;
+  error: string | null;
+  convention: ConventionSummary;
+  onClose: () => void;
+  onRetry: () => void;
+};
+
+export function VerificationErrorModal({
+  visible,
+  error,
+  convention,
+  onClose,
+  onRetry,
+}: VerificationErrorModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.cardWrapper} onPress={(event) => event.stopPropagation()}>
+          <TailTagCard>
+            <View style={styles.iconRow}>
+              <Ionicons name="warning-outline" size={48} color={colors.error} />
+            </View>
+            <Text style={styles.title}>Couldn&apos;t verify location</Text>
+            <Text style={styles.body}>{error ?? 'You must be at the convention to join.'}</Text>
+
+            <View style={styles.conventionInfo}>
+              <Text style={styles.conventionName}>{convention.name}</Text>
+              {convention.location ? (
+                <Text style={styles.conventionLocation}>{convention.location}</Text>
+              ) : null}
+            </View>
+
+            <View style={styles.actions}>
+              <TailTagButton onPress={onRetry}>Try again</TailTagButton>
+              <TailTagButton variant="ghost" onPress={onClose}>
+                Cancel
+              </TailTagButton>
+            </View>
+          </TailTagCard>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  cardWrapper: {
+    width: '100%',
+  },
+  iconRow: {
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  title: {
+    color: colors.foreground,
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+    textAlign: 'center',
+  },
+  body: {
+    color: 'rgba(148,163,184,0.9)',
+    fontSize: 14,
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+  conventionInfo: {
+    alignItems: 'center',
+    gap: 2,
+    marginBottom: spacing.md,
+  },
+  conventionName: {
+    color: colors.foreground,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  conventionLocation: {
+    color: 'rgba(148,163,184,0.9)',
+    fontSize: 13,
+  },
+  actions: {
+    gap: spacing.sm,
+  },
+});

--- a/src/features/conventions/components/VerificationErrorModal.tsx
+++ b/src/features/conventions/components/VerificationErrorModal.tsx
@@ -32,7 +32,7 @@ export function VerificationErrorModal({
         <Pressable style={styles.cardWrapper} onPress={(event) => event.stopPropagation()}>
           <TailTagCard>
             <View style={styles.iconRow}>
-              <Ionicons name="warning-outline" size={48} color={colors.error} />
+              <Ionicons name="warning-outline" size={48} color={colors.destructive} />
             </View>
             <Text style={styles.title}>Couldn&apos;t verify location</Text>
             <Text style={styles.body}>{error ?? 'You must be at the convention to join.'}</Text>

--- a/src/features/conventions/hooks/useGeoVerification.ts
+++ b/src/features/conventions/hooks/useGeoVerification.ts
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import * as Location from 'expo-location';
+
+import { verifyConventionLocation } from '../api/geoVerification';
+import { captureHandledException } from '@/lib/sentry';
+import type { VerifiedLocation } from '../api/conventions';
+
+export type VerificationResult =
+  | { verified: true; location: VerifiedLocation }
+  | { verified: false; distance_meters?: number | null; error?: string | null };
+
+type UseGeoVerificationReturn = {
+  verifyLocation: (conventionId: string, profileId: string) => Promise<VerificationResult>;
+  isVerifying: boolean;
+};
+
+export function useGeoVerification(): UseGeoVerificationReturn {
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  async function verifyLocation(conventionId: string, profileId: string): Promise<VerificationResult> {
+    setIsVerifying(true);
+    try {
+      const position = await Location.getCurrentPositionAsync({
+        accuracy: Location.Accuracy.High,
+        timeInterval: 5000,
+        distanceInterval: 0,
+      });
+
+      const { latitude, longitude, accuracy } = position.coords;
+      const effectiveAccuracy = typeof accuracy === 'number' ? accuracy : 50;
+
+      const result = await verifyConventionLocation({
+        profileId,
+        conventionId,
+        latitude,
+        longitude,
+        accuracy: effectiveAccuracy,
+      });
+
+      if (result.verified) {
+        return {
+          verified: true,
+          location: { latitude, longitude, accuracy: effectiveAccuracy },
+        };
+      }
+
+      return {
+        verified: false,
+        distance_meters: result.distance_meters ?? null,
+        error: result.error ?? `You must be at ${result.convention_name} to join`,
+      };
+    } catch (error) {
+      captureHandledException(error, { scope: 'geo-verification' });
+      return {
+        verified: false,
+        error: 'Unable to verify location. Please try again.',
+      };
+    } finally {
+      setIsVerifying(false);
+    }
+  }
+
+  return { verifyLocation, isVerifying };
+}

--- a/src/features/conventions/hooks/useGeoVerification.ts
+++ b/src/features/conventions/hooks/useGeoVerification.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import * as Location from 'expo-location';
 
 import { verifyConventionLocation } from '../api/geoVerification';
-import { captureHandledException } from '@/lib/sentry';
+import { captureHandledException, captureHandledMessage } from '@/lib/sentry';
 import type { VerifiedLocation } from '../api/conventions';
 
 export type VerificationResult =
@@ -28,19 +28,50 @@ export function useGeoVerification(): UseGeoVerificationReturn {
 
       const { latitude, longitude, accuracy } = position.coords;
       const effectiveAccuracy = typeof accuracy === 'number' ? accuracy : 50;
+      const roundedAccuracy = Math.max(1, Math.round(effectiveAccuracy));
+
+      captureHandledMessage('geo_verification_attempt', {
+        conventionId,
+        latitude,
+        longitude,
+        accuracy: roundedAccuracy,
+      });
+      console.log('[GeoVerification] attempt', {
+        conventionId,
+        latitude,
+        longitude,
+        accuracy: roundedAccuracy,
+      });
 
       const result = await verifyConventionLocation({
         profileId,
         conventionId,
         latitude,
         longitude,
-        accuracy: effectiveAccuracy,
+        accuracy: roundedAccuracy,
+      });
+
+      captureHandledMessage('geo_verification_result', {
+        conventionId,
+        verified: result.verified,
+        distance_meters: result.distance_meters ?? null,
+        radius_meters: result.geofence_radius_meters,
+        effective_radius_meters: result.effective_radius_meters ?? null,
+        error: result.error ?? null,
+      });
+      console.log('[GeoVerification] result', {
+        conventionId,
+        verified: result.verified,
+        distance_meters: result.distance_meters ?? null,
+        radius_meters: result.geofence_radius_meters,
+        effective_radius_meters: result.effective_radius_meters ?? null,
+        error: result.error ?? null,
       });
 
       if (result.verified) {
         return {
           verified: true,
-          location: { latitude, longitude, accuracy: effectiveAccuracy },
+          location: { latitude, longitude, accuracy: roundedAccuracy },
         };
       }
 

--- a/src/features/conventions/hooks/useLocationPermission.ts
+++ b/src/features/conventions/hooks/useLocationPermission.ts
@@ -18,18 +18,15 @@ type UseLocationPermissionReturn = {
   isLoading: boolean;
 };
 
-export function useLocationPermission(profileId?: string, enabled = true): UseLocationPermissionReturn {
+export function useLocationPermission(profileId?: string): UseLocationPermissionReturn {
   const [status, setStatus] = useState<LocationPermissionStatus>('not_determined');
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (enabled) {
-      void checkPermission();
-    }
-  }, [enabled]);
+    void checkPermission();
+  }, []);
 
   async function checkPermission() {
-    if (!enabled) return;
     try {
       const { status: nativeStatus } = await Location.getForegroundPermissionsAsync();
       const mapped = mapPermissionStatus(nativeStatus);
@@ -41,7 +38,6 @@ export function useLocationPermission(profileId?: string, enabled = true): UseLo
   }
 
   async function requestPermission(): Promise<boolean> {
-    if (!enabled) return false;
     setIsLoading(true);
     try {
       const { status: nativeStatus } = await Location.requestForegroundPermissionsAsync();

--- a/src/features/conventions/hooks/useLocationPermission.ts
+++ b/src/features/conventions/hooks/useLocationPermission.ts
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import * as Location from 'expo-location';
+
+import { supabase } from '@/lib/supabase';
+import { captureHandledException } from '@/lib/sentry';
+
+export type LocationPermissionStatus =
+  | 'not_determined'
+  | 'granted'
+  | 'denied'
+  | 'restricted';
+
+type PermissionSource = 'check' | 'request';
+
+type UseLocationPermissionReturn = {
+  status: LocationPermissionStatus;
+  requestPermission: () => Promise<boolean>;
+  isLoading: boolean;
+};
+
+export function useLocationPermission(profileId?: string, enabled = true): UseLocationPermissionReturn {
+  const [status, setStatus] = useState<LocationPermissionStatus>('not_determined');
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (enabled) {
+      void checkPermission();
+    }
+  }, [enabled]);
+
+  async function checkPermission() {
+    if (!enabled) return;
+    try {
+      const { status: nativeStatus } = await Location.getForegroundPermissionsAsync();
+      const mapped = mapPermissionStatus(nativeStatus);
+      setStatus(mapped);
+      await persistPermission(mapped, 'check');
+    } catch (error) {
+      captureHandledException(error, { scope: 'location-permission.check' });
+    }
+  }
+
+  async function requestPermission(): Promise<boolean> {
+    if (!enabled) return false;
+    setIsLoading(true);
+    try {
+      const { status: nativeStatus } = await Location.requestForegroundPermissionsAsync();
+      const mapped = mapPermissionStatus(nativeStatus);
+      setStatus(mapped);
+      await persistPermission(mapped, 'request');
+      return mapped === 'granted';
+    } catch (error) {
+      captureHandledException(error, { scope: 'location-permission.request' });
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function persistPermission(nextStatus: LocationPermissionStatus, source: PermissionSource) {
+    if (!profileId) return;
+    const now = new Date().toISOString();
+    const payload: Record<string, unknown> = {
+      location_permission_status: nextStatus === 'not_determined' ? 'not_requested' : nextStatus,
+    };
+
+    if (source === 'request') {
+      payload.location_permission_requested_at = now;
+    }
+    if (nextStatus === 'granted') {
+      payload.location_permission_granted_at = now;
+    }
+
+    const { error } = await supabase
+      .from('profiles')
+      .update(payload)
+      .eq('id', profileId);
+
+    if (error) {
+      captureHandledException(error, { scope: 'location-permission.persist', profileId });
+    }
+  }
+
+  return { status, requestPermission, isLoading };
+}
+
+function mapPermissionStatus(status: Location.PermissionStatus): LocationPermissionStatus {
+  switch (status) {
+    case Location.PermissionStatus.GRANTED:
+      return 'granted';
+    case Location.PermissionStatus.DENIED:
+      return 'denied';
+    case Location.PermissionStatus.UNDETERMINED:
+      return 'not_determined';
+    default:
+      return 'restricted';
+  }
+}

--- a/src/features/conventions/hooks/useLocationPermission.ts
+++ b/src/features/conventions/hooks/useLocationPermission.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as Location from 'expo-location';
 
 import { supabase } from '@/lib/supabase';
@@ -22,11 +22,34 @@ export function useLocationPermission(profileId?: string): UseLocationPermission
   const [status, setStatus] = useState<LocationPermissionStatus>('not_determined');
   const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    void checkPermission();
-  }, []);
+  const persistPermission = useCallback(
+    async (nextStatus: LocationPermissionStatus, source: PermissionSource) => {
+      if (!profileId) return;
+      const now = new Date().toISOString();
+      const payload: Record<string, unknown> = {
+        location_permission_status: nextStatus === 'not_determined' ? 'not_requested' : nextStatus,
+      };
 
-  async function checkPermission() {
+      if (source === 'request') {
+        payload.location_permission_requested_at = now;
+      }
+      if (nextStatus === 'granted') {
+        payload.location_permission_granted_at = now;
+      }
+
+      const { error } = await supabase
+        .from('profiles')
+        .update(payload)
+        .eq('id', profileId);
+
+      if (error) {
+        captureHandledException(error, { scope: 'location-permission.persist', profileId });
+      }
+    },
+    [profileId]
+  );
+
+  const checkPermission = useCallback(async () => {
     try {
       const { status: nativeStatus } = await Location.getForegroundPermissionsAsync();
       const mapped = mapPermissionStatus(nativeStatus);
@@ -35,7 +58,11 @@ export function useLocationPermission(profileId?: string): UseLocationPermission
     } catch (error) {
       captureHandledException(error, { scope: 'location-permission.check' });
     }
-  }
+  }, [persistPermission]);
+
+  useEffect(() => {
+    void checkPermission();
+  }, [checkPermission]);
 
   async function requestPermission(): Promise<boolean> {
     setIsLoading(true);
@@ -50,30 +77,6 @@ export function useLocationPermission(profileId?: string): UseLocationPermission
       return false;
     } finally {
       setIsLoading(false);
-    }
-  }
-
-  async function persistPermission(nextStatus: LocationPermissionStatus, source: PermissionSource) {
-    if (!profileId) return;
-    const now = new Date().toISOString();
-    const payload: Record<string, unknown> = {
-      location_permission_status: nextStatus === 'not_determined' ? 'not_requested' : nextStatus,
-    };
-
-    if (source === 'request') {
-      payload.location_permission_requested_at = now;
-    }
-    if (nextStatus === 'granted') {
-      payload.location_permission_granted_at = now;
-    }
-
-    const { error } = await supabase
-      .from('profiles')
-      .update(payload)
-      .eq('id', profileId);
-
-    if (error) {
-      captureHandledException(error, { scope: 'location-permission.persist', profileId });
     }
   }
 

--- a/src/features/conventions/index.ts
+++ b/src/features/conventions/index.ts
@@ -11,3 +11,8 @@ export {
   addFursuitConvention,
   removeFursuitConvention,
 } from './api/conventions';
+export {
+  verifyConventionLocation,
+  type LocationVerificationRequest,
+  type LocationVerificationResponse,
+} from './api/geoVerification';

--- a/src/features/conventions/index.ts
+++ b/src/features/conventions/index.ts
@@ -1,4 +1,4 @@
-export type { ConventionSummary } from './api/conventions';
+export type { ConventionSummary, VerifiedLocation } from './api/conventions';
 export {
   fetchConventions,
   CONVENTIONS_QUERY_KEY,

--- a/src/features/onboarding/components/ConventionStep.tsx
+++ b/src/features/onboarding/components/ConventionStep.tsx
@@ -109,7 +109,7 @@ export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
       const operations: Promise<void>[] = [];
 
       toAdd.forEach((conventionId) => {
-        operations.push(optInToConvention(userId, conventionId));
+        operations.push(optInToConvention({ profileId: userId, conventionId }));
       });
 
       toRemove.forEach((conventionId) => {

--- a/src/features/onboarding/components/ConventionStep.tsx
+++ b/src/features/onboarding/components/ConventionStep.tsx
@@ -214,7 +214,6 @@ export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
                     pending={isSubmitting}
                     disabled={isSubmitting}
                     profileId={userId}
-                    enableVerification
                     onToggle={(conventionId, nextSelected, verifiedLocation) =>
                       toggleConvention(conventionId, nextSelected, verifiedLocation)
                     }

--- a/src/features/onboarding/components/ConventionStep.tsx
+++ b/src/features/onboarding/components/ConventionStep.tsx
@@ -13,6 +13,7 @@ import {
   optOutOfConvention,
   PROFILE_CONVENTIONS_QUERY_KEY,
   type ConventionSummary,
+  type VerifiedLocation,
 } from '../../conventions';
 import { ConventionToggle } from '../../../components/conventions/ConventionToggle';
 import { colors, spacing } from '../../../theme';
@@ -28,6 +29,7 @@ export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
   const hasInitializedSelectionsRef = useRef(false);
   const [searchInput, setSearchInput] = useState('');
   const [selectedConventionIds, setSelectedConventionIds] = useState<Set<string>>(new Set());
+  const [verifiedLocations, setVerifiedLocations] = useState<Record<string, VerifiedLocation>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -76,13 +78,27 @@ export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
     });
   }, [conventions, searchInput]);
 
-  const toggleConvention = (conventionId: string) => {
+  const toggleConvention = (
+    conventionId: string,
+    nextSelected: boolean,
+    verifiedLocation?: VerifiedLocation | null
+  ) => {
     setSelectedConventionIds((current) => {
       const next = new Set(current);
-      if (next.has(conventionId)) {
-        next.delete(conventionId);
-      } else {
+      if (nextSelected) {
         next.add(conventionId);
+      } else {
+        next.delete(conventionId);
+      }
+      return next;
+    });
+
+    setVerifiedLocations((current) => {
+      const next = { ...current };
+      if (nextSelected && verifiedLocation) {
+        next[conventionId] = verifiedLocation;
+      } else if (!nextSelected && next[conventionId]) {
+        delete next[conventionId];
       }
       return next;
     });
@@ -109,7 +125,13 @@ export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
       const operations: Promise<void>[] = [];
 
       toAdd.forEach((conventionId) => {
-        operations.push(optInToConvention({ profileId: userId, conventionId }));
+        operations.push(
+          optInToConvention({
+            profileId: userId,
+            conventionId,
+            verifiedLocation: verifiedLocations[conventionId],
+          })
+        );
       });
 
       toRemove.forEach((conventionId) => {
@@ -191,7 +213,11 @@ export function ConventionStep({ userId, onComplete }: ConventionStepProps) {
                     selected={selected}
                     pending={isSubmitting}
                     disabled={isSubmitting}
-                    onToggle={() => toggleConvention(convention.id)}
+                    profileId={userId}
+                    enableVerification
+                    onToggle={(conventionId, nextSelected, verifiedLocation) =>
+                      toggleConvention(conventionId, nextSelected, verifiedLocation)
+                    }
                   />
                 </View>
               );

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -48,7 +48,13 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
           name,
           location,
           start_date,
-          end_date
+          end_date,
+          timezone,
+          latitude,
+          longitude,
+          geofence_radius_meters,
+          geofence_enabled,
+          location_verification_required
         )
       ),
       fursuit_bios (
@@ -89,6 +95,12 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
         location: convention.location ?? null,
         start_date: convention.start_date ?? null,
         end_date: convention.end_date ?? null,
+        timezone: convention.timezone ?? 'UTC',
+        latitude: convention.latitude ?? null,
+        longitude: convention.longitude ?? null,
+        geofence_radius_meters: convention.geofence_radius_meters ?? null,
+        geofence_enabled: Boolean(convention.geofence_enabled),
+        location_verification_required: Boolean(convention.location_verification_required),
       }));
 
     const bio = mapLatestFursuitBio(item.fursuit_bios ?? null);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -282,8 +282,13 @@ export type Database = {
           config: Json
           created_at: string
           end_date: string | null
+          geofence_enabled: boolean
+          geofence_radius_meters: number | null
           id: string
+          latitude: number | null
           location: string | null
+          location_verification_required: boolean
+          longitude: number | null
           name: string
           slug: string
           start_date: string | null
@@ -294,8 +299,13 @@ export type Database = {
           config?: Json
           created_at?: string
           end_date?: string | null
+          geofence_enabled?: boolean
+          geofence_radius_meters?: number | null
           id?: string
+          latitude?: number | null
           location?: string | null
+          location_verification_required?: boolean
+          longitude?: number | null
           name: string
           slug: string
           start_date?: string | null
@@ -306,8 +316,13 @@ export type Database = {
           config?: Json
           created_at?: string
           end_date?: string | null
+          geofence_enabled?: boolean
+          geofence_radius_meters?: number | null
           id?: string
+          latitude?: number | null
           location?: string | null
+          location_verification_required?: boolean
+          longitude?: number | null
           name?: string
           slug?: string
           start_date?: string | null
@@ -928,17 +943,35 @@ export type Database = {
         Row: {
           convention_id: string
           created_at: string
+          override_actor_id: string | null
+          override_at: string | null
+          override_reason: string | null
           profile_id: string
+          verified_at: string | null
+          verified_location: Json | null
+          verification_method: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Insert: {
           convention_id: string
           created_at?: string
+          override_actor_id?: string | null
+          override_at?: string | null
+          override_reason?: string | null
           profile_id: string
+          verified_at?: string | null
+          verified_location?: Json | null
+          verification_method?: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Update: {
           convention_id?: string
           created_at?: string
+          override_actor_id?: string | null
+          override_at?: string | null
+          override_reason?: string | null
           profile_id?: string
+          verified_at?: string | null
+          verified_location?: Json | null
+          verification_method?: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Relationships: [
           {
@@ -966,6 +999,9 @@ export type Database = {
           id: string
           is_new: boolean
           is_suspended: boolean
+          location_permission_granted_at: string | null
+          location_permission_requested_at: string | null
+          location_permission_status: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed: boolean
           role: Database["public"]["Enums"]["user_role"]
           suspended_until: string | null
@@ -981,6 +1017,9 @@ export type Database = {
           id: string
           is_new?: boolean
           is_suspended?: boolean
+          location_permission_granted_at?: string | null
+          location_permission_requested_at?: string | null
+          location_permission_status?: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed?: boolean
           role?: Database["public"]["Enums"]["user_role"]
           suspended_until?: string | null
@@ -996,6 +1035,9 @@ export type Database = {
           id?: string
           is_new?: boolean
           is_suspended?: boolean
+          location_permission_granted_at?: string | null
+          location_permission_requested_at?: string | null
+          location_permission_status?: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed?: boolean
           role?: Database["public"]["Enums"]["user_role"]
           suspended_until?: string | null
@@ -1057,6 +1099,54 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "nfc_tags"
             referencedColumns: ["uid"]
+          },
+        ]
+      }
+      verification_attempts: {
+        Row: {
+          convention_id: string | null
+          created_at: string | null
+          distance_meters: number | null
+          error_code: string | null
+          gps_accuracy: number | null
+          id: string
+          profile_id: string | null
+          verified: boolean
+        }
+        Insert: {
+          convention_id?: string | null
+          created_at?: string | null
+          distance_meters?: number | null
+          error_code?: string | null
+          gps_accuracy?: number | null
+          id?: string
+          profile_id?: string | null
+          verified: boolean
+        }
+        Update: {
+          convention_id?: string | null
+          created_at?: string | null
+          distance_meters?: number | null
+          error_code?: string | null
+          gps_accuracy?: number | null
+          id?: string
+          profile_id?: string | null
+          verified?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "verification_attempts_convention_id_fkey"
+            columns: ["convention_id"]
+            isOneToOne: false
+            referencedRelation: "conventions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "verification_attempts_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1571,6 +1661,16 @@ export type Database = {
         Returns: Database["public"]["Enums"]["user_role"]
       }
       grant_achievements_batch: { Args: { awards: Json }; Returns: Json }
+      opt_in_to_convention: {
+        Args: {
+          p_convention_id: string
+          p_override_reason?: string | null
+          p_profile_id: string
+          p_verification_method?: string
+          p_verified_location?: Json | null
+        }
+        Returns: void
+      }
       is_admin: { Args: { user_id: string }; Returns: boolean }
       is_event_staff: {
         Args: { convention_id: string; user_id: string }
@@ -1618,6 +1718,16 @@ export type Database = {
       refresh_fursuit_popularity: {
         Args: { convention_uuid?: string }
         Returns: undefined
+      }
+      verify_convention_location: {
+        Args: {
+          p_accuracy: number
+          p_convention_id: string
+          p_profile_id: string
+          p_user_lat: number
+          p_user_lng: number
+        }
+        Returns: Json
       }
       search_players: {
         Args: {

--- a/src/types/database.ts.minimal
+++ b/src/types/database.ts.minimal
@@ -193,8 +193,13 @@ export type Database = {
         Row: {
           created_at: string
           end_date: string | null
+          geofence_enabled: boolean
+          geofence_radius_meters: number | null
           id: string
+          latitude: number | null
           location: string | null
+          location_verification_required: boolean
+          longitude: number | null
           name: string
           slug: string
           start_date: string | null
@@ -204,8 +209,13 @@ export type Database = {
         Insert: {
           created_at?: string
           end_date?: string | null
+          geofence_enabled?: boolean
+          geofence_radius_meters?: number | null
           id?: string
+          latitude?: number | null
           location?: string | null
+          location_verification_required?: boolean
+          longitude?: number | null
           name: string
           slug: string
           start_date?: string | null
@@ -215,8 +225,13 @@ export type Database = {
         Update: {
           created_at?: string
           end_date?: string | null
+          geofence_enabled?: boolean
+          geofence_radius_meters?: number | null
           id?: string
+          latitude?: number | null
           location?: string | null
+          location_verification_required?: boolean
+          longitude?: number | null
           name?: string
           slug?: string
           start_date?: string | null
@@ -661,17 +676,35 @@ export type Database = {
         Row: {
           convention_id: string
           created_at: string
+          override_actor_id: string | null
+          override_at: string | null
+          override_reason: string | null
           profile_id: string
+          verified_at: string | null
+          verified_location: Json | null
+          verification_method: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Insert: {
           convention_id: string
           created_at?: string
+          override_actor_id?: string | null
+          override_at?: string | null
+          override_reason?: string | null
           profile_id: string
+          verified_at?: string | null
+          verified_location?: Json | null
+          verification_method?: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Update: {
           convention_id?: string
           created_at?: string
+          override_actor_id?: string | null
+          override_at?: string | null
+          override_reason?: string | null
           profile_id?: string
+          verified_at?: string | null
+          verified_location?: Json | null
+          verification_method?: "none" | "gps" | "manual_override" | "grandfathered"
         }
         Relationships: [
           {
@@ -698,6 +731,9 @@ export type Database = {
           default_catch_mode: string
           id: string
           is_new: boolean
+          location_permission_granted_at: string | null
+          location_permission_requested_at: string | null
+          location_permission_status: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed: boolean
           updated_at: string | null
           username: string | null
@@ -709,6 +745,9 @@ export type Database = {
           default_catch_mode?: string
           id: string
           is_new?: boolean
+          location_permission_granted_at?: string | null
+          location_permission_requested_at?: string | null
+          location_permission_status?: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed?: boolean
           updated_at?: string | null
           username?: string | null
@@ -720,11 +759,62 @@ export type Database = {
           default_catch_mode?: string
           id?: string
           is_new?: boolean
+          location_permission_granted_at?: string | null
+          location_permission_requested_at?: string | null
+          location_permission_status?: "not_requested" | "granted" | "denied" | "restricted"
           onboarding_completed?: boolean
           updated_at?: string | null
           username?: string | null
         }
         Relationships: []
+      }
+      verification_attempts: {
+        Row: {
+          convention_id: string | null
+          created_at: string | null
+          distance_meters: number | null
+          error_code: string | null
+          gps_accuracy: number | null
+          id: string
+          profile_id: string | null
+          verified: boolean
+        }
+        Insert: {
+          convention_id?: string | null
+          created_at?: string | null
+          distance_meters?: number | null
+          error_code?: string | null
+          gps_accuracy?: number | null
+          id?: string
+          profile_id?: string | null
+          verified: boolean
+        }
+        Update: {
+          convention_id?: string | null
+          created_at?: string | null
+          distance_meters?: number | null
+          error_code?: string | null
+          gps_accuracy?: number | null
+          id?: string
+          profile_id?: string | null
+          verified?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "verification_attempts_convention_id_fkey"
+            columns: ["convention_id"]
+            isOneToOne: false
+            referencedRelation: "conventions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "verification_attempts_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_achievements: {
         Row: {
@@ -970,6 +1060,16 @@ export type Database = {
         }[]
       }
       grant_achievements_batch: { Args: { awards: Json }; Returns: Json }
+      opt_in_to_convention: {
+        Args: {
+          p_convention_id: string
+          p_override_reason?: string | null
+          p_profile_id: string
+          p_verification_method?: string
+          p_verified_location?: Json | null
+        }
+        Returns: void
+      }
       notify_catch_decision: {
         Args: {
           p_catch_id: string
@@ -998,6 +1098,16 @@ export type Database = {
       refresh_fursuit_popularity: {
         Args: { convention_uuid?: string }
         Returns: undefined
+      }
+      verify_convention_location: {
+        Args: {
+          p_accuracy: number
+          p_convention_id: string
+          p_profile_id: string
+          p_user_lat: number
+          p_user_lng: number
+        }
+        Returns: Json
       }
     }
     Enums: {


### PR DESCRIPTION
Adds full geo-verification enforcement end to end: the admin geofence form/action now make verification mandatory whenever a geofence is enabled (no extra toggle) and auto-sync `location_verification_required`, while the mobile clients always run the permission + verification flow for those conventions using the strengthened `useLocationPermission` hook. Added a pg_cron-powered `purge_geo_verification_data()` job that clears verification attempts and stored coordinates a day after each convention ends, documenting the immediate Phase 4/5 rollout plus retention details in the PRD. Updated Expo deps to the required SDK versions and fixed lint/typecheck nits so `npm run ci:validate` succeeds.
Resolves TAILTAG-29