### PR TITLE
Enforce Catch Settings in User Settings

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -56,6 +56,21 @@ const resolveRequiredExistingFile = (relativePath: string, label: string) => {
 
   throw new Error(`Missing ${label} for APP_ENV=${APP_ENV}. Expected file at ${relativePath}.`);
 };
+const resolveAndroidGoogleServicesFile = () => {
+  const envSpecificFile = maybeResolveExistingFile(env.googleServicesFile);
+  if (envSpecificFile) {
+    return envSpecificFile;
+  }
+
+  if (APP_ENV === 'development') {
+    const developmentFallback = maybeResolveExistingFile('google-services.json');
+    if (developmentFallback) {
+      return developmentFallback;
+    }
+  }
+
+  return resolveRequiredExistingFile(env.googleServicesFile, 'Android Firebase config');
+};
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
@@ -104,10 +119,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     edgeToEdgeEnabled: true,
     predictiveBackGestureEnabled: false,
     package: env.androidApplicationId,
-    googleServicesFile: resolveRequiredExistingFile(
-      env.googleServicesFile,
-      'Android Firebase config',
-    ),
+    googleServicesFile: resolveAndroidGoogleServicesFile(),
     blockedPermissions: [
       'android.permission.RECORD_AUDIO',
       'android.permission.READ_EXTERNAL_STORAGE',

--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -621,8 +621,8 @@ export default function CatchScreen() {
           />
           <Text style={styles.helpText}>Letters only, {codeInput.length}/8 characters.</Text>
           <Text style={[styles.helpText, { marginTop: spacing.xs }]}>
-            Some fursuits require manual approval. If so, the owner will be notified and your catch
-            will count once approved.
+            Some owners require manual approval. If so, they will be notified and your catch will
+            count once approved.
           </Text>
         </View>
 

--- a/app/(tabs)/suits/index.tsx
+++ b/app/(tabs)/suits/index.tsx
@@ -230,7 +230,7 @@ export default function MySuitsScreen() {
           <Text style={styles.guidanceEyebrow}>Next step</Text>
           <Text style={styles.guidanceTitle}>Add Ask me about prompts</Text>
           <Text style={styles.guidanceBody}>
-            Review each suit's conversation starter and catch settings before this step is complete.
+            Review each suit's conversation starter before this step is complete.
           </Text>
           <View style={styles.guidanceSuitList}>
             {incompleteGuidanceSuits.map((suit) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailtag",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tailtag",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@expo/metro-runtime": "~6.1.2",
         "@expo/vector-icons": "^15.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailtag",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "index.ts",
   "engines": {
     "node": ">=22 <23",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tailtag-admin-v2:lint": "npm --prefix admin-v2 run lint",
     "tailtag-admin-v2:typecheck": "npm --prefix admin-v2 run typecheck",
     "tailtag-admin-v2:format": "npm --prefix admin-v2 run format",
-    "doctor": "npx expo-doctor",
+    "doctor": "npx --cache /tmp/npm-cache expo-doctor",
     "lint": "eslint app src --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "prebuild": "npm run sync:native-env && expo prebuild --non-interactive",


### PR DESCRIPTION
This PR fixes a bug where catch settings would show up outside of user settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Clarified help text for manual-approval behavior in the catch code input.
  * Streamlined fursuit setup guidance to focus on reviewing conversation starters only.

* **Infrastructure**
  * Improved Android configuration resolution to prefer environment-specific files, fall back in development, and surface clear errors when required files are missing.

* **Chores**
  * App version bumped and developer tooling invocation adjusted for more reliable diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->