### PR TITLE
Auto-Catch A/B Test

### DIFF
--- a/admin-v2/src/lib/server/analytics.ts
+++ b/admin-v2/src/lib/server/analytics.ts
@@ -7,6 +7,35 @@ export type ConventionAnalytics = {
   pendingCatches: number;
 };
 
+export type CatchModeExperimentResult = {
+  experimentKey: string;
+  variant: string;
+  assignedProfiles: number;
+  exposedProfiles: number;
+  defaultsApplied: number;
+  currentAutoProfiles: number;
+  currentManualProfiles: number;
+  switchedAwayProfiles: number;
+  switchAwayRate: number;
+  fursuitsCreatedAfterExposure: number;
+  catchesAfterExposure: number;
+  acceptedCatchesAfterExposure: number;
+  pendingCatchesAfterExposure: number;
+};
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
 export async function fetchConventionAnalytics(conventionId: string): Promise<ConventionAnalytics> {
   const supabase = createServiceRoleClient();
   const todayStart = new Date();
@@ -39,4 +68,49 @@ export async function fetchConventionAnalytics(conventionId: string): Promise<Co
 
 export async function fetchAllConventionAnalytics(conventionIds: string[]) {
   return Promise.all(conventionIds.map((id) => fetchConventionAnalytics(id)));
+}
+
+export async function fetchCatchModeExperimentResults(): Promise<CatchModeExperimentResult[]> {
+  const supabase = createServiceRoleClient();
+
+  const { data, error } = await (supabase as any)
+    .from('catch_mode_default_experiment_results')
+    .select(
+      `
+      experiment_key,
+      variant,
+      assigned_profiles,
+      exposed_profiles,
+      defaults_applied,
+      current_auto_profiles,
+      current_manual_profiles,
+      switched_away_profiles,
+      switch_away_rate,
+      fursuits_created_after_exposure,
+      catches_after_exposure,
+      accepted_catches_after_exposure,
+      pending_catches_after_exposure
+    `,
+    )
+    .order('variant', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row: any) => ({
+    experimentKey: String(row.experiment_key ?? 'catch_mode_default_v1'),
+    variant: String(row.variant ?? ''),
+    assignedProfiles: toNumber(row.assigned_profiles),
+    exposedProfiles: toNumber(row.exposed_profiles),
+    defaultsApplied: toNumber(row.defaults_applied),
+    currentAutoProfiles: toNumber(row.current_auto_profiles),
+    currentManualProfiles: toNumber(row.current_manual_profiles),
+    switchedAwayProfiles: toNumber(row.switched_away_profiles),
+    switchAwayRate: toNumber(row.switch_away_rate),
+    fursuitsCreatedAfterExposure: toNumber(row.fursuits_created_after_exposure),
+    catchesAfterExposure: toNumber(row.catches_after_exposure),
+    acceptedCatchesAfterExposure: toNumber(row.accepted_catches_after_exposure),
+    pendingCatchesAfterExposure: toNumber(row.pending_catches_after_exposure),
+  }));
 }

--- a/admin-v2/src/routes/(dashboard)/analytics/+page.server.ts
+++ b/admin-v2/src/routes/(dashboard)/analytics/+page.server.ts
@@ -1,16 +1,24 @@
 import { fail } from '@sveltejs/kit';
-import { fetchAllConventionAnalytics } from '$lib/server/analytics';
+import {
+  fetchAllConventionAnalytics,
+  fetchCatchModeExperimentResults,
+} from '$lib/server/analytics';
 import { fetchConventions } from '$lib/server/data';
 import { simulateCatchAction } from '$lib/server/actions/analytics';
 
 export async function load() {
   const conventions = await fetchConventions();
-  const analytics = await fetchAllConventionAnalytics(conventions.map((c) => c.id));
+  const [analytics, catchModeExperimentResults] = await Promise.all([
+    fetchAllConventionAnalytics(conventions.map((c) => c.id)),
+    fetchCatchModeExperimentResults(),
+  ]);
+
   return {
     rows: conventions.map((convention) => ({
       ...convention,
       stats: analytics.find((entry) => entry.conventionId === convention.id),
     })),
+    catchModeExperimentResults,
   };
 }
 

--- a/admin-v2/src/routes/(dashboard)/analytics/+page.svelte
+++ b/admin-v2/src/routes/(dashboard)/analytics/+page.svelte
@@ -1,10 +1,27 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
   import Card from '$lib/components/Card.svelte';
+  import Metric from '$lib/components/Metric.svelte';
   import Table from '$lib/components/Table.svelte';
 
   let { data, form } = $props();
   let pendingConventionId = $state<string | null>(null);
+  let experimentTotals = $derived(
+    data.catchModeExperimentResults.reduce(
+      (totals, row) => ({
+        assignedProfiles: totals.assignedProfiles + row.assignedProfiles,
+        exposedProfiles: totals.exposedProfiles + row.exposedProfiles,
+        defaultsApplied: totals.defaultsApplied + row.defaultsApplied,
+        switchedAwayProfiles: totals.switchedAwayProfiles + row.switchedAwayProfiles,
+      }),
+      {
+        assignedProfiles: 0,
+        exposedProfiles: 0,
+        defaultsApplied: 0,
+        switchedAwayProfiles: 0,
+      },
+    ),
+  );
 </script>
 
 <div class="space-y-4">
@@ -20,6 +37,68 @@
         </tr>
       {:else}
         <tr><td class="px-4 py-3 text-sm text-muted" colspan="5">No conventions found.</td></tr>
