### PR TITLE
Fix Achievement Name Handling and Update Profile Guidance Copy

### DIFF
--- a/src/features/achievements/components/AchievementToastManager.tsx
+++ b/src/features/achievements/components/AchievementToastManager.tsx
@@ -103,6 +103,26 @@ function normalizeDailyTaskMetadata(raw: unknown): DailyTaskMetadata | null {
   };
 }
 
+function normalizeUserFacingAchievementName(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const name = value.trim();
+  if (name.length === 0) {
+    return null;
+  }
+
+  const looksLikeInternalKey = /^[A-Z0-9_]+$/.test(name) || /^[a-z0-9_]+$/.test(name);
+  const containsUuid = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(name);
+
+  if (looksLikeInternalKey || containsUuid) {
+    return null;
+  }
+
+  return name;
+}
+
 function matchesLocalDailyTaskFilters(
   metadata: DailyTaskMetadata,
   eventPayload: Record<string, unknown>,
@@ -858,10 +878,7 @@ export function AchievementToastManager() {
         }
 
         const fallbackName =
-          (typeof payload?.achievement_key === 'string' &&
-          payload?.achievement_key.trim().length > 0
-            ? payload?.achievement_key
-            : null) ?? 'achievement';
+          normalizeUserFacingAchievementName(payload?.achievement_name) ?? 'achievement';
 
         const toastDisplayedAt = Date.now();
         const latencyMs = toastDisplayedAt - notificationReceivedAt;

--- a/src/features/profile-guidance/index.ts
+++ b/src/features/profile-guidance/index.ts
@@ -75,19 +75,19 @@ export function createProfileGuidanceState(options: {
     {
       id: 'fursuit-profile',
       title: 'Update your fursuit profile',
-      description: 'Add "Ask me about" prompts and choose how catches should work.',
+      description: 'Add "Ask Me About..." prompts and other profile details.',
       isComplete: fursuitProfileComplete,
     },
     {
       id: 'username',
       title: 'Review your username',
-      description: 'Keep the generated name or pick one that other players will recognize.',
+      description: 'Keep the generated username or pick one that others will recognize.',
       isComplete: usernameReviewed,
     },
     {
       id: 'goals',
       title: "View today's goals",
-      description: 'Check daily tasks and achievements you can work toward.',
+      description: 'Check daily tasks and achievements you can work on today.',
       isComplete: goalsViewed,
     },
   ];

--- a/supabase/functions/_shared/achievements.ts
+++ b/supabase/functions/_shared/achievements.ts
@@ -758,6 +758,10 @@ async function evaluateConventionAchievements(
       typeof metadata?.sourceAchievementKey === 'string' ? metadata.sourceAchievementKey : null;
 
     if (sourceAchievementKey) {
+      if (triggerEvent === 'convention_joined') {
+        continue;
+      }
+
       for (const sourceAward of sourceAwards) {
         if (sourceAward.achievementKey !== sourceAchievementKey) continue;
         candidates.push({
@@ -846,16 +850,46 @@ async function insertNotificationsForAwards(
   results: RpcAwardResult[],
 ) {
   const notifications: NotificationInsert[] = [];
+  const awardedAchievementIds = Array.from(
+    new Set(
+      results
+        .filter((summary) => summary.awarded && summary.achievement_id)
+        .map((summary) => summary.achievement_id as string),
+    ),
+  );
+  const achievementNamesById = new Map<string, string>();
+
+  if (awardedAchievementIds.length > 0) {
+    const { data, error } = await supabaseAdmin
+      .from('achievements')
+      .select('id, name')
+      .in('id', awardedAchievementIds);
+
+    if (error) {
+      console.error('[events-ingress] Failed resolving achievement notification names', { error });
+    } else {
+      for (const row of data ?? []) {
+        const achievementId = typeof row.id === 'string' ? row.id : null;
+        const achievementName = typeof row.name === 'string' ? row.name.trim() : '';
+        if (achievementId && achievementName.length > 0) {
+          achievementNamesById.set(achievementId, achievementName);
+        }
+      }
+    }
+  }
+
   for (const summary of results) {
     if (!summary.awarded || !summary.achievement_id) {
       continue;
     }
+    const achievementName = achievementNamesById.get(summary.achievement_id) ?? null;
     notifications.push({
       user_id: summary.user_id,
       type: 'achievement_awarded',
       payload: {
         achievement_id: summary.achievement_id,
         achievement_key: summary.achievement_key,
+        achievement_name: achievementName,
         awarded_at: summary.awarded_at,
         context: summary.context ?? {},
         source_event_id: summary.source_event_id ?? null,

--- a/supabase/functions/_shared/achievements.ts
+++ b/supabase/functions/_shared/achievements.ts
@@ -758,12 +758,15 @@ async function evaluateConventionAchievements(
       typeof metadata?.sourceAchievementKey === 'string' ? metadata.sourceAchievementKey : null;
 
     if (sourceAchievementKey) {
-      if (triggerEvent === 'convention_joined' && sourceAchievementKey === 'EXPLORER') {
-        continue;
-      }
-
       for (const sourceAward of sourceAwards) {
         if (sourceAward.achievementKey !== sourceAchievementKey) continue;
+        if (
+          triggerEvent === 'convention_joined' &&
+          sourceAchievementKey === 'EXPLORER' &&
+          sourceAward.userId === (context as SimpleEventContext).userId
+        ) {
+          continue;
+        }
         candidates.push({
           achievementKey: row.key,
           userId: sourceAward.userId,

--- a/supabase/functions/_shared/achievements.ts
+++ b/supabase/functions/_shared/achievements.ts
@@ -758,7 +758,7 @@ async function evaluateConventionAchievements(
       typeof metadata?.sourceAchievementKey === 'string' ? metadata.sourceAchievementKey : null;
 
     if (sourceAchievementKey) {
-      if (triggerEvent === 'convention_joined') {
+      if (triggerEvent === 'convention_joined' && sourceAchievementKey === 'EXPLORER') {
         continue;
       }
 

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -105,9 +105,16 @@ function extractString(value: unknown): string | null {
   return null;
 }
 
+function isUserFacingAchievementName(value: string): boolean {
+  const looksLikeInternalKey = /^[A-Z0-9_]+$/.test(value) || /^[a-z0-9_]+$/.test(value);
+  const containsUuid = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(value);
+
+  return !looksLikeInternalKey && !containsUuid;
+}
+
 async function resolveAchievementName(payload: Record<string, unknown>): Promise<string> {
   const existing = extractString(payload.achievement_name);
-  if (existing) {
+  if (existing && isUserFacingAchievementName(existing)) {
     return existing;
   }
 
@@ -118,7 +125,7 @@ async function resolveAchievementName(payload: Record<string, unknown>): Promise
       .select('name')
       .eq('id', achievementId)
       .maybeSingle();
-    if (!error && data?.name) {
+    if (!error && data?.name && isUserFacingAchievementName(data.name)) {
       payload.achievement_name = data.name;
       return data.name;
     }
@@ -131,13 +138,13 @@ async function resolveAchievementName(payload: Record<string, unknown>): Promise
       .select('name')
       .eq('key', achievementKey)
       .maybeSingle();
-    if (!error && data?.name) {
+    if (!error && data?.name && isUserFacingAchievementName(data.name)) {
       payload.achievement_name = data.name;
       return data.name;
     }
   }
 
-  return achievementKey ?? 'achievement';
+  return 'achievement';
 }
 
 async function buildMessage(


### PR DESCRIPTION
This PR fixes some minor bugs in the getting started flow, including updated game copy and removing duplicated achievement grants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Achievement notifications now sanitize names to avoid exposing internal IDs/keys or UUID-like strings; unknown names fall back to a generic label.
  * Notification logic more reliably resolves user-facing achievement names and avoids duplicate convention-related award candidates for the same user.

* **Documentation**
  * Profile guidance task descriptions clarified with friendlier, more actionable wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->