### PR TITLE
Add Fursuit Maker to Fursuit Profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Unless explicitly stated, all changes, migrations, and Edge Function updates are
 - **Supabase Project Ref:** `rtxbvjicfxgcouufumce`
 - **Project URL:** `https://rtxbvjicfxgcouufumce.supabase.co`
 
-For any work that requires database changes, apply those changes to the dev environment using the Supabase CLI or the MCP if it is already configured. Verify the CLI/MCP target before pushing migrations or schema changes. Never push database changes to staging or production unless explicitly instructed to do so.
+For any work that requires database changes, apply those changes to the dev environment using the Supabase CLI or the MCP (Model Context Protocol) tooling if it is already configured for database/migration access. Verify the Supabase CLI or MCP target before pushing migrations or schema changes. Never push database changes to staging or production unless explicitly instructed to do so.
 
 Only apply changes to other environments (staging, production) if explicitly instructed or after approval.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Unless explicitly stated, all changes, migrations, and Edge Function updates are
 - **Supabase Project Ref:** `rtxbvjicfxgcouufumce`
 - **Project URL:** `https://rtxbvjicfxgcouufumce.supabase.co`
 
+For any work that requires database changes, apply those changes to the dev environment using the Supabase CLI or the MCP if it is already configured. Verify the CLI/MCP target before pushing migrations or schema changes. Never push database changes to staging or production unless explicitly instructed to do so.
+
 Only apply changes to other environments (staging, production) if explicitly instructed or after approval.
 
 ## Security & Configuration Tips

--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -12,9 +12,10 @@ import {
   CAUGHT_SUITS_QUERY_KEY,
   mapLatestFursuitBio,
   mapFursuitColors,
+  fetchFursuitMakersByFursuitIds,
   fursuitDetailQueryKey,
 } from '../../src/features/suits';