+      {/each}
+    </Table>
+  </Card>
+
+  <Card
+    title="Catch mode default experiment"
+    subtitle="Profile-level auto-catching vs manual approval defaults"
+  >
+    <div class="mb-4 grid gap-3 md:grid-cols-4">
+      <Metric label="Assigned" value={experimentTotals.assignedProfiles} />
+      <Metric label="Exposed" value={experimentTotals.exposedProfiles} />
+      <Metric label="Defaults applied" value={experimentTotals.defaultsApplied} />
+      <Metric label="Switched away" value={experimentTotals.switchedAwayProfiles} />
+    </div>
+    <Table
+      headers={[
+        'Variant',
+        'Assigned',
+        'Exposed',
+        'Applied',
+        'Current auto/manual',
+        'Switch away',
+        'Fursuits',
+        'Catches',
+      ]}
+    >
+      {#each data.catchModeExperimentResults as row}
+        <tr>
+          <td class="px-4 py-3 text-slate-200">
+            <div class="flex flex-col">
+              <span class="font-semibold text-white">
+                {row.variant === 'manual_default' ? 'Manual default' : 'Auto default'}
+              </span>
+              <span class="text-xs text-muted">{row.experimentKey}</span>
+            </div>
+          </td>
+          <td class="px-4 py-3 text-white">{row.assignedProfiles}</td>
+          <td class="px-4 py-3 text-white">{row.exposedProfiles}</td>
+          <td class="px-4 py-3 text-white">{row.defaultsApplied}</td>
+          <td class="px-4 py-3 text-white">
+            {row.currentAutoProfiles} / {row.currentManualProfiles}
+          </td>
+          <td class="px-4 py-3 text-white">
+            {row.switchedAwayProfiles} ({row.switchAwayRate}%)
+          </td>
+          <td class="px-4 py-3 text-white">{row.fursuitsCreatedAfterExposure}</td>
+          <td class="px-4 py-3 text-white">
+            <div class="flex flex-col">
+              <span>{row.catchesAfterExposure}</span>
+              <span class="text-xs text-muted">
+                {row.acceptedCatchesAfterExposure} accepted / {row.pendingCatchesAfterExposure}
+                pending
+              </span>
+            </div>
+          </td>
+        </tr>
+      {:else}
+        <tr>
+          <td class="px-4 py-3 text-sm text-muted" colspan="8">
+            No experiment assignments yet.
+          </td>
+        </tr>
       {/each}
     </Table>
   </Card>

--- a/admin/app/(dashboard)/analytics/page.tsx
+++ b/admin/app/(dashboard)/analytics/page.tsx
@@ -1,19 +1,38 @@
 import Link from 'next/link';
 
 import { Card } from '@/components/card';
+import { Metric } from '@/components/metric';
 import { Table } from '@/components/table';
 import { fetchConventions } from '@/lib/data';
-import { fetchAllConventionAnalytics } from '@/lib/analytics';
+import { fetchAllConventionAnalytics, fetchCatchModeExperimentResults } from '@/lib/analytics';
 import { SimulateCatchForm } from '@/components/simulate-catch-form';
 
 export default async function AnalyticsPage() {
   const conventions = await fetchConventions();
-  const analytics = await fetchAllConventionAnalytics(conventions.map((c) => c.id));
+  const [analytics, catchModeExperimentResults] = await Promise.all([
+    fetchAllConventionAnalytics(conventions.map((c) => c.id)),
+    fetchCatchModeExperimentResults(),
+  ]);
 
   const rows = conventions.map((c) => {
     const stats = analytics.find((a) => a.conventionId === c.id);
     return { ...c, stats };
   });
+
+  const experimentTotals = catchModeExperimentResults.reduce(
+    (totals, row) => ({
+      assignedProfiles: totals.assignedProfiles + row.assignedProfiles,
+      exposedProfiles: totals.exposedProfiles + row.exposedProfiles,
+      defaultsApplied: totals.defaultsApplied + row.defaultsApplied,
+      switchedAwayProfiles: totals.switchedAwayProfiles + row.switchedAwayProfiles,
+    }),
+    {
+      assignedProfiles: 0,
+      exposedProfiles: 0,
+      defaultsApplied: 0,
+      switchedAwayProfiles: 0,
+    },
+  );
 
   return (
     <div className="space-y-4">
@@ -52,6 +71,84 @@ export default async function AnalyticsPage() {
                 colSpan={5}
               >
                 No conventions found.
+              </td>
+            </tr>
+          ) : null}
+        </Table>
+      </Card>
+
+      <Card
+        title="Catch mode default experiment"
+        subtitle="Profile-level auto-catching vs manual approval defaults"
+      >
+        <div className="mb-4 grid gap-3 md:grid-cols-4">
+          <Metric
+            label="Assigned"
+            value={experimentTotals.assignedProfiles}
+          />
+          <Metric
+            label="Exposed"
+            value={experimentTotals.exposedProfiles}
+          />
+          <Metric
+            label="Defaults applied"
+            value={experimentTotals.defaultsApplied}
+          />
+          <Metric
+            label="Switched away"
+            value={experimentTotals.switchedAwayProfiles}
+          />
+        </div>
+        <Table
+          headers={[
+            'Variant',
+            'Assigned',
+            'Exposed',
+            'Applied',
+            'Current auto/manual',
+            'Switch away',
+            'Fursuits',
+            'Catches',
+          ]}
+        >
+          {catchModeExperimentResults.map((row) => (
+            <tr key={row.variant}>
+              <td className="px-4 py-3 text-slate-200">
+                <div className="flex flex-col">
+                  <span className="font-semibold text-white">
+                    {row.variant === 'manual_default' ? 'Manual default' : 'Auto default'}
+                  </span>
+                  <span className="text-xs text-muted">{row.experimentKey}</span>
+                </div>
+              </td>
+              <td className="px-4 py-3 text-white">{row.assignedProfiles}</td>
+              <td className="px-4 py-3 text-white">{row.exposedProfiles}</td>
+              <td className="px-4 py-3 text-white">{row.defaultsApplied}</td>
+              <td className="px-4 py-3 text-white">
+                {row.currentAutoProfiles} / {row.currentManualProfiles}
+              </td>
+              <td className="px-4 py-3 text-white">
+                {row.switchedAwayProfiles} ({row.switchAwayRate}%)
+              </td>
+              <td className="px-4 py-3 text-white">{row.fursuitsCreatedAfterExposure}</td>
+              <td className="px-4 py-3 text-white">
+                <div className="flex flex-col">
+                  <span>{row.catchesAfterExposure}</span>
+                  <span className="text-xs text-muted">
+                    {row.acceptedCatchesAfterExposure} accepted / {row.pendingCatchesAfterExposure}{' '}
+                    pending
+                  </span>
+                </div>
+              </td>
+            </tr>
+          ))}
+          {!catchModeExperimentResults.length ? (
+            <tr>
+              <td
+                className="px-4 py-3 text-sm text-muted"
+                colSpan={8}
+              >
+                No experiment assignments yet.
               </td>
             </tr>
           ) : null}

--- a/admin/lib/analytics.ts
+++ b/admin/lib/analytics.ts
@@ -7,6 +7,35 @@ export type ConventionAnalytics = {
   pendingCatches: number;
 };
 
+export type CatchModeExperimentResult = {
+  experimentKey: string;
+  variant: string;
+  assignedProfiles: number;
+  exposedProfiles: number;
+  defaultsApplied: number;
+  currentAutoProfiles: number;
+  currentManualProfiles: number;
+  switchedAwayProfiles: number;
+  switchAwayRate: number;
+  fursuitsCreatedAfterExposure: number;
+  catchesAfterExposure: number;
+  acceptedCatchesAfterExposure: number;
+  pendingCatchesAfterExposure: number;
+};
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
 export async function fetchConventionAnalytics(conventionId: string): Promise<ConventionAnalytics> {
   const supabase = createServiceRoleClient();
   const todayStart = new Date();
@@ -39,4 +68,49 @@ export async function fetchConventionAnalytics(conventionId: string): Promise<Co
 
 export async function fetchAllConventionAnalytics(conventionIds: string[]) {
   return Promise.all(conventionIds.map((id) => fetchConventionAnalytics(id)));
+}
+
+export async function fetchCatchModeExperimentResults(): Promise<CatchModeExperimentResult[]> {
+  const supabase = createServiceRoleClient();
+
+  const { data, error } = await (supabase as any)
+    .from('catch_mode_default_experiment_results')
+    .select(
+      `
+      experiment_key,
+      variant,
+      assigned_profiles,
+      exposed_profiles,
+      defaults_applied,
+      current_auto_profiles,
+      current_manual_profiles,
+      switched_away_profiles,
+      switch_away_rate,
+      fursuits_created_after_exposure,
+      catches_after_exposure,
+      accepted_catches_after_exposure,
+      pending_catches_after_exposure
+    `,
+    )
+    .order('variant', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row: any) => ({
+    experimentKey: String(row.experiment_key ?? 'catch_mode_default_v1'),
+    variant: String(row.variant ?? ''),
+    assignedProfiles: toNumber(row.assigned_profiles),
+    exposedProfiles: toNumber(row.exposed_profiles),
+    defaultsApplied: toNumber(row.defaults_applied),
+    currentAutoProfiles: toNumber(row.current_auto_profiles),
+    currentManualProfiles: toNumber(row.current_manual_profiles),
+    switchedAwayProfiles: toNumber(row.switched_away_profiles),
+    switchAwayRate: toNumber(row.switch_away_rate),
+    fursuitsCreatedAfterExposure: toNumber(row.fursuits_created_after_exposure),
+    catchesAfterExposure: toNumber(row.catches_after_exposure),
+    acceptedCatchesAfterExposure: toNumber(row.accepted_catches_after_exposure),
+    pendingCatchesAfterExposure: toNumber(row.pending_catches_after_exposure),
+  }));
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -795,6 +795,7 @@ export default function SettingsScreen() {
       }
 
       const previousCatchMode = profile?.default_catch_mode ?? 'AUTO_ACCEPT';
+      const previousPreferenceSource = profile?.catch_mode_preference_source ?? 'system_default';
       if (previousCatchMode === nextCatchMode) {
         return;
       }
@@ -839,7 +840,13 @@ export default function SettingsScreen() {
           caught instanceof Error ? caught.message : 'Could not save catch settings. Try again.',
         );
         queryClient.setQueryData<ProfileSummary | null>(profileQueryKey, (current) =>
-          current ? { ...current, default_catch_mode: previousCatchMode } : current,
+          current
+            ? {
+                ...current,
+                default_catch_mode: previousCatchMode,
+                catch_mode_preference_source: previousPreferenceSource,
+              }
+            : current,
         );
       } finally {
         setIsSavingCatchMode(false);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -55,13 +55,15 @@ import {
   normalizeUsernameInput,
   USERNAME_MAX_LENGTH,
   uploadProfileAvatar,
+  updateProfileCatchMode,
   updateProfileAvatar,
   updateProfileSocialLinks,
   validateUsername,
   PROFILE_QUERY_KEY,
   PROFILE_STALE_TIME,
 } from '../../src/features/profile';
-import type { ProfileSummary } from '../../src/features/profile';
+import type { CatchMode, ProfileSummary } from '../../src/features/profile';
+import { CatchModeSwitch } from '../../src/features/catch-confirmations';
 import type { FursuitPhotoCandidate } from '../../src/features/onboarding/api/onboarding';
 import type { EditableSocialLink } from '../../src/features/suits/forms/socialLinks';
 import {
@@ -223,6 +225,9 @@ export default function SettingsScreen() {
   const [isSavingSocialLinks, setIsSavingSocialLinks] = useState(false);
   const [socialLinksError, setSocialLinksError] = useState<string | null>(null);
   const [socialLinksMessage, setSocialLinksMessage] = useState<string | null>(null);
+  const [isSavingCatchMode, setIsSavingCatchMode] = useState(false);
+  const [catchModeError, setCatchModeError] = useState<string | null>(null);
+  const [catchModeMessage, setCatchModeMessage] = useState<string | null>(null);
   const [hasHydratedSocialLinks, setHasHydratedSocialLinks] = useState(false);
 
   const [isSaving, setIsSaving] = useState(false);
@@ -665,6 +670,8 @@ export default function SettingsScreen() {
               avatar_path: null,
               avatar_url: null,
               social_links: [],
+              default_catch_mode: 'AUTO_ACCEPT',
+              catch_mode_preference_source: 'system_default',
               is_new: false,
               onboarding_completed: false,
             },
@@ -780,6 +787,73 @@ export default function SettingsScreen() {
       setIsUploadingAvatar(false);
     }
   }, [userId, isUploadingAvatar, profile?.bio, profile?.username, profileQueryKey, queryClient]);
+
+  const handleCatchModeChange = useCallback(
+    async (nextCatchMode: CatchMode) => {
+      if (!userId || isSavingCatchMode) {
+        return;
+      }
+
+      const previousCatchMode = profile?.default_catch_mode ?? 'AUTO_ACCEPT';
+      if (previousCatchMode === nextCatchMode) {
+        return;
+      }
+
+      setIsSavingCatchMode(true);
+      setCatchModeError(null);
+      setCatchModeMessage(null);
+
+      try {
+        await updateProfileCatchMode(userId, nextCatchMode);
+
+        queryClient.setQueryData<ProfileSummary | null>(profileQueryKey, (current) =>
+          current
+            ? {
+                ...current,
+                default_catch_mode: nextCatchMode,
+                catch_mode_preference_source: 'user_selected',
+              }
+            : current,
+        );
+
+        setCatchModeMessage('Catch settings saved');
+
+        void emitGameplayEvent({
+          type: 'profile_catch_mode_changed',
+          payload: {
+            previous_catch_mode: previousCatchMode,
+            new_catch_mode: nextCatchMode,
+            previous_preference_source: profile?.catch_mode_preference_source ?? 'system_default',
+            preference_source: 'user_selected',
+            source: 'settings',
+          },
+          idempotencyKey: `profile-catch-mode:${userId}:${Date.now()}`,
+        }).catch((error) => {
+          captureHandledException(error, {
+            scope: 'settings.handleCatchModeChange.event',
+            userId,
+          });
+        });
+      } catch (caught) {
+        setCatchModeError(
+          caught instanceof Error ? caught.message : 'Could not save catch settings. Try again.',
+        );
+        queryClient.setQueryData<ProfileSummary | null>(profileQueryKey, (current) =>
+          current ? { ...current, default_catch_mode: previousCatchMode } : current,
+        );
+      } finally {
+        setIsSavingCatchMode(false);
+      }
+    },
+    [
+      userId,
+      isSavingCatchMode,
+      profile?.default_catch_mode,
+      profile?.catch_mode_preference_source,
+      profileQueryKey,
+      queryClient,
+    ],
+  );
 
   const socialLinksCanAddMore = socialLinks.length < SOCIAL_LINK_LIMIT;
 
@@ -1300,6 +1374,17 @@ export default function SettingsScreen() {
                 style={styles.bioInput}
                 placeholder="Share species, favorite cons, or a quick hello."
               />
+            </View>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.sectionTitle}>Catch settings</Text>
+              <CatchModeSwitch
+                value={profile?.default_catch_mode ?? 'AUTO_ACCEPT'}
+                onChange={handleCatchModeChange}
+                disabled={isProfileLoading || isSavingCatchMode}
+                scope="profile"
+              />
+              {catchModeError ? <Text style={styles.error}>{catchModeError}</Text> : null}
+              {catchModeMessage ? <Text style={styles.success}>{catchModeMessage}</Text> : null}
             </View>
             {saveError ? <Text style={styles.error}>{saveError}</Text> : null}
             <TailTagButton

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -27,7 +27,6 @@ import {
   createMySuitsCountQueryOptions,
 } from '../../../src/features/suits';
 import { MAX_FURSUITS_PER_USER } from '../../../src/constants/fursuits';
-import { CatchModeSwitch, type CatchMode } from '../../../src/features/catch-confirmations';
 import {
   ensureSpeciesEntry,
   fetchFursuitSpecies,
@@ -50,7 +49,12 @@ import {
   fetchActiveProfileConventionIds,
 } from '../../../src/features/conventions';
 import { ConventionToggle } from '../../../src/components/conventions/ConventionToggle';
-import { createProfileQueryOptions } from '../../../src/features/profile';
+import {
+  createProfileQueryOptions,
+  getOrAssignCatchModeDefaultExperiment,
+  PROFILE_QUERY_KEY,
+} from '../../../src/features/profile';
+import type { ProfileSummary } from '../../../src/features/profile';
 import { emitGameplayEvent } from '../../../src/features/events';
 import { DAILY_TASKS_QUERY_KEY } from '../../../src/features/daily-tasks/hooks';
 import type {
@@ -149,7 +153,6 @@ export default function AddFursuitScreen() {
   const [socialLinks, setSocialLinks] = useState<EditableSocialLink[]>(() =>
     createInitialSocialLinks(),
   );
-  const [catchMode, setCatchMode] = useState<CatchMode>('AUTO_ACCEPT');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -177,6 +180,84 @@ export default function AddFursuitScreen() {
       .filter((option) => option.normalizedName.includes(normalizedSpeciesInput))
       .slice(0, 12);
   }, [normalizedSpeciesInput, speciesOptions]);
+
+  useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const exposeCatchModeExperiment = async () => {
+      try {
+        const assignment = await getOrAssignCatchModeDefaultExperiment();
+
+        if (!isMounted || !assignment) {
+          return;
+        }
+
+        queryClient.setQueryData<ProfileSummary | null>([PROFILE_QUERY_KEY, userId], (current) =>
+          current
+            ? {
+                ...current,
+                default_catch_mode: assignment.currentCatchMode,
+                catch_mode_preference_source: assignment.currentPreferenceSource,
+              }
+            : current,
+        );
+
+        const commonPayload = {
+          experiment_key: assignment.experimentKey,
+          variant: assignment.variant,
+          previous_catch_mode: assignment.previousCatchMode,
+          current_catch_mode: assignment.currentCatchMode,
+          previous_preference_source: assignment.previousPreferenceSource,
+          preference_source: assignment.currentPreferenceSource,
+          default_applied: assignment.defaultApplied,
+          source: 'add_fursuit',
+        };
+
+        if (assignment.assignmentCreated) {
+          void emitGameplayEvent({
+            type: 'experiment_assigned',
+            payload: commonPayload,
+            occurredAt: assignment.exposedAt,
+            idempotencyKey: `${assignment.experimentKey}:${userId}:assigned`,
+          });
+        }
+
+        void emitGameplayEvent({
+          type: 'experiment_exposed',
+          payload: commonPayload,
+          occurredAt: assignment.exposedAt,
+          idempotencyKey: `${assignment.experimentKey}:${userId}:exposed:${assignment.exposedAt}`,
+        });
+
+        if (assignment.defaultApplied) {
+          void emitGameplayEvent({
+            type: 'catch_mode_default_applied',
+            payload: {
+              ...commonPayload,
+              new_catch_mode: assignment.currentCatchMode,
+            },
+            occurredAt: assignment.exposedAt,
+            idempotencyKey: `${assignment.experimentKey}:${userId}:default-applied`,
+          });
+        }
+      } catch (error) {
+        captureNonCriticalError(error, {
+          scope: 'add-fursuit.catchModeExperiment',
+          userId,
+        });
+      }
+    };
+
+    void exposeCatchModeExperiment();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [queryClient, userId]);
 
   const handleSpeciesInputChange = useCallback(
     (value: string) => {
@@ -542,7 +623,6 @@ export default function AddFursuitScreen() {
           avatar_path: avatarPath,
           avatar_url: avatarUrl,
           unique_code: uniqueCode,
-          catch_mode: catchMode,
         };
         const { data: inserted, error } = await (supabase as any)
           .from('fursuits')
@@ -632,7 +712,6 @@ export default function AddFursuitScreen() {
       setAskMeAboutInput('');
       setMakers(createInitialFursuitMakers());
       setSocialLinks(createInitialSocialLinks());
-      setCatchMode('AUTO_ACCEPT');
       setSelectedConventionIds(new Set(activeProfileConventionIds));
       setHasHydratedConventions(true);
       setSelectedPhoto(null);
@@ -1031,15 +1110,6 @@ export default function AddFursuitScreen() {
               numberOfLines={2}
               textAlignVertical="top"
               style={styles.textArea}
-            />
-          </View>
-
-          <View style={styles.fieldGroup}>
-            <Text style={styles.label}>Catch settings</Text>
-            <CatchModeSwitch
-              value={catchMode}
-              onChange={setCatchMode}
-              disabled={isSubmitting}
             />
           </View>
 

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Keyboard, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 
@@ -159,6 +159,7 @@ export default function AddFursuitScreen() {
   const [selectedPhoto, setSelectedPhoto] = useState<UploadCandidate>(null);
   const [isProcessingPhoto, setIsProcessingPhoto] = useState(false);
   const [photoError, setPhotoError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
 
   const speciesLoadError = speciesError?.message ?? null;
   const isSpeciesBusy = isSpeciesLoading;
@@ -182,81 +183,86 @@ export default function AddFursuitScreen() {
   }, [normalizedSpeciesInput, speciesOptions]);
 
   useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const exposeCatchModeExperiment = useCallback(async () => {
     if (!userId) {
       return;
     }
 
-    let isMounted = true;
+    try {
+      const assignment = await getOrAssignCatchModeDefaultExperiment();
 
-    const exposeCatchModeExperiment = async () => {
-      try {
-        const assignment = await getOrAssignCatchModeDefaultExperiment();
+      if (!isMountedRef.current || !assignment) {
+        return;
+      }
 
-        if (!isMounted || !assignment) {
-          return;
-        }
+      queryClient.setQueryData<ProfileSummary | null>([PROFILE_QUERY_KEY, userId], (current) =>
+        current
+          ? {
+              ...current,
+              default_catch_mode: assignment.currentCatchMode,
+              catch_mode_preference_source: assignment.currentPreferenceSource,
+            }
+          : current,
+      );
 
-        queryClient.setQueryData<ProfileSummary | null>([PROFILE_QUERY_KEY, userId], (current) =>
-          current
-            ? {
-                ...current,
-                default_catch_mode: assignment.currentCatchMode,
-                catch_mode_preference_source: assignment.currentPreferenceSource,
-              }
-            : current,
-        );
+      const commonPayload = {
+        experiment_key: assignment.experimentKey,
+        variant: assignment.variant,
+        previous_catch_mode: assignment.previousCatchMode,
+        current_catch_mode: assignment.currentCatchMode,
+        previous_preference_source: assignment.previousPreferenceSource,
+        preference_source: assignment.currentPreferenceSource,
+        default_applied: assignment.defaultApplied,
+        source: 'add_fursuit',
+      };
 
-        const commonPayload = {
-          experiment_key: assignment.experimentKey,
-          variant: assignment.variant,
-          previous_catch_mode: assignment.previousCatchMode,
-          current_catch_mode: assignment.currentCatchMode,
-          previous_preference_source: assignment.previousPreferenceSource,
-          preference_source: assignment.currentPreferenceSource,
-          default_applied: assignment.defaultApplied,
-          source: 'add_fursuit',
-        };
-
-        if (assignment.assignmentCreated) {
-          void emitGameplayEvent({
-            type: 'experiment_assigned',
-            payload: commonPayload,
-            occurredAt: assignment.exposedAt,
-            idempotencyKey: `${assignment.experimentKey}:${userId}:assigned`,
-          });
-        }
-
-        void emitGameplayEvent({
-          type: 'experiment_exposed',
-          payload: commonPayload,
-          occurredAt: assignment.exposedAt,
-          idempotencyKey: `${assignment.experimentKey}:${userId}:exposed:${assignment.exposedAt}`,
-        });
-
-        if (assignment.defaultApplied) {
-          void emitGameplayEvent({
-            type: 'catch_mode_default_applied',
-            payload: {
-              ...commonPayload,
-              new_catch_mode: assignment.currentCatchMode,
-            },
-            occurredAt: assignment.exposedAt,
-            idempotencyKey: `${assignment.experimentKey}:${userId}:default-applied`,
-          });
-        }
-      } catch (error) {
+      const captureExperimentEventError = (eventType: string) => (error: unknown) => {
         captureNonCriticalError(error, {
-          scope: 'add-fursuit.catchModeExperiment',
+          scope: 'add-fursuit.catchModeExperiment.event',
+          eventType,
+          experimentKey: assignment.experimentKey,
           userId,
         });
+      };
+
+      if (assignment.assignmentCreated) {
+        void emitGameplayEvent({
+          type: 'experiment_assigned',
+          payload: commonPayload,
+          occurredAt: assignment.exposedAt,
+          idempotencyKey: `${assignment.experimentKey}:${userId}:assigned`,
+        }).catch(captureExperimentEventError('experiment_assigned'));
       }
-    };
 
-    void exposeCatchModeExperiment();
+      void emitGameplayEvent({
+        type: 'experiment_exposed',
+        payload: commonPayload,
+        occurredAt: assignment.exposedAt,
+        idempotencyKey: `${assignment.experimentKey}:${userId}:exposed:${assignment.exposedAt}`,
+      }).catch(captureExperimentEventError('experiment_exposed'));
 
-    return () => {
-      isMounted = false;
-    };
+      if (assignment.defaultApplied) {
+        void emitGameplayEvent({
+          type: 'catch_mode_default_applied',
+          payload: {
+            ...commonPayload,
+            new_catch_mode: assignment.currentCatchMode,
+          },
+          occurredAt: assignment.exposedAt,
+          idempotencyKey: `${assignment.experimentKey}:${userId}:default-applied`,
+        }).catch(captureExperimentEventError('catch_mode_default_applied'));
+      }
+    } catch (error) {
+      captureNonCriticalError(error, {
+        scope: 'add-fursuit.catchModeExperiment',
+        userId,
+      });
+    }
   }, [queryClient, userId]);
 
   const handleSpeciesInputChange = useCallback(
@@ -723,6 +729,7 @@ export default function AddFursuitScreen() {
         queryKey: [MY_SUITS_COUNT_QUERY_KEY, userId],
       });
       void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
+      void exposeCatchModeExperiment();
 
       // Navigate immediately
       router.replace('/suits');

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -60,7 +60,6 @@ import {
   type FursuitColorOption,
 } from '../../../src/features/colors';
 import { useAuth } from '../../../src/features/auth';
-import { CatchModeSwitch, type CatchMode } from '../../../src/features/catch-confirmations';
 import { supabase } from '../../../src/lib/supabase';
 import { FURSUIT_BUCKET } from '../../../src/constants/storage';
 import { loadUriAsUint8Array } from '../../../src/utils/files';
@@ -204,8 +203,6 @@ export default function EditFursuitScreen() {
   const [selectedSpecies, setSelectedSpecies] = useState<FursuitSpeciesOption | null>(null);
   const [selectedColors, setSelectedColors] = useState<FursuitColorOption[]>([]);
   const [initialColors, setInitialColors] = useState<FursuitColorOption[]>([]);
-  const [catchMode, setCatchMode] = useState<CatchMode>('AUTO_ACCEPT');
-  const [initialCatchMode, setInitialCatchMode] = useState<CatchMode>('AUTO_ACCEPT');
   const [selectedPhoto, setSelectedPhoto] = useState<UploadCandidate>(null);
   const [isProcessingPhoto, setIsProcessingPhoto] = useState(false);
   const [photoError, setPhotoError] = useState<string | null>(null);
@@ -330,10 +327,6 @@ export default function EditFursuitScreen() {
     const resolvedColors = detail.colors ?? [];
     setSelectedColors(resolvedColors);
     setInitialColors(resolvedColors);
-
-    const resolvedCatchMode = detail.catchMode ?? 'AUTO_ACCEPT';
-    setCatchMode(resolvedCatchMode);
-    setInitialCatchMode(resolvedCatchMode);
 
     setHasHydratedForm(true);
   }, [detail, hasHydratedForm]);
@@ -527,7 +520,6 @@ export default function EditFursuitScreen() {
     const client = supabase as any;
     const previousName = detail.name;
     const previousSpeciesId = detail.speciesId ?? null;
-    const previousCatchMode = initialCatchMode;
     const previousAvatarPath = detail.avatar_path ?? null;
     const previousAvatarUrl = detail.avatar_url;
     const initialNormalizedMakers = fursuitMakersToSave(initialMakers);
@@ -591,7 +583,6 @@ export default function EditFursuitScreen() {
         .update({
           name: trimmedName,
           species_id: speciesRecord.id,
-          catch_mode: catchMode,
           ...(newAvatarPath !== undefined
             ? { avatar_path: newAvatarPath, avatar_url: newAvatarUrl }
             : {}),
@@ -708,7 +699,6 @@ export default function EditFursuitScreen() {
       setInitialConventionIds(new Set(selectedConventionIds));
       setInitialColors(selectedColors);
       setInitialMakers(makers);
-      setInitialCatchMode(catchMode);
 
       router.back();
     } catch (caught) {
@@ -772,7 +762,6 @@ export default function EditFursuitScreen() {
           .update({
             name: previousName,
             species_id: previousSpeciesId,
-            catch_mode: previousCatchMode,
             avatar_path: previousAvatarPath,
             avatar_url: previousAvatarUrl,
           })
@@ -782,9 +771,6 @@ export default function EditFursuitScreen() {
         if (revertError) {
           console.warn('Failed to revert fursuit record after edit error', revertError);
         }
-
-        // Also revert local state for catch mode
-        setCatchMode(previousCatchMode);
       }
     } finally {
       setIsSubmitting(false);
@@ -1159,15 +1145,6 @@ export default function EditFursuitScreen() {
                   numberOfLines={2}
                   textAlignVertical="top"
                   style={styles.textArea}
-                />
-              </View>
-
-              <View style={styles.fieldGroup}>
-                <Text style={styles.label}>Catch settings</Text>
-                <CatchModeSwitch
-                  value={catchMode}
-                  onChange={setCatchMode}
-                  disabled={disableForm}
                 />
               </View>
 

--- a/src/features/catch-confirmations/api/confirmations.ts
+++ b/src/features/catch-confirmations/api/confirmations.ts
@@ -17,7 +17,6 @@ import {
 import { emitLocalGameplayEvent } from '../../events/localGameplayEventsBus';
 import type { Json } from '../../../types/database';
 import type {
-  CatchMode,
   PendingCatch,
   ConfirmCatchResult,
   CreateCatchResult,
@@ -217,29 +216,8 @@ export async function confirmCatch(
 }
 
 /**
- * Update fursuit catch mode
- */
-export async function updateFursuitCatchMode(
-  fursuitId: string,
-  userId: string,
-  catchMode: CatchMode,
-): Promise<void> {
-  const client = supabase as any;
-
-  const { error } = await client
-    .from('fursuits')
-    .update({ catch_mode: catchMode })
-    .eq('id', fursuitId)
-    .eq('owner_id', userId);
-
-  if (error) {
-    throw new Error("We couldn't update the catch mode. Please try again.");
-  }
-}
-
-/**
  * Create a catch via the Edge Function.
- * Handles auto-accept vs manual approval based on fursuit settings.
+ * Handles auto-accept vs manual approval based on the owner's profile settings.
  */
 export async function createCatch(params: CreateCatchParams): Promise<CreateCatchResult> {
   const { data: sessionData } = await supabase.auth.getSession();

--- a/src/features/catch-confirmations/api/index.ts
+++ b/src/features/catch-confirmations/api/index.ts
@@ -4,7 +4,6 @@ export {
   pendingCatchesQueryKey,
   fetchPendingCatches,
   confirmCatch,
-  updateFursuitCatchMode,
   createCatch,
   updateCatchPhoto,
   fetchConventionFursuits,

--- a/src/features/catch-confirmations/components/CatchModeSwitch.tsx
+++ b/src/features/catch-confirmations/components/CatchModeSwitch.tsx
@@ -9,11 +9,39 @@ type CatchModeSwitchProps = {
   value: CatchMode;
   onChange: (mode: CatchMode) => void | Promise<void>;
   disabled?: boolean;
+  scope?: 'fursuit' | 'profile';
 };
 
-export function CatchModeSwitch({ value, onChange, disabled = false }: CatchModeSwitchProps) {
+export function CatchModeSwitch({
+  value,
+  onChange,
+  disabled = false,
+  scope = 'fursuit',
+}: CatchModeSwitchProps) {
   const [isUpdating, setIsUpdating] = useState(false);
   const isAutoCatchingEnabled = value === 'AUTO_ACCEPT';
+  const copy =
+    scope === 'profile'
+      ? {
+          label: 'Auto-catching for all suits',
+          autoDescription: 'Catches for your suits are recorded instantly without your approval.',
+          manualDescription: 'Players must wait for you to approve catches for your suits.',
+          accessibilityLabel: 'Auto-catching for all suits',
+          autoHint:
+            'Currently enabled for all your suits. Toggle to require manual approval for catches.',
+          manualHint:
+            'Currently disabled for all your suits. Players must wait for approval. Toggle to auto-accept catches.',
+        }
+      : {
+          label: 'Auto-catching',
+          autoDescription: 'Catches are recorded instantly without requiring your approval.',
+          manualDescription: 'Players must wait for you to approve their catch before it counts.',
+          accessibilityLabel: 'Auto-catching',
+          autoHint:
+            'Currently enabled. Catches are recorded instantly. Toggle to require manual approval.',
+          manualHint:
+            'Currently disabled. Players must wait for approval. Toggle to auto-accept catches.',
+        };
 
   const handleToggle = useCallback(
     async (newValue: boolean) => {
@@ -35,11 +63,9 @@ export function CatchModeSwitch({ value, onChange, disabled = false }: CatchMode
   return (
     <View style={styles.container}>
       <View style={styles.textContainer}>
-        <Text style={styles.label}>Auto-catching</Text>
+        <Text style={styles.label}>{copy.label}</Text>
         <Text style={styles.description}>
-          {isAutoCatchingEnabled
-            ? 'Catches are recorded instantly without requiring your approval.'
-            : 'Players must wait for you to approve their catch before it counts.'}
+          {isAutoCatchingEnabled ? copy.autoDescription : copy.manualDescription}
         </Text>
       </View>
       <Switch
@@ -53,12 +79,8 @@ export function CatchModeSwitch({ value, onChange, disabled = false }: CatchMode
         thumbColor={isAutoCatchingEnabled ? colors.primary : 'rgba(203,213,225,0.9)'}
         ios_backgroundColor="rgba(148,163,184,0.3)"
         accessibilityRole="switch"
-        accessibilityLabel="Auto-catching"
-        accessibilityHint={
-          isAutoCatchingEnabled
-            ? 'Currently enabled. Catches are recorded instantly. Toggle to require manual approval.'
-            : 'Currently disabled. Players must wait for approval. Toggle to auto-accept catches.'
-        }
+        accessibilityLabel={copy.accessibilityLabel}
+        accessibilityHint={isAutoCatchingEnabled ? copy.autoHint : copy.manualHint}
         accessibilityState={{
           checked: isAutoCatchingEnabled,
           disabled: disabled || isUpdating,

--- a/src/features/catch-confirmations/index.ts
+++ b/src/features/catch-confirmations/index.ts
@@ -29,7 +29,6 @@ export {
   pendingCatchesQueryKey,
   fetchPendingCatches,
   confirmCatch,
-  updateFursuitCatchMode,
   createCatch,
   fetchConventionFursuits,
   MY_PENDING_CATCHES_QUERY_KEY,

--- a/src/features/onboarding/components/AchievementStep.tsx
+++ b/src/features/onboarding/components/AchievementStep.tsx
@@ -45,6 +45,8 @@ export function AchievementStep({
         bio: current?.bio ?? null,
         avatar_url: current?.avatar_url ?? null,
         social_links: current?.social_links ?? [],
+        default_catch_mode: current?.default_catch_mode ?? 'AUTO_ACCEPT',
+        catch_mode_preference_source: current?.catch_mode_preference_source ?? 'system_default',
         onboarding_completed: true,
         is_new: false,
         role: current?.role,

--- a/src/features/onboarding/components/AchievementStep.tsx
+++ b/src/features/onboarding/components/AchievementStep.tsx
@@ -40,17 +40,15 @@ export function AchievementStep({
     try {
       await completeOnboarding(userId);
 
-      queryClient.setQueryData<ProfileSummary | null>(profileQueryKey(userId), (current) => ({
-        username: current?.username ?? null,
-        bio: current?.bio ?? null,
-        avatar_url: current?.avatar_url ?? null,
-        social_links: current?.social_links ?? [],
-        default_catch_mode: current?.default_catch_mode ?? 'AUTO_ACCEPT',
-        catch_mode_preference_source: current?.catch_mode_preference_source ?? 'system_default',
-        onboarding_completed: true,
-        is_new: false,
-        role: current?.role,
-      }));
+      queryClient.setQueryData<ProfileSummary | null>(profileQueryKey(userId), (current) =>
+        current
+          ? {
+              ...current,
+              onboarding_completed: true,
+              is_new: false,
+            }
+          : current,
+      );
 
       await queryClient.invalidateQueries({
         queryKey: profileQueryKey(userId),

--- a/src/features/onboarding/components/FursuitStep.tsx
+++ b/src/features/onboarding/components/FursuitStep.tsx
@@ -26,8 +26,14 @@ import {
   fetchActiveProfileConventionIds,
 } from '../../conventions';
 import { captureHandledException } from '../../../lib/sentry';
+import { emitGameplayEvent } from '../../events';
 import { processImageForUpload, IMAGE_UPLOAD_PRESETS } from '../../../utils/images';
 import { colors } from '../../../theme';
+import {
+  getOrAssignCatchModeDefaultExperiment,
+  PROFILE_QUERY_KEY,
+  type ProfileSummary,
+} from '../../profile';
 import {
   fetchFursuitColors,
   FURSUIT_COLORS_QUERY_KEY,
@@ -171,6 +177,80 @@ export function FursuitStep({
         .filter((option): option is FursuitColorOption => Boolean(option)),
     [colorOptions, selectedColorIds],
   );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const exposeCatchModeExperiment = async () => {
+      try {
+        const assignment = await getOrAssignCatchModeDefaultExperiment();
+
+        if (!isMounted || !assignment) {
+          return;
+        }
+
+        queryClient.setQueryData<ProfileSummary | null>([PROFILE_QUERY_KEY, userId], (current) =>
+          current
+            ? {
+                ...current,
+                default_catch_mode: assignment.currentCatchMode,
+                catch_mode_preference_source: assignment.currentPreferenceSource,
+              }
+            : current,
+        );
+
+        const commonPayload = {
+          experiment_key: assignment.experimentKey,
+          variant: assignment.variant,
+          previous_catch_mode: assignment.previousCatchMode,
+          current_catch_mode: assignment.currentCatchMode,
+          previous_preference_source: assignment.previousPreferenceSource,
+          preference_source: assignment.currentPreferenceSource,
+          default_applied: assignment.defaultApplied,
+          source: 'onboarding_fursuit',
+        };
+
+        if (assignment.assignmentCreated) {
+          void emitGameplayEvent({
+            type: 'experiment_assigned',
+            payload: commonPayload,
+            occurredAt: assignment.exposedAt,
+            idempotencyKey: `${assignment.experimentKey}:${userId}:assigned`,
+          });
+        }
+
+        void emitGameplayEvent({
+          type: 'experiment_exposed',
+          payload: commonPayload,
+          occurredAt: assignment.exposedAt,
+          idempotencyKey: `${assignment.experimentKey}:${userId}:exposed:${assignment.exposedAt}`,
+        });
+
+        if (assignment.defaultApplied) {
+          void emitGameplayEvent({
+            type: 'catch_mode_default_applied',
+            payload: {
+              ...commonPayload,
+              new_catch_mode: assignment.currentCatchMode,
+            },
+            occurredAt: assignment.exposedAt,
+            idempotencyKey: `${assignment.experimentKey}:${userId}:default-applied`,
+          });
+        }
+      } catch (error) {
+        captureHandledException(error, {
+          scope: 'onboarding.fursuitStep.catchModeExperiment',
+          userId,
+        });
+      }
+    };
+
+    void exposeCatchModeExperiment();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [queryClient, userId]);
 
   useEffect(() => {
     onDraftChange({

--- a/src/features/onboarding/components/FursuitStep.tsx
+++ b/src/features/onboarding/components/FursuitStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Keyboard, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 
@@ -41,6 +41,8 @@ import {
   type FursuitColorOption,
 } from '../../colors';
 import { styles } from './FursuitStep.styles';
+
+const EXPERIMENT_EVENT_TIMEOUT_MS = 5000;
 
 type FursuitStepProps = {
   userId: string;
@@ -143,6 +145,7 @@ export function FursuitStep({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedColorIds, setSelectedColorIds] = useState<string[]>(draft.selectedColorIds);
+  const isMountedRef = useRef(true);
   const colorLoadError = colorError?.message ?? null;
   const isColorBusy = isColorLoading;
 
@@ -179,78 +182,103 @@ export function FursuitStep({
   );
 
   useEffect(() => {
-    let isMounted = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
-    const exposeCatchModeExperiment = async () => {
-      try {
-        const assignment = await getOrAssignCatchModeDefaultExperiment();
+  const createTimeoutPromise = useCallback(
+    (eventType: string) =>
+      new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(
+            new Error(
+              `Catch mode experiment event timed out after ${EXPERIMENT_EVENT_TIMEOUT_MS}ms (${eventType})`,
+            ),
+          );
+        }, EXPERIMENT_EVENT_TIMEOUT_MS);
+      }),
+    [],
+  );
 
-        if (!isMounted || !assignment) {
-          return;
-        }
+  const exposeCatchModeExperiment = useCallback(async () => {
+    try {
+      const assignment = await getOrAssignCatchModeDefaultExperiment();
 
-        queryClient.setQueryData<ProfileSummary | null>([PROFILE_QUERY_KEY, userId], (current) =>
-          current
-            ? {
-                ...current,
-                default_catch_mode: assignment.currentCatchMode,
-                catch_mode_preference_source: assignment.currentPreferenceSource,
-              }
-            : current,
+      if (!isMountedRef.current || !assignment) {
+        return;
+      }
+
+      queryClient.setQueryData<ProfileSummary | null>([PROFILE_QUERY_KEY, userId], (current) =>
+        current
+          ? {
+              ...current,
+              default_catch_mode: assignment.currentCatchMode,
+              catch_mode_preference_source: assignment.currentPreferenceSource,
+            }
+          : current,
+      );
+
+      const commonPayload = {
+        experiment_key: assignment.experimentKey,
+        variant: assignment.variant,
+        previous_catch_mode: assignment.previousCatchMode,
+        current_catch_mode: assignment.currentCatchMode,
+        previous_preference_source: assignment.previousPreferenceSource,
+        preference_source: assignment.currentPreferenceSource,
+        default_applied: assignment.defaultApplied,
+        source: 'onboarding_fursuit',
+      };
+
+      const emitExperimentEvent = (input: Parameters<typeof emitGameplayEvent>[0]) => {
+        const eventType = input.type;
+
+        void Promise.race([emitGameplayEvent(input), createTimeoutPromise(eventType)]).catch(
+          (error) => {
+            captureHandledException(error, {
+              scope: 'onboarding.fursuitStep.catchModeExperiment.event',
+              eventType,
+              experimentKey: assignment.experimentKey,
+              userId,
+            });
+          },
         );
+      };
 
-        const commonPayload = {
-          experiment_key: assignment.experimentKey,
-          variant: assignment.variant,
-          previous_catch_mode: assignment.previousCatchMode,
-          current_catch_mode: assignment.currentCatchMode,
-          previous_preference_source: assignment.previousPreferenceSource,
-          preference_source: assignment.currentPreferenceSource,
-          default_applied: assignment.defaultApplied,
-          source: 'onboarding_fursuit',
-        };
-
-        if (assignment.assignmentCreated) {
-          void emitGameplayEvent({
-            type: 'experiment_assigned',
-            payload: commonPayload,
-            occurredAt: assignment.exposedAt,
-            idempotencyKey: `${assignment.experimentKey}:${userId}:assigned`,
-          });
-        }
-
-        void emitGameplayEvent({
-          type: 'experiment_exposed',
+      if (assignment.assignmentCreated) {
+        emitExperimentEvent({
+          type: 'experiment_assigned',
           payload: commonPayload,
           occurredAt: assignment.exposedAt,
-          idempotencyKey: `${assignment.experimentKey}:${userId}:exposed:${assignment.exposedAt}`,
-        });
-
-        if (assignment.defaultApplied) {
-          void emitGameplayEvent({
-            type: 'catch_mode_default_applied',
-            payload: {
-              ...commonPayload,
-              new_catch_mode: assignment.currentCatchMode,
-            },
-            occurredAt: assignment.exposedAt,
-            idempotencyKey: `${assignment.experimentKey}:${userId}:default-applied`,
-          });
-        }
-      } catch (error) {
-        captureHandledException(error, {
-          scope: 'onboarding.fursuitStep.catchModeExperiment',
-          userId,
+          idempotencyKey: `${assignment.experimentKey}:${userId}:assigned`,
         });
       }
-    };
 
-    void exposeCatchModeExperiment();
+      emitExperimentEvent({
+        type: 'experiment_exposed',
+        payload: commonPayload,
+        occurredAt: assignment.exposedAt,
+        idempotencyKey: `${assignment.experimentKey}:${userId}:exposed:${assignment.exposedAt}`,
+      });
 
-    return () => {
-      isMounted = false;
-    };
-  }, [queryClient, userId]);
+      if (assignment.defaultApplied) {
+        emitExperimentEvent({
+          type: 'catch_mode_default_applied',
+          payload: {
+            ...commonPayload,
+            new_catch_mode: assignment.currentCatchMode,
+          },
+          occurredAt: assignment.exposedAt,
+          idempotencyKey: `${assignment.experimentKey}:${userId}:default-applied`,
+        });
+      }
+    } catch (error) {
+      captureHandledException(error, {
+        scope: 'onboarding.fursuitStep.catchModeExperiment',
+        userId,
+      });
+    }
+  }, [createTimeoutPromise, queryClient, userId]);
 
   useEffect(() => {
     onDraftChange({
@@ -449,6 +477,7 @@ export function FursuitStep({
       }
 
       queryClient.invalidateQueries({ queryKey: [MY_SUITS_QUERY_KEY, userId] });
+      void exposeCatchModeExperiment();
 
       await deleteDraftPhoto(userId, selectedPhoto);
       resetForm();

--- a/src/features/profile/api/profile.ts
+++ b/src/features/profile/api/profile.ts
@@ -7,7 +7,7 @@ import {
   resolveStorageMediaUrl,
 } from '../../../utils/supabase-image';
 import type { FursuitPhotoCandidate } from '../../onboarding/api/onboarding';
-import type { FursuitSocialLink } from '../../../types/database';
+import type { Database, FursuitSocialLink } from '../../../types/database';
 import {
   buildGeneratedUsername,
   normalizeUsernameInput,
@@ -16,6 +16,25 @@ import {
 } from '../usernameRules';
 
 type UserRole = 'player' | 'staff' | 'moderator' | 'organizer' | 'owner';
+export type CatchMode = Database['public']['Enums']['catch_mode'];
+export type CatchModePreferenceSource =
+  | 'system_default'
+  | 'migrated_from_suits'
+  | 'experiment_default'
+  | 'user_selected';
+
+export type CatchModeExperimentAssignment = {
+  experimentKey: string;
+  variant: 'auto_default' | 'manual_default';
+  profileId: string;
+  previousCatchMode: CatchMode;
+  currentCatchMode: CatchMode;
+  previousPreferenceSource: CatchModePreferenceSource;
+  currentPreferenceSource: CatchModePreferenceSource;
+  assignmentCreated: boolean;
+  defaultApplied: boolean;
+  exposedAt: string;
+};
 
 export type ProfileSummary = {
   username: string | null;
@@ -23,6 +42,8 @@ export type ProfileSummary = {
   avatar_path?: string | null;
   avatar_url: string | null;
   social_links: FursuitSocialLink[];
+  default_catch_mode: CatchMode;
+  catch_mode_preference_source: CatchModePreferenceSource;
   is_new: boolean;
   onboarding_completed: boolean;
   role?: UserRole;
@@ -41,8 +62,22 @@ export const profileQueryKey = (userId: string) => [PROFILE_QUERY_KEY, userId] a
 // Stable columns that have always existed — used as fallback when new columns aren't migrated yet.
 const STABLE_COLUMNS =
   'username, bio, is_new, onboarding_completed, role, push_notifications_enabled, push_notifications_prompted';
-const FULL_COLUMNS = `${STABLE_COLUMNS}, avatar_url, avatar_path, social_links, is_suspended, suspended_until, suspension_reason`;
+const FULL_COLUMNS = `${STABLE_COLUMNS}, avatar_url, avatar_path, social_links, default_catch_mode, catch_mode_preference_source, is_suspended, suspended_until, suspension_reason`;
 const NEW_USER_PROFILE_RETRY_DELAYS_MS = [150, 500] as const;
+
+const normalizeCatchMode = (value: unknown): CatchMode =>
+  value === 'MANUAL_APPROVAL' ? 'MANUAL_APPROVAL' : 'AUTO_ACCEPT';
+
+const normalizeCatchModePreferenceSource = (value: unknown): CatchModePreferenceSource => {
+  switch (value) {
+    case 'migrated_from_suits':
+    case 'experiment_default':
+    case 'user_selected':
+      return value;
+    default:
+      return 'system_default';
+  }
+};
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -134,6 +169,10 @@ function mapProfileData(data: any, overrides: Partial<ProfileSummary> = {}): Pro
     social_links: Array.isArray(data.social_links)
       ? (data.social_links as FursuitSocialLink[])
       : [],
+    default_catch_mode: normalizeCatchMode(data.default_catch_mode),
+    catch_mode_preference_source: normalizeCatchModePreferenceSource(
+      data.catch_mode_preference_source,
+    ),
     is_new: data.is_new === true,
     onboarding_completed: data.onboarding_completed === true,
     role: data.role ?? undefined,
@@ -253,6 +292,56 @@ export async function updateProfileSocialLinks(
   if (error) {
     throw new Error(`Could not save social links: ${error.message}`);
   }
+}
+
+export async function updateProfileCatchMode(userId: string, catchMode: CatchMode): Promise<void> {
+  const { error } = await (supabase as any)
+    .from('profiles')
+    .update({
+      default_catch_mode: catchMode,
+      catch_mode_preference_source: 'user_selected',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', userId);
+
+  if (error) {
+    throw new Error(`Could not save catch settings: ${error.message}`);
+  }
+}
+
+function mapCatchModeExperimentAssignment(raw: any): CatchModeExperimentAssignment {
+  return {
+    experimentKey: String(raw.experiment_key ?? 'catch_mode_default_v1'),
+    variant: raw.variant === 'manual_default' ? 'manual_default' : 'auto_default',
+    profileId: String(raw.profile_id ?? ''),
+    previousCatchMode: normalizeCatchMode(raw.previous_catch_mode),
+    currentCatchMode: normalizeCatchMode(raw.current_catch_mode),
+    previousPreferenceSource: normalizeCatchModePreferenceSource(raw.previous_preference_source),
+    currentPreferenceSource: normalizeCatchModePreferenceSource(raw.current_preference_source),
+    assignmentCreated: raw.assignment_created === true,
+    defaultApplied: raw.default_applied === true,
+    exposedAt:
+      typeof raw.exposed_at === 'string' && raw.exposed_at.length > 0
+        ? raw.exposed_at
+        : new Date().toISOString(),
+  };
+}
+
+export async function getOrAssignCatchModeDefaultExperiment(): Promise<CatchModeExperimentAssignment | null> {
+  const { data, error } = await (supabase as any).rpc(
+    'get_or_assign_catch_mode_default_experiment',
+  );
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) {
+    return null;
+  }
+
+  return mapCatchModeExperimentAssignment(row);
 }
 
 export async function checkUsernameAvailability(

--- a/src/features/profile/index.ts
+++ b/src/features/profile/index.ts
@@ -3,6 +3,8 @@ export {
   uploadProfileAvatar,
   updateProfileAvatar,
   updateProfileSocialLinks,
+  updateProfileCatchMode,
+  getOrAssignCatchModeDefaultExperiment,
   hasUploadedProfileAvatar,
   checkUsernameAvailability,
   PROFILE_QUERY_KEY,
@@ -20,5 +22,10 @@ export {
   toValidUsernameOrNull,
   buildGeneratedUsername,
 } from './usernameRules';
-export type { ProfileSummary } from './api/profile';
+export type {
+  CatchMode,
+  CatchModeExperimentAssignment,
+  CatchModePreferenceSource,
+  ProfileSummary,
+} from './api/profile';
 export type { UsernameValidationCode, UsernameValidationResult } from './usernameRules';

--- a/src/features/suits/api/catchById.ts
+++ b/src/features/suits/api/catchById.ts
@@ -1,6 +1,5 @@
 import { supabase } from '../../../lib/supabase';
 import type { FursuitSummary } from '../types';
-import type { CatchMode } from '../../catch-confirmations';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
 import { fetchFursuitMakersByFursuitIds } from './makers';
 import type { CaughtRecord } from './caughtSuits';
@@ -26,7 +25,6 @@ const CATCH_SELECT = `
     avatar_path,
     avatar_url,
     catch_count,
-    catch_mode,
     is_tutorial,
     description,
     unique_code,
@@ -80,8 +78,6 @@ export async function fetchCatchById(catchId: string): Promise<CaughtRecord | nu
     return null;
   }
 
-  const catchMode: CatchMode =
-    rawFursuit?.catch_mode === 'MANUAL_APPROVAL' ? 'MANUAL_APPROVAL' : 'AUTO_ACCEPT';
   const makersByFursuitId = await fetchFursuitMakersByFursuitIds(
     rawFursuit?.id ? [rawFursuit.id] : [],
   );
@@ -103,7 +99,6 @@ export async function fetchCatchById(catchId: string): Promise<CaughtRecord | nu
         description: rawFursuit.description ?? null,
         unique_code: rawFursuit.unique_code ?? null,
         catchCount: typeof rawFursuit.catch_count === 'number' ? rawFursuit.catch_count : 0,
-        catchMode,
         created_at: rawFursuit.created_at ?? null,
         conventions: [],
         makers: makersByFursuitId.get(rawFursuit.id) ?? [],

--- a/src/features/suits/api/caughtSuits.ts
+++ b/src/features/suits/api/caughtSuits.ts
@@ -1,6 +1,5 @@
 import { supabase } from '../../../lib/supabase';
 import type { FursuitSummary } from '../types';
-import type { CatchMode } from '../../catch-confirmations';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
 import { fetchFursuitMakersByFursuitIds } from './makers';
 import { CATCH_PHOTO_BUCKET, FURSUIT_BUCKET } from '../../../constants/storage';
@@ -39,7 +38,6 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
         avatar_path,
         avatar_url,
         catch_count,
-        catch_mode,
         is_tutorial,
         description,
         unique_code,
@@ -90,10 +88,6 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
         return null;
       }
 
-      // Default to AUTO_ACCEPT if not set
-      const catchMode: CatchMode =
-        rawFursuit?.catch_mode === 'MANUAL_APPROVAL' ? 'MANUAL_APPROVAL' : 'AUTO_ACCEPT';
-
       const fursuit = rawFursuit
         ? ({
             id: rawFursuit.id,
@@ -111,7 +105,6 @@ export async function fetchCaughtSuits(userId: string): Promise<CaughtRecord[]> 
             description: rawFursuit.description ?? null,
             unique_code: rawFursuit.unique_code ?? null,
             catchCount: typeof rawFursuit.catch_count === 'number' ? rawFursuit.catch_count : 0,
-            catchMode,
             created_at: rawFursuit.created_at ?? null,
             conventions: [],
             makers: makersByFursuitId.get(rawFursuit.id) ?? [],

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -2,7 +2,6 @@ import { supabase } from '../../../lib/supabase';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
 import { fetchFursuitMakersByFursuitIds } from './makers';
 import type { FursuitDetail } from '../types';
-import type { CatchMode } from '../../catch-confirmations';
 import { captureHandledMessage } from '../../../lib/sentry';
 import { FURSUIT_BUCKET } from '../../../constants/storage';
 import { resolveStorageMediaUrl } from '../../../utils/supabase-image';
@@ -27,7 +26,6 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       description,
       unique_code,
       catch_count,
-      catch_mode,
       created_at,
       species_entry:fursuit_species (
         id,
@@ -120,10 +118,6 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     }
   }
 
-  // Default to AUTO_ACCEPT if not set
-  const catchMode: CatchMode =
-    data.catch_mode === 'MANUAL_APPROVAL' ? 'MANUAL_APPROVAL' : 'AUTO_ACCEPT';
-
   return {
     id: data.id,
     owner_id: data.owner_id,
@@ -140,7 +134,6 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
     description: data.description ?? null,
     unique_code: data.unique_code ?? null,
     catchCount: resolvedCatchCount,
-    catchMode,
     created_at: data.created_at ?? null,
     conventions,
     makers,

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -1,7 +1,6 @@
 import { supabase } from '../../../lib/supabase';
 import type { ConventionSummary } from '../../conventions';
 import type { FursuitSummary } from '../types';
-import type { CatchMode } from '../../catch-confirmations';
 import { mapFursuitColors, mapLatestFursuitBio } from './utils';
 import { fetchFursuitMakersByFursuitIds } from './makers';
 import { FURSUIT_BUCKET } from '../../../constants/storage';
@@ -28,7 +27,6 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       description,
       unique_code,
       catch_count,
-      catch_mode,
       created_at,
       species_entry:fursuit_species (
         id,
@@ -109,10 +107,6 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
     const colors = mapFursuitColors(item.color_assignments ?? null);
     const makers = makersByFursuitId.get(item.id) ?? [];
 
-    // Default to AUTO_ACCEPT if not set
-    const catchMode: CatchMode =
-      item.catch_mode === 'MANUAL_APPROVAL' ? 'MANUAL_APPROVAL' : 'AUTO_ACCEPT';
-
     return {
       id: item.id,
       name: item.name,
@@ -128,7 +122,6 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       description: item.description ?? null,
       unique_code: item.unique_code ?? null,
       catchCount: typeof item.catch_count === 'number' ? item.catch_count : 0,
-      catchMode,
       created_at: item.created_at ?? null,
       conventions,
       makers,

--- a/src/features/suits/types.ts
+++ b/src/features/suits/types.ts
@@ -1,7 +1,6 @@
 import type { ConventionSummary } from '../conventions';
 import type { FursuitColorOption } from '../colors';
 import type { FursuitSocialLink } from '../../types/database';
-import type { CatchMode } from '../catch-confirmations';
 
 export type FursuitBio = {
   version: number;
@@ -33,7 +32,6 @@ export type FursuitSummary = {
   description: string | null;
   unique_code: string | null;
   catchCount: number;
-  catchMode: CatchMode;
   created_at: string | null;
   conventions: ConventionSummary[];
   makers: FursuitMaker[];

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -756,6 +756,51 @@ export type Database = {
           },
         ]
       }
+      experiment_assignments: {
+        Row: {
+          assigned_at: string
+          created_at: string
+          default_applied_at: string | null
+          experiment_key: string
+          exposure_count: number
+          first_exposed_at: string | null
+          last_exposed_at: string | null
+          metadata: Json
+          subject_id: string
+          subject_type: string
+          updated_at: string
+          variant: string
+        }
+        Insert: {
+          assigned_at?: string
+          created_at?: string
+          default_applied_at?: string | null
+          experiment_key: string
+          exposure_count?: number
+          first_exposed_at?: string | null
+          last_exposed_at?: string | null
+          metadata?: Json
+          subject_id: string
+          subject_type: string
+          updated_at?: string
+          variant: string
+        }
+        Update: {
+          assigned_at?: string
+          created_at?: string
+          default_applied_at?: string | null
+          experiment_key?: string
+          exposure_count?: number
+          first_exposed_at?: string | null
+          last_exposed_at?: string | null
+          metadata?: Json
+          subject_id?: string
+          subject_type?: string
+          updated_at?: string
+          variant?: string
+        }
+        Relationships: []
+      }
       fursuit_bios: {
         Row: {
           ask_me_about: string
@@ -1145,6 +1190,7 @@ export type Database = {
           avatar_path: string | null
           avatar_url: string | null
           bio: string | null
+          catch_mode_preference_source: string
           created_at: string | null
           default_catch_mode: string
           expo_push_token: string | null
@@ -1168,6 +1214,7 @@ export type Database = {
           avatar_path?: string | null
           avatar_url?: string | null
           bio?: string | null
+          catch_mode_preference_source?: string
           created_at?: string | null
           default_catch_mode?: string
           expo_push_token?: string | null
@@ -1191,6 +1238,7 @@ export type Database = {
           avatar_path?: string | null
           avatar_url?: string | null
           bio?: string | null
+          catch_mode_preference_source?: string
           created_at?: string | null
           default_catch_mode?: string
           expo_push_token?: string | null
@@ -1768,6 +1816,24 @@ export type Database = {
       }
     }
     Views: {
+      catch_mode_default_experiment_results: {
+        Row: {
+          accepted_catches_after_exposure: number | null
+          assigned_profiles: number | null
+          catches_after_exposure: number | null
+          current_auto_profiles: number | null
+          current_manual_profiles: number | null
+          defaults_applied: number | null
+          experiment_key: string | null
+          exposed_profiles: number | null
+          fursuits_created_after_exposure: number | null
+          pending_catches_after_exposure: number | null
+          switch_away_rate: number | null
+          switched_away_profiles: number | null
+          variant: string | null
+        }
+        Relationships: []
+      }
       fursuits_moderation: {
         Row: {
           created_at: string | null
@@ -2234,6 +2300,21 @@ export type Database = {
           summary: Json
           unique_catchers_for_own_fursuits_count: number
           unique_fursuits_caught_count: number
+        }[]
+      }
+      get_or_assign_catch_mode_default_experiment: {
+        Args: never
+        Returns: {
+          assignment_created: boolean
+          current_catch_mode: string
+          current_preference_source: string
+          default_applied: boolean
+          experiment_key: string
+          exposed_at: string
+          previous_catch_mode: string
+          previous_preference_source: string
+          profile_id: string
+          variant: string
         }[]
       }
       get_pending_catch_count: { Args: { p_user_id: string }; Returns: number }

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -3,7 +3,7 @@
  * Supabase Edge Function: create-catch
  *
  * Handles catch creation with approval mode support.
- * Creates catches with appropriate status based on fursuit settings.
+ * Creates catches with appropriate status based on the owner's profile settings.
  */
 
 // eslint-disable-next-line import/no-unresolved -- Deno edge functions import via remote URL
@@ -383,7 +383,8 @@ async function handlePost(req: Request): Promise<Response> {
       }
     }
 
-    // Call the create_catch_with_approval function
+    // Call the create_catch_with_approval function. The RPC reads the fursuit owner's
+    // profile-level catch mode preference.
     const { data, error } = await supabaseAdmin.rpc('create_catch_with_approval', {
       p_fursuit_id: body.fursuit_id,
       p_catcher_id: userId,

--- a/supabase/migrations/20260504092641_profile_catch_mode_experiment.sql
+++ b/supabase/migrations/20260504092641_profile_catch_mode_experiment.sql
@@ -1,0 +1,460 @@
+alter table public.profiles
+  add column if not exists catch_mode_preference_source text not null default 'system_default';
+
+update public.profiles
+set default_catch_mode = 'AUTO_ACCEPT'
+where default_catch_mode not in ('AUTO_ACCEPT', 'MANUAL_APPROVAL');
+
+alter table public.profiles
+  drop constraint if exists profiles_default_catch_mode_check;
+
+alter table public.profiles
+  add constraint profiles_default_catch_mode_check
+  check (default_catch_mode in ('AUTO_ACCEPT', 'MANUAL_APPROVAL')) not valid;
+
+alter table public.profiles
+  validate constraint profiles_default_catch_mode_check;
+
+alter table public.profiles
+  drop constraint if exists profiles_catch_mode_preference_source_check;
+
+alter table public.profiles
+  add constraint profiles_catch_mode_preference_source_check
+  check (
+    catch_mode_preference_source in (
+      'system_default',
+      'migrated_from_suits',
+      'experiment_default',
+      'user_selected'
+    )
+  ) not valid;
+
+alter table public.profiles
+  validate constraint profiles_catch_mode_preference_source_check;
+
+with owned_suit_modes as (
+  select
+    owner_id,
+    bool_or(catch_mode = 'MANUAL_APPROVAL') as has_manual_suit
+  from public.fursuits
+  where is_tutorial = false
+  group by owner_id
+)
+update public.profiles p
+set
+  default_catch_mode = case
+    when owned_suit_modes.has_manual_suit then 'MANUAL_APPROVAL'
+    else 'AUTO_ACCEPT'
+  end,
+  catch_mode_preference_source = 'migrated_from_suits',
+  updated_at = timezone('utc'::text, now())
+from owned_suit_modes
+where p.id = owned_suit_modes.owner_id
+  and p.catch_mode_preference_source = 'system_default';
+
+create table if not exists public.experiment_assignments (
+  experiment_key text not null,
+  subject_type text not null,
+  subject_id uuid not null,
+  variant text not null,
+  assigned_at timestamptz not null default timezone('utc'::text, now()),
+  first_exposed_at timestamptz,
+  last_exposed_at timestamptz,
+  exposure_count integer not null default 0,
+  default_applied_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc'::text, now()),
+  updated_at timestamptz not null default timezone('utc'::text, now()),
+  constraint experiment_assignments_pkey primary key (experiment_key, subject_type, subject_id),
+  constraint experiment_assignments_subject_type_check check (subject_type in ('profile')),
+  constraint experiment_assignments_variant_check check (variant in ('auto_default', 'manual_default')),
+  constraint experiment_assignments_exposure_count_check check (exposure_count >= 0)
+);
+
+alter table public.experiment_assignments enable row level security;
+
+create index if not exists experiment_assignments_subject_idx
+  on public.experiment_assignments (subject_type, subject_id);
+
+create index if not exists experiment_assignments_experiment_variant_idx
+  on public.experiment_assignments (experiment_key, variant);
+
+drop policy if exists "experiment_assignments_own_read" on public.experiment_assignments;
+create policy "experiment_assignments_own_read"
+  on public.experiment_assignments for select
+  to authenticated
+  using (subject_type = 'profile' and subject_id = auth.uid());
+
+drop policy if exists "experiment_assignments_service_role_all" on public.experiment_assignments;
+create policy "experiment_assignments_service_role_all"
+  on public.experiment_assignments for all
+  to public
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+insert into public.allowed_event_types (event_type, description, is_active)
+values
+  ('experiment_assigned', 'User was assigned to an experiment variant', true),
+  ('experiment_exposed', 'User was exposed to an experiment-controlled surface', true),
+  ('catch_mode_default_applied', 'Experiment default updated a profile catch mode preference', true),
+  ('profile_catch_mode_changed', 'User changed their profile-level catch approval mode', true)
+on conflict (event_type) do update
+set
+  description = excluded.description,
+  is_active = true,
+  deprecated_at = null;
+
+create or replace function public.get_or_assign_catch_mode_default_experiment()
+returns table (
+  experiment_key text,
+  variant text,
+  profile_id uuid,
+  previous_catch_mode text,
+  current_catch_mode text,
+  previous_preference_source text,
+  current_preference_source text,
+  assignment_created boolean,
+  default_applied boolean,
+  exposed_at timestamptz
+)
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $$
+declare
+  v_experiment_key constant text := 'catch_mode_default_v1';
+  v_profile_id uuid := auth.uid();
+  v_variant text;
+  v_assignment_created boolean := false;
+  v_now timestamptz := timezone('utc'::text, now());
+  v_previous_catch_mode text;
+  v_previous_source text;
+  v_current_catch_mode text;
+  v_current_source text;
+  v_default_applied boolean := false;
+begin
+  if v_profile_id is null then
+    raise exception 'Missing authenticated profile';
+  end if;
+
+  insert into public.profiles (id)
+  values (v_profile_id)
+  on conflict (id) do nothing;
+
+  select
+    p.default_catch_mode,
+    p.catch_mode_preference_source
+  into
+    v_previous_catch_mode,
+    v_previous_source
+  from public.profiles p
+  where p.id = v_profile_id
+  for update;
+
+  select ea.variant
+  into v_variant
+  from public.experiment_assignments ea
+  where ea.experiment_key = v_experiment_key
+    and ea.subject_type = 'profile'
+    and ea.subject_id = v_profile_id
+  for update;
+
+  if v_variant is null then
+    v_variant := case when random() < 0.5 then 'auto_default' else 'manual_default' end;
+    v_assignment_created := true;
+
+    insert into public.experiment_assignments (
+      experiment_key,
+      subject_type,
+      subject_id,
+      variant,
+      assigned_at,
+      metadata
+    )
+    values (
+      v_experiment_key,
+      'profile',
+      v_profile_id,
+      v_variant,
+      v_now,
+      jsonb_build_object('assignment_source', 'add_fursuit_entry')
+    );
+  end if;
+
+  update public.experiment_assignments
+  set
+    first_exposed_at = coalesce(first_exposed_at, v_now),
+    last_exposed_at = v_now,
+    exposure_count = exposure_count + 1,
+    updated_at = v_now
+  where experiment_assignments.experiment_key = v_experiment_key
+    and experiment_assignments.subject_type = 'profile'
+    and experiment_assignments.subject_id = v_profile_id;
+
+  if v_previous_source = 'system_default' then
+    v_current_catch_mode := case
+      when v_variant = 'manual_default' then 'MANUAL_APPROVAL'
+      else 'AUTO_ACCEPT'
+    end;
+    v_current_source := 'experiment_default';
+    v_default_applied := true;
+
+    update public.profiles
+    set
+      default_catch_mode = v_current_catch_mode,
+      catch_mode_preference_source = v_current_source,
+      updated_at = v_now
+    where id = v_profile_id;
+
+    update public.experiment_assignments
+    set
+      default_applied_at = coalesce(default_applied_at, v_now),
+      metadata = metadata || jsonb_build_object(
+        'applied_catch_mode',
+        v_current_catch_mode,
+        'applied_source',
+        'experiment_default'
+      ),
+      updated_at = v_now
+    where experiment_assignments.experiment_key = v_experiment_key
+      and experiment_assignments.subject_type = 'profile'
+      and experiment_assignments.subject_id = v_profile_id;
+  else
+    v_current_catch_mode := v_previous_catch_mode;
+    v_current_source := v_previous_source;
+  end if;
+
+  return query
+  select
+    v_experiment_key,
+    v_variant,
+    v_profile_id,
+    v_previous_catch_mode,
+    v_current_catch_mode,
+    v_previous_source,
+    v_current_source,
+    v_assignment_created,
+    v_default_applied,
+    v_now;
+end;
+$$;
+
+grant execute on function public.get_or_assign_catch_mode_default_experiment() to authenticated;
+
+create or replace view public.catch_mode_default_experiment_results as
+with assignments as (
+  select
+    ea.experiment_key,
+    ea.subject_id as profile_id,
+    ea.variant,
+    ea.assigned_at,
+    ea.first_exposed_at,
+    ea.default_applied_at,
+    p.default_catch_mode as current_catch_mode,
+    p.catch_mode_preference_source as current_preference_source,
+    case when ea.variant = 'manual_default' then 'MANUAL_APPROVAL' else 'AUTO_ACCEPT' end as variant_catch_mode
+  from public.experiment_assignments ea
+  join public.profiles p on p.id = ea.subject_id
+  where ea.experiment_key = 'catch_mode_default_v1'
+    and ea.subject_type = 'profile'
+),
+fursuits_after_exposure as (
+  select
+    a.variant,
+    count(f.id)::integer as fursuits_created_after_exposure
+  from assignments a
+  join public.fursuits f
+    on f.owner_id = a.profile_id
+   and f.is_tutorial = false
+   and a.first_exposed_at is not null
+   and f.created_at >= a.first_exposed_at
+  group by a.variant
+),
+catches_after_exposure as (
+  select
+    a.variant,
+    count(c.id)::integer as catches_after_exposure,
+    count(c.id) filter (where c.status = 'ACCEPTED')::integer as accepted_catches_after_exposure,
+    count(c.id) filter (where c.status = 'PENDING')::integer as pending_catches_after_exposure
+  from assignments a
+  join public.fursuits f
+    on f.owner_id = a.profile_id
+   and f.is_tutorial = false
+  join public.catches c
+    on c.fursuit_id = f.id
+   and a.first_exposed_at is not null
+   and c.caught_at >= a.first_exposed_at
+   and c.is_tutorial = false
+  group by a.variant
+)
+select
+  a.experiment_key,
+  a.variant,
+  count(*)::integer as assigned_profiles,
+  count(*) filter (where a.first_exposed_at is not null)::integer as exposed_profiles,
+  count(*) filter (where a.default_applied_at is not null)::integer as defaults_applied,
+  count(*) filter (where a.current_catch_mode = 'AUTO_ACCEPT')::integer as current_auto_profiles,
+  count(*) filter (where a.current_catch_mode = 'MANUAL_APPROVAL')::integer as current_manual_profiles,
+  count(*) filter (
+    where a.default_applied_at is not null
+      and a.current_catch_mode <> a.variant_catch_mode
+  )::integer as switched_away_profiles,
+  coalesce(
+    round(
+      (
+        count(*) filter (
+          where a.default_applied_at is not null
+            and a.current_catch_mode <> a.variant_catch_mode
+        )::numeric
+        / nullif(count(*) filter (where a.default_applied_at is not null), 0)
+      ) * 100,
+      1
+    ),
+    0
+  ) as switch_away_rate,
+  coalesce(f.fursuits_created_after_exposure, 0) as fursuits_created_after_exposure,
+  coalesce(c.catches_after_exposure, 0) as catches_after_exposure,
+  coalesce(c.accepted_catches_after_exposure, 0) as accepted_catches_after_exposure,
+  coalesce(c.pending_catches_after_exposure, 0) as pending_catches_after_exposure
+from assignments a
+left join fursuits_after_exposure f on f.variant = a.variant
+left join catches_after_exposure c on c.variant = a.variant
+group by
+  a.experiment_key,
+  a.variant,
+  f.fursuits_created_after_exposure,
+  c.catches_after_exposure,
+  c.accepted_catches_after_exposure,
+  c.pending_catches_after_exposure;
+
+grant select on public.catch_mode_default_experiment_results to authenticated, service_role;
+
+create or replace function public.create_catch_with_approval(
+  p_fursuit_id uuid,
+  p_catcher_id uuid,
+  p_convention_id uuid default null::uuid,
+  p_is_tutorial boolean default false,
+  p_force_pending boolean default false
+)
+returns json
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+declare
+  v_owner_catch_mode text;
+  v_fursuit_owner_id uuid;
+  v_catch_status text;
+  v_expires_at timestamptz;
+  v_catch_id uuid;
+  v_catch_number integer;
+  v_result json;
+begin
+  select
+    coalesce(p.default_catch_mode, 'AUTO_ACCEPT'),
+    f.owner_id
+  into
+    v_owner_catch_mode,
+    v_fursuit_owner_id
+  from public.fursuits f
+  left join public.profiles p on p.id = f.owner_id
+  where f.id = p_fursuit_id;
+
+  if not found then
+    raise exception 'Fursuit not found';
+  end if;
+
+  if v_fursuit_owner_id = p_catcher_id then
+    raise exception 'Cannot catch your own fursuit';
+  end if;
+
+  if p_convention_id is not null then
+    if not public.is_convention_joinable(p_convention_id) then
+      raise exception 'Convention is not live';
+    end if;
+
+    if not exists (
+      select 1
+        from public.profile_conventions pc
+       where pc.profile_id = p_catcher_id
+         and pc.convention_id = p_convention_id
+    ) then
+      raise exception 'Catcher must join the live convention before catching';
+    end if;
+
+    if not exists (
+      select 1
+        from public.fursuit_conventions fc
+       where fc.fursuit_id = p_fursuit_id
+         and fc.convention_id = p_convention_id
+    ) then
+      raise exception 'Fursuit must be assigned to the live convention before it can be caught there';
+    end if;
+
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id = p_convention_id
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught at this convention';
+    end if;
+  else
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id is null
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught or pending';
+    end if;
+  end if;
+
+  if (v_owner_catch_mode = 'MANUAL_APPROVAL' or p_force_pending) and not p_is_tutorial then
+    v_catch_status := 'PENDING';
+    if p_convention_id is not null then
+      v_expires_at := public.calculate_catch_expiration(p_convention_id);
+    else
+      v_expires_at := public.calculate_catch_expiration();
+    end if;
+  else
+    v_catch_status := 'ACCEPTED';
+    v_expires_at := null;
+  end if;
+
+  insert into public.catches (
+    fursuit_id,
+    catcher_id,
+    convention_id,
+    is_tutorial,
+    status,
+    expires_at,
+    caught_at
+  )
+  values (
+    p_fursuit_id,
+    p_catcher_id,
+    p_convention_id,
+    p_is_tutorial,
+    v_catch_status,
+    v_expires_at,
+    now()
+  )
+  returning id, catch_number into v_catch_id, v_catch_number;
+
+  select json_build_object(
+    'catch_id', v_catch_id,
+    'status', v_catch_status,
+    'expires_at', v_expires_at,
+    'catch_number', v_catch_number,
+    'requires_approval', v_catch_status = 'PENDING',
+    'fursuit_owner_id', v_fursuit_owner_id
+  ) into v_result;
+
+  return v_result;
+end;
+$$;

--- a/supabase/migrations/20260504093730_secure_catch_mode_experiment_results_view.sql
+++ b/supabase/migrations/20260504093730_secure_catch_mode_experiment_results_view.sql
@@ -1,0 +1,5 @@
+alter view public.catch_mode_default_experiment_results
+  set (security_invoker = true);
+
+revoke all on public.catch_mode_default_experiment_results from anon, authenticated;
+grant select on public.catch_mode_default_experiment_results to service_role;

--- a/supabase/migrations/20260504101309_harden_create_catch_profile_mode.sql
+++ b/supabase/migrations/20260504101309_harden_create_catch_profile_mode.sql
@@ -1,0 +1,152 @@
+create unique index if not exists catches_unique_convention
+  on public.catches (fursuit_id, catcher_id, convention_id)
+  where status in ('ACCEPTED', 'PENDING')
+    and convention_id is not null;
+
+create unique index if not exists catches_unique_global
+  on public.catches (fursuit_id, catcher_id)
+  where status in ('ACCEPTED', 'PENDING')
+    and convention_id is null;
+
+create or replace function public.create_catch_with_approval(
+  p_fursuit_id uuid,
+  p_catcher_id uuid,
+  p_convention_id uuid default null::uuid,
+  p_is_tutorial boolean default false,
+  p_force_pending boolean default false
+)
+returns json
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+declare
+  v_owner_catch_mode text;
+  v_fursuit_owner_id uuid;
+  v_catch_status text;
+  v_expires_at timestamptz;
+  v_catch_id uuid;
+  v_catch_number integer;
+  v_result json;
+begin
+  if auth.role() <> 'service_role' and auth.uid() is distinct from p_catcher_id then
+    raise exception 'Catcher must match the authenticated user';
+  end if;
+
+  select
+    coalesce(p.default_catch_mode, 'AUTO_ACCEPT'),
+    f.owner_id
+  into
+    v_owner_catch_mode,
+    v_fursuit_owner_id
+  from public.fursuits f
+  left join public.profiles p on p.id = f.owner_id
+  where f.id = p_fursuit_id;
+
+  if not found then
+    raise exception 'Fursuit not found';
+  end if;
+
+  if v_fursuit_owner_id = p_catcher_id then
+    raise exception 'Cannot catch your own fursuit';
+  end if;
+
+  if p_convention_id is not null then
+    if not public.is_convention_joinable(p_convention_id) then
+      raise exception 'Convention is not live';
+    end if;
+
+    if not exists (
+      select 1
+        from public.profile_conventions pc
+       where pc.profile_id = p_catcher_id
+         and pc.convention_id = p_convention_id
+    ) then
+      raise exception 'Catcher must join the live convention before catching';
+    end if;
+
+    if not exists (
+      select 1
+        from public.fursuit_conventions fc
+       where fc.fursuit_id = p_fursuit_id
+         and fc.convention_id = p_convention_id
+    ) then
+      raise exception 'Fursuit must be assigned to the live convention before it can be caught there';
+    end if;
+
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id = p_convention_id
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught at this convention';
+    end if;
+  else
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id is null
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught or pending';
+    end if;
+  end if;
+
+  if (v_owner_catch_mode = 'MANUAL_APPROVAL' or p_force_pending) and not p_is_tutorial then
+    v_catch_status := 'PENDING';
+    if p_convention_id is not null then
+      v_expires_at := public.calculate_catch_expiration(p_convention_id);
+    else
+      v_expires_at := public.calculate_catch_expiration();
+    end if;
+  else
+    v_catch_status := 'ACCEPTED';
+    v_expires_at := null;
+  end if;
+
+  begin
+    insert into public.catches (
+      fursuit_id,
+      catcher_id,
+      convention_id,
+      is_tutorial,
+      status,
+      expires_at,
+      caught_at
+    )
+    values (
+      p_fursuit_id,
+      p_catcher_id,
+      p_convention_id,
+      p_is_tutorial,
+      v_catch_status,
+      v_expires_at,
+      now()
+    )
+    returning id, catch_number into v_catch_id, v_catch_number;
+  exception
+    when unique_violation then
+      if p_convention_id is not null then
+        raise exception 'Fursuit already caught at this convention';
+      end if;
+
+      raise exception 'Fursuit already caught or pending';
+  end;
+
+  select json_build_object(
+    'catch_id', v_catch_id,
+    'status', v_catch_status,
+    'expires_at', v_expires_at,
+    'catch_number', v_catch_number,
+    'requires_approval', v_catch_status = 'PENDING',
+    'fursuit_owner_id', v_fursuit_owner_id
+  ) into v_result;
+
+  return v_result;
+end;
+$$;


### PR DESCRIPTION
This PR adds an A/B test for tracking the auto-catch setting for fursuiters with analytics and test results being shown in the admin dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added profile-level catch settings allowing users to control approval behavior across all fursuits.
  * Added experiment analytics dashboard displaying assignment variants, exposure counts, and catch metrics.

* **Refactor**
  * Moved catch mode preference from per-fursuit configuration to profile-level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->