### PR TITLE
Fix Password Reset and OAuth Set

### DIFF
--- a/app/(auth)/forgot-password.tsx
+++ b/app/(auth)/forgot-password.tsx
@@ -39,7 +39,7 @@ export default function ForgotPasswordScreen() {
 
     try {
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(trimmedEmail, {
-        redirectTo: 'tailtag://reset-password',
+        redirectTo: 'https://playtailtag.com/reset-password',
       });
 
       if (resetError) {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -69,8 +69,7 @@ import {
 } from '../../src/features/suits/forms/socialLinks';
 import { canUseStaffMode } from '../../src/features/staff-mode/constants';
 import {
-  CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY,
-  fetchCurrentUserHasPasswordCredential,
+  createCurrentUserHasPasswordCredentialQueryOptions,
   inferPasswordCredentialFromSession,
 } from '../../src/features/auth/utils/passwordCredential';
 import {
@@ -90,8 +89,6 @@ const TERMS_URL = 'https://playtailtag.com/terms';
 const DELETE_ACCOUNT_URL = 'https://playtailtag.com/delete-account';
 const SUPPORT_EMAIL_URL = 'mailto:finn@finnthepanther.com';
 const SAVE_PROFILE_FEEDBACK_DURATION_MS = 2200;
-const PASSWORD_CREDENTIAL_STALE_TIME = 60_000;
-
 export default function SettingsScreen() {
   const router = useRouter();
   const { session, forceSignOut } = useAuth();
@@ -99,18 +96,9 @@ export default function SettingsScreen() {
   const accountEmail = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = accountEmail.length > 0;
   const fallbackHasPasswordCredential = inferPasswordCredentialFromSession(session?.user);
-  const passwordCredentialQueryKey = useMemo(
-    () => [CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY, userId] as const,
-    [userId],
+  const { data: hasPasswordCredentialFromServer = null } = useQuery<boolean | null, Error>(
+    createCurrentUserHasPasswordCredentialQueryOptions(userId),
   );
-  const { data: hasPasswordCredentialFromServer = null } = useQuery<boolean | null, Error>({
-    queryKey: passwordCredentialQueryKey,
-    enabled: Boolean(userId),
-    staleTime: PASSWORD_CREDENTIAL_STALE_TIME,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-    queryFn: async () => fetchCurrentUserHasPasswordCredential(),
-  });
   const hasPasswordCredential = hasPasswordCredentialFromServer ?? fallbackHasPasswordCredential;
   const passwordActionLabel = hasPasswordCredential ? 'Change password' : 'Set password';
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -92,10 +92,12 @@ export default function SettingsScreen() {
   const userId = session?.user.id ?? null;
   const accountEmail = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = accountEmail.length > 0;
+  const hasPasswordCredentialMetadata = session?.user?.user_metadata?.has_password === true;
   const hasPasswordIdentity = Boolean(
     session?.user?.identities?.some((i) => i.provider === 'email'),
   );
-  const passwordActionLabel = hasPasswordIdentity ? 'Change password' : 'Set password';
+  const hasPasswordCredential = hasPasswordIdentity || hasPasswordCredentialMetadata;
+  const passwordActionLabel = hasPasswordCredential ? 'Change password' : 'Set password';
 
   const queryClient = useQueryClient();
   const profileQueryKey = useMemo(() => [PROFILE_QUERY_KEY, userId] as const, [userId]);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -68,6 +68,7 @@ import {
   socialLinksToSave,
 } from '../../src/features/suits/forms/socialLinks';
 import { canUseStaffMode } from '../../src/features/staff-mode/constants';
+import { hasPasswordCredential as userHasPasswordCredential } from '../../src/features/auth/utils/passwordCredential';
 import {
   CAUGHT_SUITS_QUERY_KEY,
   CAUGHT_SUITS_STALE_TIME,
@@ -92,11 +93,7 @@ export default function SettingsScreen() {
   const userId = session?.user.id ?? null;
   const accountEmail = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = accountEmail.length > 0;
-  const hasPasswordCredentialMetadata = session?.user?.user_metadata?.has_password === true;
-  const hasPasswordIdentity = Boolean(
-    session?.user?.identities?.some((i) => i.provider === 'email'),
-  );
-  const hasPasswordCredential = hasPasswordIdentity || hasPasswordCredentialMetadata;
+  const hasPasswordCredential = userHasPasswordCredential(session?.user);
   const passwordActionLabel = hasPasswordCredential ? 'Change password' : 'Set password';
 
   const queryClient = useQueryClient();

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -68,7 +68,11 @@ import {
   socialLinksToSave,
 } from '../../src/features/suits/forms/socialLinks';
 import { canUseStaffMode } from '../../src/features/staff-mode/constants';
-import { hasPasswordCredential as userHasPasswordCredential } from '../../src/features/auth/utils/passwordCredential';
+import {
+  CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY,
+  fetchCurrentUserHasPasswordCredential,
+  inferPasswordCredentialFromSession,
+} from '../../src/features/auth/utils/passwordCredential';
 import {
   CAUGHT_SUITS_QUERY_KEY,
   CAUGHT_SUITS_STALE_TIME,
@@ -86,6 +90,7 @@ const TERMS_URL = 'https://playtailtag.com/terms';
 const DELETE_ACCOUNT_URL = 'https://playtailtag.com/delete-account';
 const SUPPORT_EMAIL_URL = 'mailto:finn@finnthepanther.com';
 const SAVE_PROFILE_FEEDBACK_DURATION_MS = 2200;
+const PASSWORD_CREDENTIAL_STALE_TIME = 60_000;
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -93,7 +98,20 @@ export default function SettingsScreen() {
   const userId = session?.user.id ?? null;
   const accountEmail = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = accountEmail.length > 0;
-  const hasPasswordCredential = userHasPasswordCredential(session?.user);
+  const fallbackHasPasswordCredential = inferPasswordCredentialFromSession(session?.user);
+  const passwordCredentialQueryKey = useMemo(
+    () => [CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY, userId] as const,
+    [userId],
+  );
+  const { data: hasPasswordCredentialFromServer = null } = useQuery<boolean | null, Error>({
+    queryKey: passwordCredentialQueryKey,
+    enabled: Boolean(userId),
+    staleTime: PASSWORD_CREDENTIAL_STALE_TIME,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    queryFn: async () => fetchCurrentUserHasPasswordCredential(),
+  });
+  const hasPasswordCredential = hasPasswordCredentialFromServer ?? fallbackHasPasswordCredential;
   const passwordActionLabel = hasPasswordCredential ? 'Change password' : 'Set password';
 
   const queryClient = useQueryClient();

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -90,9 +90,12 @@ export default function SettingsScreen() {
   const router = useRouter();
   const { session, forceSignOut } = useAuth();
   const userId = session?.user.id ?? null;
+  const accountEmail = session?.user?.email?.trim() ?? '';
+  const hasEmailAddress = accountEmail.length > 0;
   const hasPasswordIdentity = Boolean(
     session?.user?.identities?.some((i) => i.provider === 'email'),
   );
+  const passwordActionLabel = hasPasswordIdentity ? 'Change password' : 'Set password';
 
   const queryClient = useQueryClient();
   const profileQueryKey = useMemo(() => [PROFILE_QUERY_KEY, userId] as const, [userId]);
@@ -1515,14 +1518,26 @@ export default function SettingsScreen() {
           <Text style={styles.sectionDescription}>
             Log out of TailTag or delete your account entirely.
           </Text>
-          {hasPasswordIdentity ? (
+          {hasEmailAddress ? (
             <TailTagButton
               variant="outline"
               onPress={() => router.push('/change-password')}
             >
-              Change password
+              {passwordActionLabel}
             </TailTagButton>
-          ) : null}
+          ) : (
+            <>
+              <TailTagButton
+                variant="outline"
+                disabled
+              >
+                Set password
+              </TailTagButton>
+              <Text style={styles.sectionHint}>
+                Password sign-in is unavailable because this account does not have an email address.
+              </Text>
+            </>
+          )}
           {signOutError ? <Text style={styles.error}>{signOutError}</Text> : null}
           <TailTagButton
             onPress={handleSignOut}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -62,9 +62,13 @@ function RootLayoutNav() {
   const router = useRouter();
   const { status, session } = useAuth();
   const segments = useSegments();
-  const inAuthGroup = segments.length > 0 && segments[0] === '(auth)';
-  const inOnboardingFlow = segments.length > 0 && segments[0] === 'onboarding';
-  const inResetPasswordFlow = segments.length > 0 && segments[0] === 'reset-password';
+  const firstSegment = segments[0];
+  const secondSegment = segments.at(1);
+  const inAuthGroup = firstSegment === '(auth)';
+  const inAuthCallbackFlow = firstSegment === 'auth' && secondSegment === 'callback';
+  const inOnboardingFlow = firstSegment === 'onboarding';
+  const inResetPasswordFlow = firstSegment === 'reset-password';
+  const inPublicAuthFlow = inAuthGroup || inAuthCallbackFlow || inResetPasswordFlow;
   const userId = session?.user.id ?? null;
   const setNavigationReady = useSetNavigationReady();
 
@@ -107,7 +111,7 @@ function RootLayoutNav() {
 
   let redirectHref: '/' | '/auth' | '/onboarding' | null = null;
 
-  if (!session && !inAuthGroup) {
+  if (!session && !inPublicAuthFlow) {
     redirectHref = '/auth';
   } else if (session && inAuthGroup && !shouldResolvePostAuthDestination) {
     redirectHref = shouldGateOnboarding ? '/onboarding' : '/';
@@ -152,7 +156,7 @@ function RootLayoutNav() {
   }
 
   // Not signed in: ensure we're in the auth stack.
-  if (!session && !inAuthGroup) {
+  if (!session && !inPublicAuthFlow) {
     return <Redirect href="/auth" />;
   }
 

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -184,8 +184,7 @@ export default function ChangePasswordScreen() {
               autoComplete="password-new"
               placeholder="8+ chars, mixed case, number, symbol"
               editable={!isSubmitting}
-              returnKeyType={hasPasswordIdentity ? 'next' : 'done'}
-              onSubmitEditing={hasPasswordIdentity ? undefined : handleSubmit}
+              returnKeyType="next"
             />
             <PasswordStrengthIndicator password={newPassword} />
           </View>

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { KeyboardAwareFormWrapper } from '../src/components/ui/KeyboardAwareFormWrapper';
 import { PasswordInput } from '../src/components/ui/PasswordInput';
@@ -25,6 +25,7 @@ const PASSWORD_CREDENTIAL_STALE_TIME = 60_000;
 
 export default function ChangePasswordScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { session } = useAuth();
   const userId = session?.user.id ?? null;
   const fallbackHasPasswordCredential = inferPasswordCredentialFromSession(session?.user);
@@ -79,10 +80,12 @@ export default function ChangePasswordScreen() {
     }
 
     let hasPasswordCredentialAtSubmit =
-      hasPasswordCredentialFromServer ?? fallbackHasPasswordCredential;
+      forceRequireCurrentPassword ||
+      (hasPasswordCredentialFromServer ?? fallbackHasPasswordCredential);
     if (!hasPasswordCredentialAtSubmit) {
       try {
         hasPasswordCredentialAtSubmit = await fetchCurrentUserHasPasswordCredential();
+        queryClient.setQueryData(passwordCredentialQueryKey, hasPasswordCredentialAtSubmit);
       } catch {
         // Keep using the best available local signal.
       }
@@ -132,6 +135,8 @@ export default function ChangePasswordScreen() {
         throw updateError;
       }
 
+      queryClient.setQueryData(passwordCredentialQueryKey, true);
+      void queryClient.invalidateQueries({ queryKey: passwordCredentialQueryKey });
       setSuccessMode(modeAtSubmit);
       setSuccess(true);
     } catch (caught) {

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -18,6 +18,16 @@ import { styles } from '../src/app-styles/reset-password.styles';
 export default function ChangePasswordScreen() {
   const router = useRouter();
   const { session } = useAuth();
+  const hasPasswordIdentity = Boolean(
+    session?.user?.identities?.some((identity) => identity.provider === 'email'),
+  );
+  const email = session?.user?.email?.trim() ?? '';
+  const hasEmailAddress = email.length > 0;
+  const screenTitle = hasPasswordIdentity ? 'Change password' : 'Set password';
+  const successTitle = hasPasswordIdentity ? 'Password changed' : 'Password set';
+  const successSubtitle = hasPasswordIdentity
+    ? 'Your password has been updated successfully.'
+    : 'You can now sign in with email and password.';
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -40,17 +50,21 @@ export default function ChangePasswordScreen() {
       return;
     }
 
-    if (newPassword === currentPassword) {
+    if (hasPasswordIdentity && currentPassword.trim().length === 0) {
+      setSubmitError('Enter your current password to continue.');
+      return;
+    }
+
+    if (hasPasswordIdentity && newPassword === currentPassword) {
       setSubmitError('New password must be different from your current password.');
       return;
     }
 
-    const email = session?.user?.email;
-    if (!email) {
+    if (!hasEmailAddress) {
       captureHandledException(new Error('Change password: no email on session'), {
         scope: 'auth.changePassword',
       });
-      setSubmitError('Something went wrong. Please try again.');
+      setSubmitError('Password sign-in is unavailable because this account has no email address.');
       return;
     }
 
@@ -58,18 +72,20 @@ export default function ChangePasswordScreen() {
     setSubmitError(null);
 
     try {
-      const { error: signInError } = await supabase.auth.signInWithPassword({
-        email,
-        password: currentPassword,
-      });
+      if (hasPasswordIdentity) {
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email,
+          password: currentPassword,
+        });
 
-      if (signInError) {
-        const isCredentialsError =
-          signInError.message === 'Invalid login credentials' || signInError.status === 400;
-        setSubmitError(
-          isCredentialsError ? 'Current password is incorrect.' : mapAuthError(signInError),
-        );
-        return;
+        if (signInError) {
+          const isCredentialsError =
+            signInError.message === 'Invalid login credentials' || signInError.status === 400;
+          setSubmitError(
+            isCredentialsError ? 'Current password is incorrect.' : mapAuthError(signInError),
+          );
+          return;
+        }
       }
 
       const { error: updateError } = await supabase.auth.updateUser({
@@ -96,16 +112,38 @@ export default function ChangePasswordScreen() {
         edges={['bottom']}
       >
         <ScreenHeader
-          title="Change password"
+          title={screenTitle}
           onBack={() => router.back()}
         />
         <KeyboardAwareFormWrapper contentContainerStyle={styles.container}>
           <View style={styles.header}>
-            <Text style={styles.title}>Password changed</Text>
-            <Text style={styles.subtitle}>Your password has been updated successfully.</Text>
+            <Text style={styles.title}>{successTitle}</Text>
+            <Text style={styles.subtitle}>{successSubtitle}</Text>
           </View>
 
           <TailTagCard style={styles.formCard}>
+            <TailTagButton onPress={() => router.back()}>Back to settings</TailTagButton>
+          </TailTagCard>
+        </KeyboardAwareFormWrapper>
+      </SafeAreaView>
+    );
+  }
+
+  if (!hasEmailAddress) {
+    return (
+      <SafeAreaView
+        style={styles.safeArea}
+        edges={['bottom']}
+      >
+        <ScreenHeader
+          title={screenTitle}
+          onBack={() => router.back()}
+        />
+        <KeyboardAwareFormWrapper contentContainerStyle={styles.container}>
+          <TailTagCard style={styles.formCard}>
+            <Text style={styles.errorText}>
+              Password sign-in is unavailable because this account does not have an email address.
+            </Text>
             <TailTagButton onPress={() => router.back()}>Back to settings</TailTagButton>
           </TailTagCard>
         </KeyboardAwareFormWrapper>
@@ -119,22 +157,24 @@ export default function ChangePasswordScreen() {
       edges={['bottom']}
     >
       <ScreenHeader
-        title="Change password"
+        title={screenTitle}
         onBack={() => router.back()}
       />
       <KeyboardAwareFormWrapper contentContainerStyle={styles.container}>
         <TailTagCard style={styles.formCard}>
-          <View style={styles.fieldGroup}>
-            <Text style={styles.label}>Current password</Text>
-            <PasswordInput
-              value={currentPassword}
-              onChangeText={setCurrentPassword}
-              autoComplete="password"
-              placeholder="Enter your current password"
-              editable={!isSubmitting}
-              returnKeyType="next"
-            />
-          </View>
+          {hasPasswordIdentity ? (
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Current password</Text>
+              <PasswordInput
+                value={currentPassword}
+                onChangeText={setCurrentPassword}
+                autoComplete="password"
+                placeholder="Enter your current password"
+                editable={!isSubmitting}
+                returnKeyType="next"
+              />
+            </View>
+          ) : null}
 
           <View style={styles.fieldGroup}>
             <Text style={styles.label}>New password</Text>
@@ -144,7 +184,8 @@ export default function ChangePasswordScreen() {
               autoComplete="password-new"
               placeholder="8+ chars, mixed case, number, symbol"
               editable={!isSubmitting}
-              returnKeyType="next"
+              returnKeyType={hasPasswordIdentity ? 'next' : 'done'}
+              onSubmitEditing={hasPasswordIdentity ? undefined : handleSubmit}
             />
             <PasswordStrengthIndicator password={newPassword} />
           </View>

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -12,16 +12,15 @@ import { TailTagCard } from '../src/components/ui/TailTagCard';
 import { PasswordStrengthIndicator } from '../src/features/auth/components/PasswordStrengthIndicator';
 import { useAuth } from '../src/features/auth';
 import {
-  CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY,
+  createCurrentUserHasPasswordCredentialQueryOptions,
   fetchCurrentUserHasPasswordCredential,
   inferPasswordCredentialFromSession,
+  currentUserHasPasswordCredentialQueryKey,
 } from '../src/features/auth/utils/passwordCredential';
 import { supabase } from '../src/lib/supabase';
 import { captureHandledException } from '../src/lib/sentry';
 import { mapAuthError, validatePassword } from '../src/utils/authValidation';
 import { styles } from '../src/app-styles/reset-password.styles';
-
-const PASSWORD_CREDENTIAL_STALE_TIME = 60_000;
 
 export default function ChangePasswordScreen() {
   const router = useRouter();
@@ -29,18 +28,10 @@ export default function ChangePasswordScreen() {
   const { session } = useAuth();
   const userId = session?.user.id ?? null;
   const fallbackHasPasswordCredential = inferPasswordCredentialFromSession(session?.user);
-  const passwordCredentialQueryKey = useMemo(
-    () => [CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY, userId] as const,
-    [userId],
+  const passwordCredentialQueryKey = currentUserHasPasswordCredentialQueryKey(userId);
+  const { data: hasPasswordCredentialFromServer = null } = useQuery<boolean | null, Error>(
+    createCurrentUserHasPasswordCredentialQueryOptions(userId),
   );
-  const { data: hasPasswordCredentialFromServer = null } = useQuery<boolean | null, Error>({
-    queryKey: passwordCredentialQueryKey,
-    enabled: Boolean(userId),
-    staleTime: PASSWORD_CREDENTIAL_STALE_TIME,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-    queryFn: async () => fetchCurrentUserHasPasswordCredential(),
-  });
   const [forceRequireCurrentPassword, setForceRequireCurrentPassword] = useState(false);
   const hasPasswordCredential =
     forceRequireCurrentPassword ||

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -10,6 +10,7 @@ import { TailTagButton } from '../src/components/ui/TailTagButton';
 import { TailTagCard } from '../src/components/ui/TailTagCard';
 import { PasswordStrengthIndicator } from '../src/features/auth/components/PasswordStrengthIndicator';
 import { useAuth } from '../src/features/auth';
+import { hasPasswordCredential as userHasPasswordCredential } from '../src/features/auth/utils/passwordCredential';
 import { supabase } from '../src/lib/supabase';
 import { captureHandledException } from '../src/lib/sentry';
 import { mapAuthError, validatePassword } from '../src/utils/authValidation';
@@ -18,11 +19,7 @@ import { styles } from '../src/app-styles/reset-password.styles';
 export default function ChangePasswordScreen() {
   const router = useRouter();
   const { session } = useAuth();
-  const hasPasswordCredentialMetadata = session?.user?.user_metadata?.has_password === true;
-  const hasPasswordIdentity = Boolean(
-    session?.user?.identities?.some((identity) => identity.provider === 'email'),
-  );
-  const hasPasswordCredential = hasPasswordIdentity || hasPasswordCredentialMetadata;
+  const hasPasswordCredential = userHasPasswordCredential(session?.user);
   const email = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = email.length > 0;
   const screenTitle = hasPasswordCredential ? 'Change password' : 'Set password';

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -18,14 +18,16 @@ import { styles } from '../src/app-styles/reset-password.styles';
 export default function ChangePasswordScreen() {
   const router = useRouter();
   const { session } = useAuth();
+  const hasPasswordCredentialMetadata = session?.user?.user_metadata?.has_password === true;
   const hasPasswordIdentity = Boolean(
     session?.user?.identities?.some((identity) => identity.provider === 'email'),
   );
+  const hasPasswordCredential = hasPasswordIdentity || hasPasswordCredentialMetadata;
   const email = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = email.length > 0;
-  const screenTitle = hasPasswordIdentity ? 'Change password' : 'Set password';
-  const successTitle = hasPasswordIdentity ? 'Password changed' : 'Password set';
-  const successSubtitle = hasPasswordIdentity
+  const screenTitle = hasPasswordCredential ? 'Change password' : 'Set password';
+  const successTitle = hasPasswordCredential ? 'Password changed' : 'Password set';
+  const successSubtitle = hasPasswordCredential
     ? 'Your password has been updated successfully.'
     : 'You can now sign in with email and password.';
 
@@ -50,12 +52,12 @@ export default function ChangePasswordScreen() {
       return;
     }
 
-    if (hasPasswordIdentity && currentPassword.trim().length === 0) {
+    if (hasPasswordCredential && currentPassword.trim().length === 0) {
       setSubmitError('Enter your current password to continue.');
       return;
     }
 
-    if (hasPasswordIdentity && newPassword === currentPassword) {
+    if (hasPasswordCredential && newPassword === currentPassword) {
       setSubmitError('New password must be different from your current password.');
       return;
     }
@@ -72,7 +74,7 @@ export default function ChangePasswordScreen() {
     setSubmitError(null);
 
     try {
-      if (hasPasswordIdentity) {
+      if (hasPasswordCredential) {
         const { error: signInError } = await supabase.auth.signInWithPassword({
           email,
           password: currentPassword,
@@ -90,6 +92,10 @@ export default function ChangePasswordScreen() {
 
       const { error: updateError } = await supabase.auth.updateUser({
         password: newPassword,
+        data: {
+          has_password: true,
+          password_set_at: new Date().toISOString(),
+        },
       });
 
       if (updateError) {
@@ -162,7 +168,7 @@ export default function ChangePasswordScreen() {
       />
       <KeyboardAwareFormWrapper contentContainerStyle={styles.container}>
         <TailTagCard style={styles.formCard}>
-          {hasPasswordIdentity ? (
+          {hasPasswordCredential ? (
             <View style={styles.fieldGroup}>
               <Text style={styles.label}>Current password</Text>
               <PasswordInput

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -26,10 +26,6 @@ export default function ChangePasswordScreen() {
   const email = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = email.length > 0;
   const screenTitle = hasPasswordCredential ? 'Change password' : 'Set password';
-  const successTitle = hasPasswordCredential ? 'Password changed' : 'Password set';
-  const successSubtitle = hasPasswordCredential
-    ? 'Your password has been updated successfully.'
-    : 'You can now sign in with email and password.';
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -37,9 +33,11 @@ export default function ChangePasswordScreen() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [successMode, setSuccessMode] = useState<'set' | 'change' | null>(null);
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
+    const modeAtSubmit: 'set' | 'change' = hasPasswordCredential ? 'change' : 'set';
 
     const validation = validatePassword(newPassword);
     if (!validation.isAcceptable) {
@@ -102,6 +100,7 @@ export default function ChangePasswordScreen() {
         throw updateError;
       }
 
+      setSuccessMode(modeAtSubmit);
       setSuccess(true);
     } catch (caught) {
       captureHandledException(caught, { scope: 'auth.changePassword' });
@@ -112,19 +111,26 @@ export default function ChangePasswordScreen() {
   };
 
   if (success) {
+    const successHeaderTitle = successMode === 'set' ? 'Set password' : 'Change password';
+    const successScreenTitle = successMode === 'set' ? 'Password set' : 'Password changed';
+    const successScreenSubtitle =
+      successMode === 'set'
+        ? 'You can now sign in with email and password.'
+        : 'Your password has been updated successfully.';
+
     return (
       <SafeAreaView
         style={styles.safeArea}
         edges={['bottom']}
       >
         <ScreenHeader
-          title={screenTitle}
+          title={successHeaderTitle}
           onBack={() => router.back()}
         />
         <KeyboardAwareFormWrapper contentContainerStyle={styles.container}>
           <View style={styles.header}>
-            <Text style={styles.title}>{successTitle}</Text>
-            <Text style={styles.subtitle}>{successSubtitle}</Text>
+            <Text style={styles.title}>{successScreenTitle}</Text>
+            <Text style={styles.subtitle}>{successScreenSubtitle}</Text>
           </View>
 
           <TailTagCard style={styles.formCard}>

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -42,7 +42,8 @@ export default function ChangePasswordScreen() {
   });
   const [forceRequireCurrentPassword, setForceRequireCurrentPassword] = useState(false);
   const hasPasswordCredential =
-    forceRequireCurrentPassword || hasPasswordCredentialFromServer || fallbackHasPasswordCredential;
+    forceRequireCurrentPassword ||
+    (hasPasswordCredentialFromServer ?? fallbackHasPasswordCredential);
   const email = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = email.length > 0;
   const screenTitle = hasPasswordCredential ? 'Change password' : 'Set password';

--- a/app/change-password.tsx
+++ b/app/change-password.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
 
 import { KeyboardAwareFormWrapper } from '../src/components/ui/KeyboardAwareFormWrapper';
 import { PasswordInput } from '../src/components/ui/PasswordInput';
@@ -10,16 +11,38 @@ import { TailTagButton } from '../src/components/ui/TailTagButton';
 import { TailTagCard } from '../src/components/ui/TailTagCard';
 import { PasswordStrengthIndicator } from '../src/features/auth/components/PasswordStrengthIndicator';
 import { useAuth } from '../src/features/auth';
-import { hasPasswordCredential as userHasPasswordCredential } from '../src/features/auth/utils/passwordCredential';
+import {
+  CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY,
+  fetchCurrentUserHasPasswordCredential,
+  inferPasswordCredentialFromSession,
+} from '../src/features/auth/utils/passwordCredential';
 import { supabase } from '../src/lib/supabase';
 import { captureHandledException } from '../src/lib/sentry';
 import { mapAuthError, validatePassword } from '../src/utils/authValidation';
 import { styles } from '../src/app-styles/reset-password.styles';
 
+const PASSWORD_CREDENTIAL_STALE_TIME = 60_000;
+
 export default function ChangePasswordScreen() {
   const router = useRouter();
   const { session } = useAuth();
-  const hasPasswordCredential = userHasPasswordCredential(session?.user);
+  const userId = session?.user.id ?? null;
+  const fallbackHasPasswordCredential = inferPasswordCredentialFromSession(session?.user);
+  const passwordCredentialQueryKey = useMemo(
+    () => [CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY, userId] as const,
+    [userId],
+  );
+  const { data: hasPasswordCredentialFromServer = null } = useQuery<boolean | null, Error>({
+    queryKey: passwordCredentialQueryKey,
+    enabled: Boolean(userId),
+    staleTime: PASSWORD_CREDENTIAL_STALE_TIME,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    queryFn: async () => fetchCurrentUserHasPasswordCredential(),
+  });
+  const [forceRequireCurrentPassword, setForceRequireCurrentPassword] = useState(false);
+  const hasPasswordCredential =
+    forceRequireCurrentPassword || hasPasswordCredentialFromServer || fallbackHasPasswordCredential;
   const email = session?.user?.email?.trim() ?? '';
   const hasEmailAddress = email.length > 0;
   const screenTitle = hasPasswordCredential ? 'Change password' : 'Set password';
@@ -34,7 +57,6 @@ export default function ChangePasswordScreen() {
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    const modeAtSubmit: 'set' | 'change' = hasPasswordCredential ? 'change' : 'set';
 
     const validation = validatePassword(newPassword);
     if (!validation.isAcceptable) {
@@ -47,16 +69,6 @@ export default function ChangePasswordScreen() {
       return;
     }
 
-    if (hasPasswordCredential && currentPassword.trim().length === 0) {
-      setSubmitError('Enter your current password to continue.');
-      return;
-    }
-
-    if (hasPasswordCredential && newPassword === currentPassword) {
-      setSubmitError('New password must be different from your current password.');
-      return;
-    }
-
     if (!hasEmailAddress) {
       captureHandledException(new Error('Change password: no email on session'), {
         scope: 'auth.changePassword',
@@ -65,11 +77,37 @@ export default function ChangePasswordScreen() {
       return;
     }
 
+    let hasPasswordCredentialAtSubmit =
+      hasPasswordCredentialFromServer ?? fallbackHasPasswordCredential;
+    if (!hasPasswordCredentialAtSubmit) {
+      try {
+        hasPasswordCredentialAtSubmit = await fetchCurrentUserHasPasswordCredential();
+      } catch {
+        // Keep using the best available local signal.
+      }
+    }
+
+    if (hasPasswordCredentialAtSubmit) {
+      setForceRequireCurrentPassword(true);
+    }
+
+    const modeAtSubmit: 'set' | 'change' = hasPasswordCredentialAtSubmit ? 'change' : 'set';
+
+    if (hasPasswordCredentialAtSubmit && currentPassword.trim().length === 0) {
+      setSubmitError('Enter your current password to continue.');
+      return;
+    }
+
+    if (hasPasswordCredentialAtSubmit && newPassword === currentPassword) {
+      setSubmitError('New password must be different from your current password.');
+      return;
+    }
+
     setIsSubmitting(true);
     setSubmitError(null);
 
     try {
-      if (hasPasswordCredential) {
+      if (hasPasswordCredentialAtSubmit) {
         const { error: signInError } = await supabase.auth.signInWithPassword({
           email,
           password: currentPassword,
@@ -87,10 +125,6 @@ export default function ChangePasswordScreen() {
 
       const { error: updateError } = await supabase.auth.updateUser({
         password: newPassword,
-        data: {
-          has_password: true,
-          password_set_at: new Date().toISOString(),
-        },
       });
 
       if (updateError) {

--- a/app/reset-password.tsx
+++ b/app/reset-password.tsx
@@ -118,6 +118,10 @@ export default function ResetPasswordScreen() {
     try {
       const { error: updateError } = await supabase.auth.updateUser({
         password,
+        data: {
+          has_password: true,
+          password_set_at: new Date().toISOString(),
+        },
       });
 
       if (updateError) {

--- a/app/reset-password.tsx
+++ b/app/reset-password.tsx
@@ -118,10 +118,6 @@ export default function ResetPasswordScreen() {
     try {
       const { error: updateError } = await supabase.auth.updateUser({
         password,
-        data: {
-          has_password: true,
-          password_set_at: new Date().toISOString(),
-        },
       });
 
       if (updateError) {

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -168,8 +168,14 @@ Configure in the Supabase dashboard under **Authentication > Providers**.
 
 ### Auth URL Configuration
 
-- **Site URL**: Set to the appropriate deep link or app scheme per environment
-- **Redirect URLs**: Add environment-specific allowed redirect URLs
+- **Dev project (`rtxbvjicfxgcouufumce`)**
+  - **Site URL**: `https://playtailtag.com`
+  - **Redirect URLs** must include:
+    - `tailtag://auth/callback`
+    - `tailtag://reset-password`
+    - `https://playtailtag.com/reset-password`
+- **Promotion to staging/production**: after validating password reset and OAuth callback in dev,
+  copy the same URL rules to staging and production Supabase Auth settings.
 
 ---
 

--- a/src/features/auth/utils/passwordCredential.ts
+++ b/src/features/auth/utils/passwordCredential.ts
@@ -1,17 +1,29 @@
 import type { User } from '@supabase/supabase-js';
 
-const HAS_PASSWORD_METADATA_KEY = 'has_password';
-const EMAIL_PROVIDER = 'email';
+import { supabase } from '../../../lib/supabase';
 
-export function hasPasswordCredential(user: User | null | undefined): boolean {
+const EMAIL_PROVIDER = 'email';
+export const CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY =
+  'current-user-has-password-credential';
+
+export function inferPasswordCredentialFromSession(user: User | null | undefined): boolean {
   if (!user) {
     return false;
   }
 
-  const hasPasswordCredentialMetadata = user.user_metadata?.[HAS_PASSWORD_METADATA_KEY] === true;
   const hasPasswordIdentity = user.identities?.some(
     (identity) => identity.provider === EMAIL_PROVIDER,
   );
 
-  return Boolean(hasPasswordIdentity) || hasPasswordCredentialMetadata;
+  return Boolean(hasPasswordIdentity);
+}
+
+export async function fetchCurrentUserHasPasswordCredential(): Promise<boolean> {
+  const { data, error } = await (supabase as any).rpc('current_user_has_password_credential');
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data === true;
 }

--- a/src/features/auth/utils/passwordCredential.ts
+++ b/src/features/auth/utils/passwordCredential.ts
@@ -5,6 +5,19 @@ import { supabase } from '../../../lib/supabase';
 const EMAIL_PROVIDER = 'email';
 export const CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY =
   'current-user-has-password-credential';
+export const PASSWORD_CREDENTIAL_STALE_TIME = 60_000;
+
+export const currentUserHasPasswordCredentialQueryKey = (userId: string | null) =>
+  [CURRENT_USER_HAS_PASSWORD_CREDENTIAL_QUERY_KEY, userId] as const;
+
+export const createCurrentUserHasPasswordCredentialQueryOptions = (userId: string | null) => ({
+  queryKey: currentUserHasPasswordCredentialQueryKey(userId),
+  enabled: Boolean(userId),
+  staleTime: PASSWORD_CREDENTIAL_STALE_TIME,
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+  queryFn: () => fetchCurrentUserHasPasswordCredential(),
+});
 
 export function inferPasswordCredentialFromSession(user: User | null | undefined): boolean {
   if (!user) {

--- a/src/features/auth/utils/passwordCredential.ts
+++ b/src/features/auth/utils/passwordCredential.ts
@@ -1,0 +1,17 @@
+import type { User } from '@supabase/supabase-js';
+
+const HAS_PASSWORD_METADATA_KEY = 'has_password';
+const EMAIL_PROVIDER = 'email';
+
+export function hasPasswordCredential(user: User | null | undefined): boolean {
+  if (!user) {
+    return false;
+  }
+
+  const hasPasswordCredentialMetadata = user.user_metadata?.[HAS_PASSWORD_METADATA_KEY] === true;
+  const hasPasswordIdentity = user.identities?.some(
+    (identity) => identity.provider === EMAIL_PROVIDER,
+  );
+
+  return Boolean(hasPasswordIdentity) || hasPasswordCredentialMetadata;
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -132,7 +132,12 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "tailtag://auth/callback",
+  "tailtag://reset-password",
+  "https://playtailtag.com/reset-password",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.

--- a/supabase/migrations/20260422212000_add_current_user_has_password_credential_rpc.sql
+++ b/supabase/migrations/20260422212000_add_current_user_has_password_credential_rpc.sql
@@ -1,0 +1,27 @@
+-- Expose a safe signal for whether the current user has a password credential.
+create or replace function public.current_user_has_password_credential()
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path to 'auth', 'public', 'pg_temp'
+as $function$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from auth.users u
+    where u.id = v_user_id
+      and coalesce(u.encrypted_password, '') <> ''
+  );
+end;
+$function$;
+
+revoke all on function public.current_user_has_password_credential() from public;
+grant execute on function public.current_user_has_password_credential() to authenticated;
+grant execute on function public.current_user_has_password_credential() to service_role;

--- a/web/src/pages/reset-password.astro
+++ b/web/src/pages/reset-password.astro
@@ -1,0 +1,129 @@
+---
+import Base from '../layouts/Base.astro';
+import Footer from '../components/Footer.astro';
+import { siteConfig } from '../config/site';
+
+const supportEmail = siteConfig.links.supportEmail;
+---
+
+<Base title="Reset Password">
+  <article class="flex-1 px-6 py-12 max-w-2xl mx-auto">
+    <h1 class="text-3xl font-bold text-foreground mb-4">Reset Your TailTag Password</h1>
+    <p
+      id="status-text"
+      class="text-foreground/80 mb-8"
+    >
+      Verifying your reset link...
+    </p>
+
+    <section
+      id="valid-state"
+      class="hidden space-y-6"
+    >
+      <p class="text-foreground/80">
+        We found a valid reset session and attempted to open TailTag so you can finish setting your
+        new password in the app.
+      </p>
+
+      <a
+        id="open-tailtag-link"
+        href="tailtag://reset-password"
+        class="inline-flex items-center justify-center rounded-md bg-primary px-5 py-3 font-semibold text-background hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+      >
+        Open TailTag
+      </a>
+
+      <div class="space-y-3 text-foreground/70">
+        <p>If TailTag did not open automatically:</p>
+        <ol class="list-decimal list-inside space-y-1">
+          <li>Tap "Open TailTag" again.</li>
+          <li>Make sure TailTag is installed on this device.</li>
+          <li>Then request a new reset link from the app sign-in screen if needed.</li>
+        </ol>
+      </div>
+    </section>
+
+    <section
+      id="invalid-state"
+      class="hidden space-y-4"
+    >
+      <p class="text-foreground/80">
+        This password reset link is invalid or expired. Request a new reset link from TailTag and
+        use the newest email.
+      </p>
+      <p class="text-foreground/70">
+        Need help? Contact
+        <a
+          href={`mailto:${supportEmail}`}
+          class="text-primary hover:underline ml-1"
+          >{supportEmail}</a
+        >.
+      </p>
+    </section>
+  </article>
+  <Footer />
+</Base>
+
+<script is:inline>
+  (() => {
+    const statusText = document.getElementById('status-text');
+    const validState = document.getElementById('valid-state');
+    const invalidState = document.getElementById('invalid-state');
+    const openTailTagLink = document.getElementById('open-tailtag-link');
+
+    const showElement = (element, shouldShow) => {
+      if (!element) return;
+      element.classList.toggle('hidden', !shouldShow);
+    };
+
+    const mergedParams = new URLSearchParams();
+    const searchParams = new URLSearchParams(window.location.search);
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+
+    searchParams.forEach((value, key) => {
+      if (value.length > 0) {
+        mergedParams.set(key, value);
+      }
+    });
+
+    hashParams.forEach((value, key) => {
+      if (value.length > 0) {
+        mergedParams.set(key, value);
+      }
+    });
+
+    const hasError = mergedParams.has('error') || mergedParams.has('error_code');
+    const hasAccessToken = mergedParams.has('access_token');
+    const hasRefreshToken = mergedParams.has('refresh_token');
+    const isValidRecoveryLink = !hasError && hasAccessToken && hasRefreshToken;
+
+    if (!isValidRecoveryLink) {
+      if (statusText) {
+        statusText.textContent = 'This reset link is invalid or expired.';
+      }
+      showElement(validState, false);
+      showElement(invalidState, true);
+      return;
+    }
+
+    const deepLink = `tailtag://reset-password?${mergedParams.toString()}`;
+    if (openTailTagLink instanceof HTMLAnchorElement) {
+      openTailTagLink.href = deepLink;
+    }
+
+    if (statusText) {
+      statusText.textContent = 'Opening TailTag...';
+    }
+
+    showElement(validState, true);
+    showElement(invalidState, false);
+
+    window.location.assign(deepLink);
+
+    window.setTimeout(() => {
+      if (statusText) {
+        statusText.textContent = 'If TailTag did not open, use the button below.';
+      }
+    }, 1500);
+  })();
+</script>


### PR DESCRIPTION
This PR fixes a bug where users who created an account via OAuth couldn't set a password to sign in with their OAuth email and password. This also fixes a bug where there was no where to properly reset a password after receiving a password reset email.