-import type { FursuitBio } from '../../src/features/suits';
+import type { FursuitBio, FursuitMaker } from '../../src/features/suits';
 import {
   CONVENTION_LEADERBOARD_QUERY_KEY,
   CONVENTION_SUIT_LEADERBOARD_QUERY_KEY,
@@ -68,6 +69,7 @@ type FursuitDetails = Pick<
   species: string | null;
   bio: FursuitBio | null;
   colors: FursuitColorOption[];
+  makers: FursuitMaker[];
 };
 
 type CatchRecord = {
@@ -226,6 +228,8 @@ export default function CatchScreen() {
         return;
       }
 
+      const makersByFursuitId = await fetchFursuitMakersByFursuitIds([fursuit.id]);
+
       const initialCatchCount =
         typeof (fursuit as any)?.catch_count === 'number' ? (fursuit as any).catch_count : 0;
 
@@ -246,6 +250,7 @@ export default function CatchScreen() {
         created_at: fursuit.created_at ?? null,
         bio: mapLatestFursuitBio((fursuit as any)?.fursuit_bios ?? null),
         colors: mapFursuitColors((fursuit as any)?.color_assignments ?? null),
+        makers: makersByFursuitId.get(fursuit.id) ?? [],
         is_tutorial: fursuit.is_tutorial === true,
       };
 
@@ -473,6 +478,8 @@ export default function CatchScreen() {
         return;
       }
 
+      const makersByFursuitId = await fetchFursuitMakersByFursuitIds([fursuit.id]);
+
       const normalizedFursuit: FursuitDetails = {
         id: fursuit.id,
         name: fursuit.name,
@@ -491,6 +498,7 @@ export default function CatchScreen() {
         created_at: fursuit.created_at ?? null,
         bio: mapLatestFursuitBio((fursuit as any)?.fursuit_bios ?? null),
         colors: mapFursuitColors((fursuit as any)?.color_assignments ?? null),
+        makers: makersByFursuitId.get(fursuit.id) ?? [],
         is_tutorial: false,
       };
 
@@ -690,10 +698,13 @@ export default function CatchScreen() {
               onCodeCopied={handleCatchCodeCopied}
             />
           </View>
-          {caughtFursuit.bio && fursuitBioHasDisplayableContent(caughtFursuit.bio) ? (
+          {fursuitBioHasDisplayableContent(caughtFursuit.bio, caughtFursuit.makers) ? (
             <View style={styles.bioSpacing}>
               <TailTagCard>
-                <FursuitBioDetails bio={caughtFursuit.bio} />
+                <FursuitBioDetails
+                  bio={caughtFursuit.bio}
+                  makers={caughtFursuit.makers}
+                />
               </TailTagCard>
             </View>
           ) : null}

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -53,7 +53,12 @@ import { ConventionToggle } from '../../../src/components/conventions/Convention
 import { createProfileQueryOptions } from '../../../src/features/profile';
 import { emitGameplayEvent } from '../../../src/features/events';
 import { DAILY_TASKS_QUERY_KEY } from '../../../src/features/daily-tasks/hooks';
-import type { FursuitBiosInsert, FursuitsInsert, Json } from '../../../src/types/database';
+import type {
+  FursuitBiosInsert,
+  FursuitMakersInsert,
+  FursuitsInsert,
+  Json,
+} from '../../../src/types/database';
 import {
   ALLOWED_SOCIAL_PLATFORMS,
   CUSTOM_PLATFORM_ID,
@@ -63,6 +68,14 @@ import {
   socialLinksToSave,
 } from '../../../src/features/suits/forms/socialLinks';
 import type { EditableSocialLink } from '../../../src/features/suits/forms/socialLinks';
+import {
+  createEmptyFursuitMaker,
+  createInitialFursuitMakers,
+  FURSUIT_MAKER_LIMIT,
+  fursuitMakersToSave,
+  hasDuplicateFursuitMakers,
+  type EditableFursuitMaker,
+} from '../../../src/features/suits/forms/makers';
 import { styles } from '../../../src/app-styles/(tabs)/suits/add-fursuit.styles';
 
 type UploadCandidate = {
@@ -132,6 +145,7 @@ export default function AddFursuitScreen() {
   const [selectedPronouns, setSelectedPronouns] = useState<string[]>([]);
   const [likesInput, setLikesInput] = useState('');
   const [askMeAboutInput, setAskMeAboutInput] = useState('');
+  const [makers, setMakers] = useState<EditableFursuitMaker[]>(() => createInitialFursuitMakers());
   const [socialLinks, setSocialLinks] = useState<EditableSocialLink[]>(() =>
     createInitialSocialLinks(),
   );
@@ -248,6 +262,7 @@ export default function AddFursuitScreen() {
     () => socialLinks.length < SOCIAL_LINK_LIMIT,
     [socialLinks.length],
   );
+  const makersCanAddMore = useMemo(() => makers.length < FURSUIT_MAKER_LIMIT, [makers.length]);
 
   const profileConventionIdSet = useMemo(
     () => new Set(profileConventionIds),
@@ -413,6 +428,7 @@ export default function AddFursuitScreen() {
     const trimmedAskMeAbout = askMeAboutInput.trim();
     const normalizedSpeciesValue = normalizeSpeciesName(trimmedSpecies);
     const normalizedSocialLinks = socialLinksToSave(socialLinks);
+    const normalizedMakers = fursuitMakersToSave(makers);
     const selectedColorIds = selectedColors.map((color) => color.id);
 
     if (!trimmedName) {
@@ -432,6 +448,16 @@ export default function AddFursuitScreen() {
 
     if (selectedColorIds.length > MAX_FURSUIT_COLORS) {
       setSubmitError('You can choose up to three colors. Remove one to add another.');
+      return;
+    }
+
+    if (normalizedMakers.length > FURSUIT_MAKER_LIMIT) {
+      setSubmitError(`You can add up to ${FURSUIT_MAKER_LIMIT} fursuit makers.`);
+      return;
+    }
+
+    if (hasDuplicateFursuitMakers(normalizedMakers)) {
+      setSubmitError('Remove duplicate fursuit maker names before saving.');
       return;
     }
 
@@ -558,6 +584,21 @@ export default function AddFursuitScreen() {
         }
       }
 
+      if (normalizedMakers.length > 0) {
+        const makerPayload: FursuitMakersInsert[] = normalizedMakers.map((maker) => ({
+          fursuit_id: createdFursuitId!,
+          ...maker,
+        }));
+
+        const { error: makerError } = await (supabase as any)
+          .from('fursuit_makers')
+          .insert(makerPayload);
+
+        if (makerError) {
+          throw makerError;
+        }
+      }
+
       if (allowedConventionIds.length > 0) {
         await Promise.all(
           allowedConventionIds.map((conventionId) =>
@@ -589,6 +630,7 @@ export default function AddFursuitScreen() {
       setSelectedPronouns([]);
       setLikesInput('');
       setAskMeAboutInput('');
+      setMakers(createInitialFursuitMakers());
       setSocialLinks(createInitialSocialLinks());
       setCatchMode('AUTO_ACCEPT');
       setSelectedConventionIds(new Set(activeProfileConventionIds));
@@ -672,6 +714,24 @@ export default function AddFursuitScreen() {
     setSocialLinks((current) => {
       const next = current.filter((entry) => entry.id !== id);
       return next.length > 0 ? next : [createEmptySocialLink()];
+    });
+  };
+
+  const handleMakerNameChange = useCallback((id: string, value: string) => {
+    setMakers((current) =>
+      current.map((entry) => (entry.id === id ? { ...entry, name: value } : entry)),
+    );
+  }, []);
+
+  const handleAddMaker = () => {
+    if (!makersCanAddMore) return;
+    setMakers((current) => [...current, createEmptyFursuitMaker()]);
+  };
+
+  const handleRemoveMaker = (id: string) => {
+    setMakers((current) => {
+      const next = current.filter((entry) => entry.id !== id);
+      return next.length > 0 ? next : [createEmptyFursuitMaker()];
     });
   };
 
@@ -882,6 +942,53 @@ export default function AddFursuitScreen() {
                   </Text>
                 ) : null}
               </>
+            )}
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Fursuit Maker</Text>
+            <Text style={styles.helperLabel}>
+              Add the maker names catchers should see. You can add more than one.
+            </Text>
+            <View style={styles.makerList}>
+              {makers.map((maker, index) => (
+                <View
+                  key={maker.id}
+                  style={styles.makerRow}
+                >
+                  <TailTagInput
+                    value={maker.name}
+                    onChangeText={(value) => handleMakerNameChange(maker.id, value)}
+                    placeholder={index === 0 ? 'Maker name' : 'Another maker'}
+                    editable={!isSubmitting}
+                    returnKeyType={index === makers.length - 1 ? 'done' : 'next'}
+                    style={styles.makerInput}
+                  />
+                  <TailTagButton
+                    variant="ghost"
+                    size="sm"
+                    onPress={() => handleRemoveMaker(maker.id)}
+                    disabled={isSubmitting}
+                    style={styles.makerRemoveButton}
+                  >
+                    Remove
+                  </TailTagButton>
+                </View>
+              ))}
+            </View>
+            {makersCanAddMore ? (
+              <TailTagButton
+                variant="outline"
+                size="sm"
+                onPress={handleAddMaker}
+                disabled={isSubmitting}
+              >
+                Add another maker
+              </TailTagButton>
+            ) : (
+              <Text style={styles.helperLabel}>
+                You can add up to {FURSUIT_MAKER_LIMIT} makers.
+              </Text>
             )}
           </View>
 

--- a/app/catches/[id].tsx
+++ b/app/catches/[id].tsx
@@ -200,8 +200,11 @@ export default function CatchDetailScreen() {
                 </TailTagButton>
               </View>
             ) : null}
-            {details.bio && fursuitBioHasDisplayableContent(details.bio) ? (
-              <FursuitBioDetails bio={details.bio} />
+            {fursuitBioHasDisplayableContent(details.bio, details.makers) ? (
+              <FursuitBioDetails
+                bio={details.bio}
+                makers={details.makers}
+              />
             ) : null}
           </View>
         </TailTagCard>

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -72,7 +72,7 @@ import {
 } from '../../../src/utils/images';
 import { buildAuthenticatedStorageObjectUrl } from '../../../src/utils/supabase-image';
 import { colors } from '../../../src/theme';
-import type { FursuitMakersInsert, Json } from '../../../src/types/database';
+import type { Json } from '../../../src/types/database';
 import { styles } from '../../../src/app-styles/fursuits/[id]/edit.styles';
 
 const PRONOUN_OPTIONS = [
@@ -521,10 +521,9 @@ export default function EditFursuitScreen() {
     const previousCatchMode = initialCatchMode;
     const previousAvatarPath = detail.avatar_path ?? null;
     const previousAvatarUrl = detail.avatar_url;
-    const previousMakers = fursuitMakersToSave(initialMakers);
+    const initialNormalizedMakers = fursuitMakersToSave(initialMakers);
     let updatedCoreRecord = false;
     let replacedColors = false;
-    let replacedMakers = false;
     const addedConventionIds: string[] = [];
     const removedConventionIds: string[] = [];
 
@@ -645,38 +644,21 @@ export default function EditFursuitScreen() {
       }
 
       const makersChanged =
-        previousMakers.length !== normalizedMakers.length ||
-        previousMakers.some(
+        initialNormalizedMakers.length !== normalizedMakers.length ||
+        initialNormalizedMakers.some(
           (maker, index) =>
             maker.maker_name !== normalizedMakers[index]?.maker_name ||
             maker.normalized_maker_name !== normalizedMakers[index]?.normalized_maker_name,
         );
 
       if (makersChanged) {
-        const { error: clearMakersError } = await client
-          .from('fursuit_makers')
-          .delete()
-          .eq('fursuit_id', fursuitId);
+        const { error: replaceMakersError } = await client.rpc('replace_fursuit_makers', {
+          fursuit_id: fursuitId,
+          makers: normalizedMakers,
+        });
 
-        if (clearMakersError) {
-          throw clearMakersError;
-        }
-
-        replacedMakers = true;
-
-        if (normalizedMakers.length > 0) {
-          const makerPayload: FursuitMakersInsert[] = normalizedMakers.map((maker) => ({
-            fursuit_id: fursuitId,
-            ...maker,
-          }));
-
-          const { error: insertMakersError } = await client
-            .from('fursuit_makers')
-            .insert(makerPayload);
-
-          if (insertMakersError) {
-            throw insertMakersError;
-          }
+        if (replaceMakersError) {
+          throw replaceMakersError;
         }
       }
 
@@ -773,35 +755,6 @@ export default function EditFursuitScreen() {
 
         setSelectedColors(previousColors);
         setInitialColors(previousColors);
-      }
-
-      if (replacedMakers) {
-        const { error: revertClearMakersError } = await client
-          .from('fursuit_makers')
-          .delete()
-          .eq('fursuit_id', fursuitId);
-
-        if (revertClearMakersError) {
-          console.warn('Failed to clear maker assignments after error', revertClearMakersError);
-        } else if (previousMakers.length > 0) {
-          const revertMakers: FursuitMakersInsert[] = previousMakers.map((maker) => ({
-            fursuit_id: fursuitId,
-            ...maker,
-          }));
-
-          const { error: revertInsertMakersError } = await client
-            .from('fursuit_makers')
-            .insert(revertMakers);
-
-          if (revertInsertMakersError) {
-            console.warn(
-              'Failed to restore maker assignments after error',
-              revertInsertMakersError,
-            );
-          }
-        }
-
-        setMakers(initialMakers.length > 0 ? initialMakers : createInitialFursuitMakers());
       }
 
       if (updatedCoreRecord) {

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -29,6 +29,14 @@ import {
   socialLinksToSave,
 } from '../../../src/features/suits/forms/socialLinks';
 import {
+  createEmptyFursuitMaker,
+  createInitialFursuitMakers,
+  FURSUIT_MAKER_LIMIT,
+  fursuitMakersToSave,
+  hasDuplicateFursuitMakers,
+  type EditableFursuitMaker,
+} from '../../../src/features/suits/forms/makers';
+import {
   ACTIVE_PROFILE_CONVENTIONS_QUERY_KEY,
   addFursuitConvention,
   CONVENTIONS_STALE_TIME,
@@ -64,7 +72,7 @@ import {
 } from '../../../src/utils/images';
 import { buildAuthenticatedStorageObjectUrl } from '../../../src/utils/supabase-image';
 import { colors } from '../../../src/theme';
-import type { Json } from '../../../src/types/database';
+import type { FursuitMakersInsert, Json } from '../../../src/types/database';
 import { styles } from '../../../src/app-styles/fursuits/[id]/edit.styles';
 
 const PRONOUN_OPTIONS = [
@@ -177,6 +185,8 @@ export default function EditFursuitScreen() {
   const [selectedPronouns, setSelectedPronouns] = useState<string[]>([]);
   const [likesInput, setLikesInput] = useState('');
   const [askMeAboutInput, setAskMeAboutInput] = useState('');
+  const [makers, setMakers] = useState<EditableFursuitMaker[]>(() => createInitialFursuitMakers());
+  const [initialMakers, setInitialMakers] = useState<EditableFursuitMaker[]>([]);
   const [socialLinks, setSocialLinks] = useState<EditableSocialLink[]>(() =>
     createInitialSocialLinks(),
   );
@@ -289,6 +299,16 @@ export default function EditFursuitScreen() {
     setLikesInput(bio?.likesAndInterests ?? '');
     setAskMeAboutInput(bio?.askMeAbout ?? '');
 
+    const mappedMakers =
+      detail.makers.length > 0
+        ? detail.makers.map((maker) => ({
+            id: maker.id,
+            name: maker.name,
+          }))
+        : createInitialFursuitMakers();
+    setMakers(mappedMakers);
+    setInitialMakers(mappedMakers);
+
     const existingLinks = bio?.socialLinks ?? [];
     const linksToMap = existingLinks
       .filter((e) => (e.label?.trim() ?? '') && (e.url?.trim() ?? ''))
@@ -321,6 +341,7 @@ export default function EditFursuitScreen() {
     () => socialLinks.length < SOCIAL_LINK_LIMIT,
     [socialLinks.length],
   );
+  const makersCanAddMore = useMemo(() => makers.length < FURSUIT_MAKER_LIMIT, [makers.length]);
 
   const handleSocialLinkChange = (
     id: string,
@@ -341,6 +362,24 @@ export default function EditFursuitScreen() {
     setSocialLinks((current) => {
       const next = current.filter((entry) => entry.id !== id);
       return next.length > 0 ? next : [createEmptySocialLink()];
+    });
+  };
+
+  const handleMakerNameChange = useCallback((id: string, value: string) => {
+    setMakers((current) =>
+      current.map((entry) => (entry.id === id ? { ...entry, name: value } : entry)),
+    );
+  }, []);
+
+  const handleAddMaker = () => {
+    if (!makersCanAddMore) return;
+    setMakers((current) => [...current, createEmptyFursuitMaker()]);
+  };
+
+  const handleRemoveMaker = (id: string) => {
+    setMakers((current) => {
+      const next = current.filter((entry) => entry.id !== id);
+      return next.length > 0 ? next : [createEmptyFursuitMaker()];
     });
   };
 
@@ -420,6 +459,7 @@ export default function EditFursuitScreen() {
     const normalizedSpeciesValue = normalizeSpeciesName(trimmedSpecies);
 
     const normalizedSocialLinks = socialLinksToSave(socialLinks);
+    const normalizedMakers = fursuitMakersToSave(makers);
     const selectedColorIds = selectedColors.map((color) => color.id);
     const previousColors = initialColors;
     const previousColorIds = previousColors.map((color) => color.id);
@@ -441,6 +481,16 @@ export default function EditFursuitScreen() {
 
     if (selectedColorIds.length > MAX_FURSUIT_COLORS) {
       setSubmitError('You can choose up to three colors. Remove one to add another.');
+      return;
+    }
+
+    if (normalizedMakers.length > FURSUIT_MAKER_LIMIT) {
+      setSubmitError(`You can add up to ${FURSUIT_MAKER_LIMIT} fursuit makers.`);
+      return;
+    }
+
+    if (hasDuplicateFursuitMakers(normalizedMakers)) {
+      setSubmitError('Remove duplicate fursuit maker names before saving.');
       return;
     }
 
@@ -471,8 +521,10 @@ export default function EditFursuitScreen() {
     const previousCatchMode = initialCatchMode;
     const previousAvatarPath = detail.avatar_path ?? null;
     const previousAvatarUrl = detail.avatar_url;
+    const previousMakers = fursuitMakersToSave(initialMakers);
     let updatedCoreRecord = false;
     let replacedColors = false;
+    let replacedMakers = false;
     const addedConventionIds: string[] = [];
     const removedConventionIds: string[] = [];
 
@@ -592,6 +644,42 @@ export default function EditFursuitScreen() {
         }
       }
 
+      const makersChanged =
+        previousMakers.length !== normalizedMakers.length ||
+        previousMakers.some(
+          (maker, index) =>
+            maker.maker_name !== normalizedMakers[index]?.maker_name ||
+            maker.normalized_maker_name !== normalizedMakers[index]?.normalized_maker_name,
+        );
+
+      if (makersChanged) {
+        const { error: clearMakersError } = await client
+          .from('fursuit_makers')
+          .delete()
+          .eq('fursuit_id', fursuitId);
+
+        if (clearMakersError) {
+          throw clearMakersError;
+        }
+
+        replacedMakers = true;
+
+        if (normalizedMakers.length > 0) {
+          const makerPayload: FursuitMakersInsert[] = normalizedMakers.map((maker) => ({
+            fursuit_id: fursuitId,
+            ...maker,
+          }));
+
+          const { error: insertMakersError } = await client
+            .from('fursuit_makers')
+            .insert(makerPayload);
+
+          if (insertMakersError) {
+            throw insertMakersError;
+          }
+        }
+      }
+
       const nextVersion = (detail.bio?.version ?? 0) + 1;
 
       const { error: bioError } = await client.from('fursuit_bios').insert({
@@ -628,6 +716,7 @@ export default function EditFursuitScreen() {
 
       setInitialConventionIds(new Set(selectedConventionIds));
       setInitialColors(selectedColors);
+      setInitialMakers(makers);
       setInitialCatchMode(catchMode);
 
       router.back();
@@ -684,6 +773,35 @@ export default function EditFursuitScreen() {
 
         setSelectedColors(previousColors);
         setInitialColors(previousColors);
+      }
+
+      if (replacedMakers) {
+        const { error: revertClearMakersError } = await client
+          .from('fursuit_makers')
+          .delete()
+          .eq('fursuit_id', fursuitId);
+
+        if (revertClearMakersError) {
+          console.warn('Failed to clear maker assignments after error', revertClearMakersError);
+        } else if (previousMakers.length > 0) {
+          const revertMakers: FursuitMakersInsert[] = previousMakers.map((maker) => ({
+            fursuit_id: fursuitId,
+            ...maker,
+          }));
+
+          const { error: revertInsertMakersError } = await client
+            .from('fursuit_makers')
+            .insert(revertMakers);
+
+          if (revertInsertMakersError) {
+            console.warn(
+              'Failed to restore maker assignments after error',
+              revertInsertMakersError,
+            );
+          }
+        }
+
+        setMakers(initialMakers.length > 0 ? initialMakers : createInitialFursuitMakers());
       }
 
       if (updatedCoreRecord) {
@@ -986,6 +1104,53 @@ export default function EditFursuitScreen() {
                     );
                   })}
                 </View>
+              </View>
+
+              <View style={styles.fieldGroup}>
+                <Text style={styles.label}>Fursuit Maker</Text>
+                <Text style={styles.helperLabel}>
+                  Add the maker names catchers should see. You can add more than one.
+                </Text>
+                <View style={styles.makerList}>
+                  {makers.map((maker, index) => (
+                    <View
+                      key={maker.id}
+                      style={styles.makerRow}
+                    >
+                      <TailTagInput
+                        value={maker.name}
+                        onChangeText={(value) => handleMakerNameChange(maker.id, value)}
+                        placeholder={index === 0 ? 'Maker name' : 'Another maker'}
+                        editable={!disableForm}
+                        returnKeyType={index === makers.length - 1 ? 'done' : 'next'}
+                        style={styles.makerInput}
+                      />
+                      <TailTagButton
+                        variant="ghost"
+                        size="sm"
+                        onPress={() => handleRemoveMaker(maker.id)}
+                        disabled={disableForm}
+                        style={styles.makerRemoveButton}
+                      >
+                        Remove
+                      </TailTagButton>
+                    </View>
+                  ))}
+                </View>
+                {makersCanAddMore ? (
+                  <TailTagButton
+                    variant="outline"
+                    size="sm"
+                    onPress={handleAddMaker}
+                    disabled={disableForm}
+                  >
+                    Add another maker
+                  </TailTagButton>
+                ) : (
+                  <Text style={styles.helperLabel}>
+                    You can add up to {FURSUIT_MAKER_LIMIT} makers.
+                  </Text>
+                )}
               </View>
 
               <View style={styles.fieldGroup}>

--- a/app/fursuits/[id]/index.tsx
+++ b/app/fursuits/[id]/index.tsx
@@ -305,8 +305,11 @@ export default function FursuitDetailScreen() {
                       </View>
                     </Pressable>
                   ) : null}
-                  {detail.bio && fursuitBioHasDisplayableContent(detail.bio) ? (
-                    <FursuitBioDetails bio={detail.bio} />
+                  {fursuitBioHasDisplayableContent(detail.bio, detail.makers) ? (
+                    <FursuitBioDetails
+                      bio={detail.bio}
+                      makers={detail.makers}
+                    />
                   ) : (
                     <Text style={styles.message}>This fursuit does not have a bio yet.</Text>
                   )}

--- a/src/app-styles/(tabs)/suits/add-fursuit.styles.ts
+++ b/src/app-styles/(tabs)/suits/add-fursuit.styles.ts
@@ -162,6 +162,18 @@ export const styles = StyleSheet.create({
   socialList: {
     gap: spacing.md,
   },
+  makerList: {
+    gap: spacing.sm,
+  },
+  makerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  makerInput: {
+    flex: 1,
+  },
+  makerRemoveButton: {},
   socialRow: {
     flexDirection: 'column',
     gap: spacing.sm,

--- a/src/app-styles/fursuits/[id]/edit.styles.ts
+++ b/src/app-styles/fursuits/[id]/edit.styles.ts
@@ -128,6 +128,18 @@ export const styles = StyleSheet.create({
   socialList: {
     gap: spacing.md,
   },
+  makerList: {
+    gap: spacing.sm,
+  },
+  makerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  makerInput: {
+    flex: 1,
+  },
+  makerRemoveButton: {},
   socialRow: {
     flexDirection: 'column',
     gap: spacing.sm,

--- a/src/features/catch-confirmations/api/confirmations.ts
+++ b/src/features/catch-confirmations/api/confirmations.ts
@@ -32,6 +32,7 @@ export const pendingCatchesQueryKey = (userId: string) =>
 
 // Stale times
 export const PENDING_CATCHES_STALE_TIME = 15 * 1000; // 15 seconds
+const EDGE_FUNCTION_TIMEOUT_MS = 15 * 1000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -255,9 +256,9 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
     throw new Error('Supabase configuration not set.');
   }
 
-  // Create AbortController for 5-second timeout
+  // Edge Functions can commit the catch before slower notification/achievement work finishes.
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const timeoutId = setTimeout(() => controller.abort(), EDGE_FUNCTION_TIMEOUT_MS);
 
   try {
     const response = await fetch(`${supabaseUrl}/functions/v1/create-catch`, {
@@ -372,10 +373,11 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
 
     // Handle timeout/abort
     if (error instanceof Error && error.name === 'AbortError') {
-      captureFeatureError(new Error('Create catch request timed out after 5 seconds'), {
+      captureFeatureError(new Error('Create catch request timed out'), {
         scope: 'catch-confirmations.createCatch',
         action: 'timeout',
         fursuitId: params.fursuitId,
+        timeoutMs: EDGE_FUNCTION_TIMEOUT_MS,
       });
       throw new Error('The request took too long. Please check your connection and try again.');
     }
@@ -407,7 +409,7 @@ export async function updateCatchPhoto(
   }
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const timeoutId = setTimeout(() => controller.abort(), EDGE_FUNCTION_TIMEOUT_MS);
 
   try {
     const resolvedPhotoUrl =

--- a/src/features/suits/api/catchById.ts
+++ b/src/features/suits/api/catchById.ts
@@ -2,6 +2,7 @@ import { supabase } from '../../../lib/supabase';
 import type { FursuitSummary } from '../types';
 import type { CatchMode } from '../../catch-confirmations';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
+import { fetchFursuitMakersByFursuitIds } from './makers';
 import type { CaughtRecord } from './caughtSuits';
 import { CATCH_PHOTO_BUCKET, FURSUIT_BUCKET } from '../../../constants/storage';
 import { resolveStorageMediaUrl } from '../../../utils/supabase-image';
@@ -81,6 +82,9 @@ export async function fetchCatchById(catchId: string): Promise<CaughtRecord | nu
 
   const catchMode: CatchMode =
     rawFursuit?.catch_mode === 'MANUAL_APPROVAL' ? 'MANUAL_APPROVAL' : 'AUTO_ACCEPT';
+  const makersByFursuitId = await fetchFursuitMakersByFursuitIds(
+    rawFursuit?.id ? [rawFursuit.id] : [],
+  );
 
   const fursuit: FursuitSummary | null = rawFursuit
     ? {
@@ -102,6 +106,7 @@ export async function fetchCatchById(catchId: string): Promise<CaughtRecord | nu
         catchMode,
         created_at: rawFursuit.created_at ?? null,
         conventions: [],
+        makers: makersByFursuitId.get(rawFursuit.id) ?? [],
         bio: mapLatestFursuitBio(rawFursuit.fursuit_bios ?? null),
       }
     : null;

--- a/src/features/suits/api/caughtSuits.ts
+++ b/src/features/suits/api/caughtSuits.ts
@@ -2,6 +2,7 @@ import { supabase } from '../../../lib/supabase';
 import type { FursuitSummary } from '../types';
 import type { CatchMode } from '../../catch-confirmations';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
+import { fetchFursuitMakersByFursuitIds } from './makers';
 import { CATCH_PHOTO_BUCKET, FURSUIT_BUCKET } from '../../../constants/storage';
 import { resolveStorageMediaUrl } from '../../../utils/supabase-image';
 
@@ -77,6 +78,10 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
     throw new Error(`We couldn't load your catches: ${error.message}`);
   }
 
+  const makersByFursuitId = await fetchFursuitMakersByFursuitIds(
+    (data ?? []).map((record: any) => record.fursuit?.id).filter(Boolean),
+  );
+
   return (data ?? [])
     .map((record: any) => {
       const rawFursuit = record.fursuit;
@@ -109,6 +114,7 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
             catchMode,
             created_at: rawFursuit.created_at ?? null,
             conventions: [],
+            makers: makersByFursuitId.get(rawFursuit.id) ?? [],
             bio: mapLatestFursuitBio(rawFursuit.fursuit_bios ?? null),
           } satisfies FursuitSummary)
         : null;

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../../../lib/supabase';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
+import { fetchFursuitMakersByFursuitIds } from './makers';
 import type { FursuitDetail } from '../types';
 import type { CatchMode } from '../../catch-confirmations';
 import { captureHandledMessage } from '../../../lib/sentry';
@@ -100,6 +101,8 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
   const speciesName = speciesEntry?.name ?? null;
   const speciesId = speciesEntry?.id ?? data.species_id ?? null;
   const colors = mapFursuitColors(data.color_assignments ?? null);
+  const makersByFursuitId = await fetchFursuitMakersByFursuitIds([data.id]);
+  const makers = makersByFursuitId.get(data.id) ?? [];
 
   let resolvedCatchCount = typeof data.catch_count === 'number' ? data.catch_count : 0;
 
@@ -140,6 +143,7 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     catchMode,
     created_at: data.created_at ?? null,
     conventions,
+    makers,
     bio,
   } satisfies FursuitDetail;
 }

--- a/src/features/suits/api/makers.ts
+++ b/src/features/suits/api/makers.ts
@@ -1,0 +1,48 @@
+import { supabase } from '../../../lib/supabase';
+import { mapFursuitMakers } from './utils';
+import type { FursuitMaker } from '../types';
+
+type RawFursuitMakerRow = {
+  fursuit_id?: unknown;
+};
+
+export async function fetchFursuitMakersByFursuitIds(
+  fursuitIds: string[],
+): Promise<Map<string, FursuitMaker[]>> {
+  const uniqueIds = [...new Set(fursuitIds.filter(Boolean))];
+  const grouped = new Map<string, FursuitMaker[]>();
+
+  if (uniqueIds.length === 0) {
+    return grouped;
+  }
+
+  const { data, error } = await (supabase as any)
+    .from('fursuit_makers')
+    .select('id, fursuit_id, maker_name, normalized_maker_name, position')
+    .in('fursuit_id', uniqueIds)
+    .order('position', { ascending: true });
+
+  if (error) {
+    throw new Error(`We couldn't load fursuit makers: ${error.message}`);
+  }
+
+  for (const row of data ?? []) {
+    const fursuitId =
+      typeof (row as RawFursuitMakerRow).fursuit_id === 'string'
+        ? ((row as RawFursuitMakerRow).fursuit_id as string)
+        : null;
+
+    if (!fursuitId) {
+      continue;
+    }
+
+    const current = grouped.get(fursuitId) ?? [];
+    grouped.set(fursuitId, [...current, row]);
+  }
+
+  for (const [fursuitId, makers] of grouped) {
+    grouped.set(fursuitId, mapFursuitMakers(makers));
+  }
+
+  return grouped;
+}

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -3,6 +3,7 @@ import type { ConventionSummary } from '../../conventions';
 import type { FursuitSummary } from '../types';
 import type { CatchMode } from '../../catch-confirmations';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
+import { fetchFursuitMakersByFursuitIds } from './makers';
 import { FURSUIT_BUCKET } from '../../../constants/storage';
 import { resolveStorageMediaUrl } from '../../../utils/supabase-image';
 
@@ -78,6 +79,10 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
     throw new Error(`We couldn't load your suits: ${error.message}`);
   }
 
+  const makersByFursuitId = await fetchFursuitMakersByFursuitIds(
+    (data ?? []).map((item: any) => item.id),
+  );
+
   return (data ?? []).map((item: any) => {
     const conventions: ConventionSummary[] = (item.fursuit_conventions ?? [])
       .map((entry: any) => entry?.convention)
@@ -102,6 +107,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
     const speciesName = speciesEntry?.name ?? null;
     const speciesId = speciesEntry?.id ?? item.species_id ?? null;
     const colors = mapFursuitColors(item.color_assignments ?? null);
+    const makers = makersByFursuitId.get(item.id) ?? [];
 
     // Default to AUTO_ACCEPT if not set
     const catchMode: CatchMode =
@@ -125,6 +131,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       catchMode,
       created_at: item.created_at ?? null,
       conventions,
+      makers,
       bio,
     } satisfies FursuitSummary;
   });

--- a/src/features/suits/api/utils.ts
+++ b/src/features/suits/api/utils.ts
@@ -1,4 +1,4 @@
-import type { FursuitBio } from '../types';
+import type { FursuitBio, FursuitMaker } from '../types';
 import type { FursuitColorOption } from '../../colors';
 import type { FursuitSocialLink } from '../../../types/database';
 
@@ -25,6 +25,13 @@ type RawColorAssignment = {
     name?: unknown;
     normalized_name?: unknown;
   } | null;
+};
+
+type RawFursuitMaker = {
+  id?: unknown;
+  maker_name?: unknown;
+  normalized_maker_name?: unknown;
+  position?: unknown;
 };
 
 const coerceString = (value: unknown): string => {
@@ -153,6 +160,49 @@ export const mapFursuitColors = (raw: unknown): FursuitColorOption[] => {
       };
     })
     .filter((entry): entry is { option: FursuitColorOption; order: number } => Boolean(entry));
+
+  return mapped
+    .sort((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+      return a.option.name.localeCompare(b.option.name, undefined, { sensitivity: 'base' });
+    })
+    .map((entry) => entry.option);
+};
+
+export const mapFursuitMakers = (raw: unknown): FursuitMaker[] => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const mapped = raw
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+
+      const source = entry as RawFursuitMaker;
+      const id = coerceString(source.id).trim();
+      const name = coerceString(source.maker_name).trim();
+      const normalizedName = coerceString(source.normalized_maker_name).trim();
+      const positionNumber = Number(source.position);
+
+      if (!id || !name || !normalizedName) {
+        return null;
+      }
+
+      return {
+        option: {
+          id,
+          name,
+          normalizedName,
+          position: Number.isFinite(positionNumber) ? positionNumber : Number.MAX_SAFE_INTEGER,
+        } satisfies FursuitMaker,
+        order: Number.isFinite(positionNumber) ? positionNumber : Number.MAX_SAFE_INTEGER,
+      };
+    })
+    .filter((entry): entry is { option: FursuitMaker; order: number } => Boolean(entry));
 
   return mapped
     .sort((a, b) => {

--- a/src/features/suits/components/FursuitBioDetails.styles.ts
+++ b/src/features/suits/components/FursuitBioDetails.styles.ts
@@ -21,6 +21,15 @@ export const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
   },
+  makerList: {
+    gap: spacing.xs,
+  },
+  makerName: {
+    color: colors.foreground,
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 20,
+  },
   socialList: {
     gap: spacing.sm,
   },

--- a/src/features/suits/components/FursuitBioDetails.tsx
+++ b/src/features/suits/components/FursuitBioDetails.tsx
@@ -1,17 +1,21 @@
 import { Alert, Linking, Pressable, Text, View } from 'react-native';
 
-import type { FursuitBio } from '../types';
+import type { FursuitBio, FursuitMaker } from '../types';
 import { captureNonCriticalError } from '../../../lib/sentry';
 import { styles } from './FursuitBioDetails.styles';
 
 /** True when {@link FursuitBioDetails} would render at least one section (excludes owner-only bios). */
-export function fursuitBioHasDisplayableContent(bio: FursuitBio): boolean {
-  const hasPronouns = Boolean(bio.pronouns?.trim());
-  const hasLikesAndInterests = Boolean(bio.likesAndInterests?.trim());
-  const hasAskMeAbout = Boolean(bio.askMeAbout?.trim());
+export function fursuitBioHasDisplayableContent(
+  bio: FursuitBio | null | undefined,
+  makers: FursuitMaker[] = [],
+): boolean {
+  const hasPronouns = Boolean(bio?.pronouns?.trim());
+  const hasLikesAndInterests = Boolean(bio?.likesAndInterests?.trim());
+  const hasAskMeAbout = Boolean(bio?.askMeAbout?.trim());
   const hasLikesSection = hasLikesAndInterests || hasAskMeAbout;
-  const hasSocial = bio.socialLinks.length > 0;
-  return hasPronouns || hasLikesSection || hasSocial;
+  const hasSocial = (bio?.socialLinks ?? []).length > 0;
+  const hasMakers = makers.length > 0;
+  return hasPronouns || hasLikesSection || hasSocial || hasMakers;
 }
 
 const openSocialLink = async (url: string) => {
@@ -34,25 +38,43 @@ const openSocialLink = async (url: string) => {
 };
 
 type FursuitBioDetailsProps = {
-  bio: FursuitBio;
+  bio: FursuitBio | null;
+  makers?: FursuitMaker[];
 };
 
-export function FursuitBioDetails({ bio }: FursuitBioDetailsProps) {
-  if (!fursuitBioHasDisplayableContent(bio)) {
+export function FursuitBioDetails({ bio, makers = [] }: FursuitBioDetailsProps) {
+  if (!fursuitBioHasDisplayableContent(bio, makers)) {
     return null;
   }
 
-  const hasPronouns = Boolean(bio.pronouns?.trim());
-  const hasLikesAndInterests = Boolean(bio.likesAndInterests?.trim());
-  const hasAskMeAbout = Boolean(bio.askMeAbout?.trim());
+  const hasPronouns = Boolean(bio?.pronouns?.trim());
+  const hasLikesAndInterests = Boolean(bio?.likesAndInterests?.trim());
+  const hasAskMeAbout = Boolean(bio?.askMeAbout?.trim());
   const hasLikesSection = hasLikesAndInterests || hasAskMeAbout;
+  const socialLinks = bio?.socialLinks ?? [];
 
   return (
     <View style={styles.sections}>
+      {makers.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Fursuit Maker</Text>
+          <View style={styles.makerList}>
+            {makers.map((maker) => (
+              <Text
+                key={maker.id}
+                style={styles.makerName}
+              >
+                {maker.name}
+              </Text>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
       {hasPronouns ? (
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Pronouns</Text>
-          <Text style={styles.sectionBody}>{bio.pronouns!.trim()}</Text>
+          <Text style={styles.sectionBody}>{bio?.pronouns.trim()}</Text>
         </View>
       ) : null}
 
@@ -61,23 +83,23 @@ export function FursuitBioDetails({ bio }: FursuitBioDetailsProps) {
           {hasLikesAndInterests ? (
             <>
               <Text style={styles.sectionLabel}>Likes & interests</Text>
-              <Text style={styles.sectionBody}>{bio.likesAndInterests!.trim()}</Text>
+              <Text style={styles.sectionBody}>{bio?.likesAndInterests.trim()}</Text>
             </>
           ) : null}
           {hasAskMeAbout ? (
             <>
               <Text style={styles.sectionLabel}>Ask me about…</Text>
-              <Text style={styles.sectionBody}>{bio.askMeAbout!.trim()}</Text>
+              <Text style={styles.sectionBody}>{bio?.askMeAbout.trim()}</Text>
             </>
           ) : null}
         </View>
       ) : null}
 
-      {bio.socialLinks.length > 0 ? (
+      {socialLinks.length > 0 ? (
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Social links</Text>
           <View style={styles.socialList}>
-            {bio.socialLinks.map((link) => (
+            {socialLinks.map((link) => (
               <Pressable
                 key={`${link.label}-${link.url}`}
                 style={styles.socialLink}

--- a/src/features/suits/forms/makers.ts
+++ b/src/features/suits/forms/makers.ts
@@ -1,0 +1,52 @@
+export const FURSUIT_MAKER_LIMIT = 10;
+
+export type EditableFursuitMaker = {
+  id: string;
+  name: string;
+};
+
+export type FursuitMakerToSave = {
+  maker_name: string;
+  normalized_maker_name: string;
+  position: number;
+};
+
+export function normalizeFursuitMakerName(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function createEmptyFursuitMaker(): EditableFursuitMaker {
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    name: '',
+  };
+}
+
+export function createInitialFursuitMakers(): EditableFursuitMaker[] {
+  return [createEmptyFursuitMaker()];
+}
+
+export function fursuitMakersToSave(makers: EditableFursuitMaker[]): FursuitMakerToSave[] {
+  return makers
+    .map((maker) => maker.name.trim().replace(/\s+/g, ' '))
+    .filter(Boolean)
+    .map((makerName, index) => ({
+      maker_name: makerName,
+      normalized_maker_name: normalizeFursuitMakerName(makerName),
+      position: index + 1,
+    }));
+}
+
+export function hasDuplicateFursuitMakers(makers: FursuitMakerToSave[]): boolean {
+  const seen = new Set<string>();
+
+  for (const maker of makers) {
+    if (seen.has(maker.normalized_maker_name)) {
+      return true;
+    }
+
+    seen.add(maker.normalized_maker_name);
+  }
+
+  return false;
+}

--- a/src/features/suits/index.ts
+++ b/src/features/suits/index.ts
@@ -31,7 +31,7 @@ export {
   createMySuitsQueryOptions,
   createMySuitsCountQueryOptions,
 } from './api/mySuits';
-export type { FursuitSummary, FursuitBio } from './types';
+export type { FursuitSummary, FursuitBio, FursuitMaker } from './types';
 export {
   fetchCaughtSuits,
   CAUGHT_SUITS_QUERY_KEY,
@@ -40,7 +40,13 @@ export {
   createCaughtSuitsQueryOptions,
 } from './api/caughtSuits';
 export type { CaughtRecord } from './api/caughtSuits';
-export { mapFursuitBio, mapLatestFursuitBio, mapFursuitColors } from './api/utils';
+export {
+  mapFursuitBio,
+  mapLatestFursuitBio,
+  mapFursuitColors,
+  mapFursuitMakers,
+} from './api/utils';
+export { fetchFursuitMakersByFursuitIds } from './api/makers';
 export {
   fetchFursuitDetail,
   FURSUIT_DETAIL_QUERY_KEY,

--- a/src/features/suits/types.ts
+++ b/src/features/suits/types.ts
@@ -14,6 +14,13 @@ export type FursuitBio = {
   updatedAt: string | null;
 };
 
+export type FursuitMaker = {
+  id: string;
+  name: string;
+  normalizedName: string;
+  position: number;
+};
+
 export type FursuitSummary = {
   id: string;
   owner_id?: string | null;
@@ -29,6 +36,7 @@ export type FursuitSummary = {
   catchMode: CatchMode;
   created_at: string | null;
   conventions: ConventionSummary[];
+  makers: FursuitMaker[];
   bio: FursuitBio | null;
 };
 

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -441,6 +441,44 @@ export type Database = {
           },
         ];
       };
+      fursuit_makers: {
+        Row: {
+          created_at: string;
+          fursuit_id: string;
+          id: string;
+          maker_name: string;
+          normalized_maker_name: string;
+          position: number;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          fursuit_id: string;
+          id?: string;
+          maker_name: string;
+          normalized_maker_name: string;
+          position: number;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          fursuit_id?: string;
+          id?: string;
+          maker_name?: string;
+          normalized_maker_name?: string;
+          position?: number;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'fursuit_makers_fursuit_id_fkey';
+            columns: ['fursuit_id'];
+            isOneToOne: false;
+            referencedRelation: 'fursuits';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       fursuit_colors: {
         Row: {
           created_at: string;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2361,6 +2361,10 @@ export type Database = {
         Args: { convention_uuid?: string }
         Returns: undefined
       }
+      replace_fursuit_makers: {
+        Args: { fursuit_id: string; makers?: Json }
+        Returns: undefined
+      }
       search_players: {
         Args: {
           convention_filter?: string

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -856,51 +856,6 @@ export type Database = {
           },
         ]
       }
-      fursuit_makers: {
-        Row: {
-          created_at: string
-          fursuit_id: string
-          id: string
-          maker_name: string
-          normalized_maker_name: string
-          position: number
-          updated_at: string
-        }
-        Insert: {
-          created_at?: string
-          fursuit_id: string
-          id?: string
-          maker_name: string
-          normalized_maker_name: string
-          position: number
-          updated_at?: string
-        }
-        Update: {
-          created_at?: string
-          fursuit_id?: string
-          id?: string
-          maker_name?: string
-          normalized_maker_name?: string
-          position?: number
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
-            columns: ["fursuit_id"]
-            isOneToOne: false
-            referencedRelation: "fursuits"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
-            columns: ["fursuit_id"]
-            isOneToOne: false
-            referencedRelation: "fursuits_moderation"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       fursuit_colors: {
         Row: {
           created_at: string
@@ -958,6 +913,51 @@ export type Database = {
           },
           {
             foreignKeyName: "fursuit_conventions_fursuit_id_fkey"
+            columns: ["fursuit_id"]
+            isOneToOne: false
+            referencedRelation: "fursuits_moderation"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      fursuit_makers: {
+        Row: {
+          created_at: string
+          fursuit_id: string
+          id: string
+          maker_name: string
+          normalized_maker_name: string
+          position: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          fursuit_id: string
+          id?: string
+          maker_name: string
+          normalized_maker_name: string
+          position: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          fursuit_id?: string
+          id?: string
+          maker_name?: string
+          normalized_maker_name?: string
+          position?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
+            columns: ["fursuit_id"]
+            isOneToOne: false
+            referencedRelation: "fursuits"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
             columns: ["fursuit_id"]
             isOneToOne: false
             referencedRelation: "fursuits_moderation"

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -856,6 +856,51 @@ export type Database = {
           },
         ]
       }
+      fursuit_makers: {
+        Row: {
+          created_at: string
+          fursuit_id: string
+          id: string
+          maker_name: string
+          normalized_maker_name: string
+          position: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          fursuit_id: string
+          id?: string
+          maker_name: string
+          normalized_maker_name: string
+          position: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          fursuit_id?: string
+          id?: string
+          maker_name?: string
+          normalized_maker_name?: string
+          position?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
+            columns: ["fursuit_id"]
+            isOneToOne: false
+            referencedRelation: "fursuits"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
+            columns: ["fursuit_id"]
+            isOneToOne: false
+            referencedRelation: "fursuits_moderation"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       fursuit_colors: {
         Row: {
           created_at: string
@@ -2540,6 +2585,7 @@ export type FursuitSocialLink = {
 export type FursuitsRow = Database['public']['Tables']['fursuits']['Row'];
 export type FursuitsInsert = Database['public']['Tables']['fursuits']['Insert'];
 export type FursuitBiosInsert = Database['public']['Tables']['fursuit_bios']['Insert'];
+export type FursuitMakersInsert = Database['public']['Tables']['fursuit_makers']['Insert'];
 export type ConventionStatus = Database['public']['Tables']['conventions']['Row']['status'];
 export type ConventionParticipantRecapRow =
   Database['public']['Tables']['convention_participant_recaps']['Row'];

--- a/src/types/database.ts.minimal
+++ b/src/types/database.ts.minimal
@@ -558,6 +558,44 @@ export type Database = {
           },
         ]
       }
+      fursuit_makers: {
+        Row: {
+          created_at: string
+          fursuit_id: string
+          id: string
+          maker_name: string
+          normalized_maker_name: string
+          position: number
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          fursuit_id: string
+          id?: string
+          maker_name: string
+          normalized_maker_name: string
+          position: number
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          fursuit_id?: string
+          id?: string
+          maker_name?: string
+          normalized_maker_name?: string
+          position?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fursuit_makers_fursuit_id_fkey"
+            columns: ["fursuit_id"]
+            isOneToOne: false
+            referencedRelation: "fursuits"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       fursuit_colors: {
         Row: {
           created_at: string
@@ -1389,6 +1427,7 @@ export type DailyTaskKind = string // "catch" | "view_bio" | "share" | "leaderbo
 export type FursuitsRow = Tables<"fursuits">
 export type FursuitsInsert = TablesInsert<"fursuits">
 export type FursuitBiosInsert = TablesInsert<"fursuit_bios">
+export type FursuitMakersInsert = TablesInsert<"fursuit_makers">
 
 // Legacy removed type - no longer exists in database
 export type AchievementEventsRow = never

--- a/supabase/migrations/20260501120000_add_fursuit_makers.sql
+++ b/supabase/migrations/20260501120000_add_fursuit_makers.sql
@@ -55,7 +55,6 @@ grant insert on table "public"."fursuit_makers" to "anon";
 grant references on table "public"."fursuit_makers" to "anon";
 grant select on table "public"."fursuit_makers" to "anon";
 grant trigger on table "public"."fursuit_makers" to "anon";
-grant truncate on table "public"."fursuit_makers" to "anon";
 grant update on table "public"."fursuit_makers" to "anon";
 
 grant delete on table "public"."fursuit_makers" to "authenticated";
@@ -63,7 +62,6 @@ grant insert on table "public"."fursuit_makers" to "authenticated";
 grant references on table "public"."fursuit_makers" to "authenticated";
 grant select on table "public"."fursuit_makers" to "authenticated";
 grant trigger on table "public"."fursuit_makers" to "authenticated";
-grant truncate on table "public"."fursuit_makers" to "authenticated";
 grant update on table "public"."fursuit_makers" to "authenticated";
 
 grant delete on table "public"."fursuit_makers" to "service_role";

--- a/supabase/migrations/20260501120000_add_fursuit_makers.sql
+++ b/supabase/migrations/20260501120000_add_fursuit_makers.sql
@@ -1,0 +1,132 @@
+create table "public"."fursuit_makers" (
+  "id" uuid not null default gen_random_uuid(),
+  "fursuit_id" uuid not null,
+  "maker_name" text not null,
+  "normalized_maker_name" text not null,
+  "position" smallint not null,
+  "created_at" timestamp with time zone not null default timezone('utc'::text, now()),
+  "updated_at" timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+alter table "public"."fursuit_makers" enable row level security;
+
+create unique index fursuit_makers_pkey on public.fursuit_makers using btree (id);
+
+create unique index fursuit_makers_unique_fursuit_position on public.fursuit_makers using btree (fursuit_id, position);
+
+create unique index fursuit_makers_unique_fursuit_normalized_name on public.fursuit_makers using btree (fursuit_id, normalized_maker_name);
+
+create index fursuit_makers_fursuit_id_idx on public.fursuit_makers using btree (fursuit_id);
+
+create index fursuit_makers_normalized_maker_name_idx on public.fursuit_makers using btree (normalized_maker_name);
+
+alter table "public"."fursuit_makers" add constraint "fursuit_makers_pkey" primary key using index "fursuit_makers_pkey";
+
+alter table "public"."fursuit_makers" add constraint "fursuit_makers_fursuit_id_fkey" foreign key (fursuit_id) references public.fursuits(id) on delete cascade not valid;
+
+alter table "public"."fursuit_makers" validate constraint "fursuit_makers_fursuit_id_fkey";
+
+alter table "public"."fursuit_makers" add constraint "fursuit_makers_maker_name_check" check (char_length(btrim(maker_name)) > 0) not valid;
+
+alter table "public"."fursuit_makers" validate constraint "fursuit_makers_maker_name_check";
+
+alter table "public"."fursuit_makers" add constraint "fursuit_makers_normalized_maker_name_check" check (char_length(btrim(normalized_maker_name)) > 0) not valid;
+
+alter table "public"."fursuit_makers" validate constraint "fursuit_makers_normalized_maker_name_check";
+
+alter table "public"."fursuit_makers" add constraint "fursuit_makers_position_check" check (position > 0) not valid;
+
+alter table "public"."fursuit_makers" validate constraint "fursuit_makers_position_check";
+
+create or replace function public.set_fursuit_makers_updated_at()
+returns trigger
+language plpgsql
+as $function$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$function$;
+
+create trigger set_fursuit_makers_updated_at before update on public.fursuit_makers for each row execute function public.set_fursuit_makers_updated_at();
+
+grant delete on table "public"."fursuit_makers" to "anon";
+grant insert on table "public"."fursuit_makers" to "anon";
+grant references on table "public"."fursuit_makers" to "anon";
+grant select on table "public"."fursuit_makers" to "anon";
+grant trigger on table "public"."fursuit_makers" to "anon";
+grant truncate on table "public"."fursuit_makers" to "anon";
+grant update on table "public"."fursuit_makers" to "anon";
+
+grant delete on table "public"."fursuit_makers" to "authenticated";
+grant insert on table "public"."fursuit_makers" to "authenticated";
+grant references on table "public"."fursuit_makers" to "authenticated";
+grant select on table "public"."fursuit_makers" to "authenticated";
+grant trigger on table "public"."fursuit_makers" to "authenticated";
+grant truncate on table "public"."fursuit_makers" to "authenticated";
+grant update on table "public"."fursuit_makers" to "authenticated";
+
+grant delete on table "public"."fursuit_makers" to "service_role";
+grant insert on table "public"."fursuit_makers" to "service_role";
+grant references on table "public"."fursuit_makers" to "service_role";
+grant select on table "public"."fursuit_makers" to "service_role";
+grant trigger on table "public"."fursuit_makers" to "service_role";
+grant truncate on table "public"."fursuit_makers" to "service_role";
+grant update on table "public"."fursuit_makers" to "service_role";
+
+create policy "fursuit_makers_select_all_authenticated"
+on "public"."fursuit_makers"
+as permissive
+for select
+to authenticated
+using (true);
+
+create policy "fursuit_makers_insert_owner"
+on "public"."fursuit_makers"
+as permissive
+for insert
+to authenticated
+with check (
+  exists (
+    select 1
+    from public.fursuits
+    where fursuits.id = fursuit_makers.fursuit_id
+      and fursuits.owner_id = auth.uid()
+  )
+);
+
+create policy "fursuit_makers_update_owner"
+on "public"."fursuit_makers"
+as permissive
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.fursuits
+    where fursuits.id = fursuit_makers.fursuit_id
+      and fursuits.owner_id = auth.uid()
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.fursuits
+    where fursuits.id = fursuit_makers.fursuit_id
+      and fursuits.owner_id = auth.uid()
+  )
+);
+
+create policy "fursuit_makers_delete_owner"
+on "public"."fursuit_makers"
+as permissive
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.fursuits
+    where fursuits.id = fursuit_makers.fursuit_id
+      and fursuits.owner_id = auth.uid()
+  )
+);

--- a/supabase/migrations/20260501133000_add_replace_fursuit_makers_rpc.sql
+++ b/supabase/migrations/20260501133000_add_replace_fursuit_makers_rpc.sql
@@ -1,0 +1,74 @@
+create or replace function public.replace_fursuit_makers(
+  fursuit_id uuid,
+  makers jsonb default '[]'::jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $function$
+declare
+  v_fursuit_id uuid := $1;
+  v_makers jsonb := coalesce($2, '[]'::jsonb);
+  v_maker jsonb;
+  v_position integer;
+  v_maker_name text;
+  v_normalized_maker_name text;
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required'
+      using errcode = '28000';
+  end if;
+
+  if not exists (
+    select 1
+    from public.fursuits
+    where id = v_fursuit_id
+      and owner_id = auth.uid()
+  ) then
+    raise exception 'Fursuit not found or not owned by current user'
+      using errcode = '42501';
+  end if;
+
+  if jsonb_typeof(v_makers) <> 'array' then
+    raise exception 'makers must be an array'
+      using errcode = '22023';
+  end if;
+
+  if jsonb_array_length(v_makers) > 10 then
+    raise exception 'A fursuit can have at most 10 makers'
+      using errcode = '22023';
+  end if;
+
+  delete from public.fursuit_makers
+  where fursuit_makers.fursuit_id = v_fursuit_id;
+
+  for v_maker, v_position in
+    select value, ordinality::integer
+    from jsonb_array_elements(v_makers) with ordinality
+  loop
+    v_maker_name := btrim(v_maker ->> 'maker_name');
+    v_normalized_maker_name := btrim(v_maker ->> 'normalized_maker_name');
+
+    if coalesce(v_maker_name, '') = '' or coalesce(v_normalized_maker_name, '') = '' then
+      raise exception 'maker_name and normalized_maker_name are required'
+        using errcode = '22023';
+    end if;
+
+    insert into public.fursuit_makers (
+      fursuit_id,
+      maker_name,
+      normalized_maker_name,
+      position
+    )
+    values (
+      v_fursuit_id,
+      v_maker_name,
+      v_normalized_maker_name,
+      v_position
+    );
+  end loop;
+end;
+$function$;
+
+grant execute on function public.replace_fursuit_makers(uuid, jsonb) to authenticated;

--- a/supabase/migrations/20260501134500_revoke_fursuit_makers_client_truncate.sql
+++ b/supabase/migrations/20260501134500_revoke_fursuit_makers_client_truncate.sql
@@ -1,0 +1,2 @@
+revoke truncate on table "public"."fursuit_makers" from "anon";
+revoke truncate on table "public"."fursuit_makers" from "authenticated";


### PR DESCRIPTION
This PR adds a new section in fursuit profiles for fursuit makers, allowing players to tie their suit to a maker(s).

Resolves TAILTAG-76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to create, edit, and manage fursuit makers (up to 10 per fursuit)
  * Fursuit makers now display alongside bio details and in catch confirmations

* **Improvements**
  * Enhanced bio display logic to incorporate maker information
  * Increased edge function timeout for improved reliability

* **Documentation**
  * Updated database migration guidelines for development workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->