### PR TITLE
Fix fursuit profile actions and form interactions

### DIFF
--- a/app/(tabs)/suits/index.tsx
+++ b/app/(tabs)/suits/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Alert, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -7,7 +7,6 @@ import {
   FursuitCard,
   fetchMySuits,
   MY_SUITS_QUERY_KEY,
-  MY_SUITS_COUNT_QUERY_KEY,
   MY_SUITS_STALE_TIME,
 } from '../../../src/features/suits';
 import {
@@ -21,13 +20,10 @@ import { MAX_FURSUITS_PER_USER } from '../../../src/constants/fursuits';
 import type { FursuitSummary } from '../../../src/features/suits';
 import { TailTagButton } from '../../../src/components/ui/TailTagButton';
 import { TailTagCard } from '../../../src/components/ui/TailTagCard';
-import { FURSUIT_BUCKET } from '../../../src/constants/storage';
 import { useAuth } from '../../../src/features/auth';
 import { getIncompleteFursuitProfiles } from '../../../src/features/profile-guidance';
-import { supabase } from '../../../src/lib/supabase';
 import { colors } from '../../../src/theme';
 import { toDisplayDate } from '../../../src/utils/dates';
-import { deriveStoragePathFromPublicUrl } from '../../../src/utils/storage';
 import { styles } from '../../../src/app-styles/(tabs)/suits/index.styles';
 
 export default function MySuitsScreen() {
@@ -54,8 +50,6 @@ export default function MySuitsScreen() {
     queryFn: () => fetchMySuits(userId!),
   });
 
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [processingCatchId, setProcessingCatchId] = useState<string | null>(null);
 
   const {
@@ -90,11 +84,9 @@ export default function MySuitsScreen() {
   useFocusEffect(
     useCallback(() => {
       if (!userId) {
-        setActionError(null);
         return;
       }
 
-      setActionError(null);
       const state = queryClient.getQueryState<FursuitSummary[]>(suitsQueryKey);
 
       if (
@@ -114,92 +106,17 @@ export default function MySuitsScreen() {
       ) {
         void refetchPendingCatches();
       }
-    }, [
-      pendingCatchesKey,
-      queryClient,
-      refetch,
-      refetchPendingCatches,
-      setActionError,
-      suitsQueryKey,
-      userId,
-    ]),
+    }, [pendingCatchesKey, queryClient, refetch, refetchPendingCatches, suitsQueryKey, userId]),
   );
 
   const handleRefresh = useCallback(async () => {
-    setActionError(null);
     await Promise.all([refetch({ throwOnError: false }), refetchPendingCatches()]);
   }, [refetch, refetchPendingCatches]);
-
-  const handleDelete = useCallback(
-    (suit: FursuitSummary) => {
-      if (!userId || deletingId) {
-        return;
-      }
-
-      Alert.alert(
-        'Remove fursuit?',
-        `Remove ${suit.name} from your fursuits? You can always add it back later.`,
-        [
-          { text: 'Cancel', style: 'cancel' },
-          {
-            text: 'Remove',
-            style: 'destructive',
-            onPress: async () => {
-              setDeletingId(suit.id);
-              setActionError(null);
-
-              try {
-                const objectPath = deriveStoragePathFromPublicUrl(suit.avatar_url, FURSUIT_BUCKET);
-
-                if (objectPath) {
-                  const { error: storageError } = await supabase.storage
-                    .from(FURSUIT_BUCKET)
-                    .remove([objectPath]);
-
-                  if (storageError) {
-                    console.warn('Failed to remove fursuit avatar from storage', storageError);
-                  }
-                }
-
-                const { error: deleteError } = await (supabase as any)
-                  .from('fursuits')
-                  .delete()
-                  .eq('id', suit.id)
-                  .eq('owner_id', userId);
-
-                if (deleteError) {
-                  throw deleteError;
-                }
-
-                queryClient.setQueryData<FursuitSummary[]>(suitsQueryKey, (current) =>
-                  (current ?? []).filter((item) => item.id !== suit.id),
-                );
-
-                // Invalidate count cache so limit check updates immediately
-                void queryClient.invalidateQueries({
-                  queryKey: [MY_SUITS_COUNT_QUERY_KEY, userId],
-                });
-              } catch (caught) {
-                const message =
-                  caught instanceof Error
-                    ? caught.message
-                    : "We couldn't delete that fursuit. Please try again.";
-                setActionError(message);
-              } finally {
-                setDeletingId(null);
-              }
-            },
-          },
-        ],
-      );
-    },
-    [queryClient, suitsQueryKey, userId, deletingId],
-  );
 
   const hasSuits = suits.length > 0;
   const suitCount = suits.length;
   const isAtFursuitLimit = suitCount >= MAX_FURSUITS_PER_USER;
-  const combinedError = actionError ?? error?.message ?? null;
+  const combinedError = error?.message ?? null;
   const incompleteGuidanceSuits = useMemo(() => getIncompleteFursuitProfiles(suits), [suits]);
   const showFursuitGuidance =
     params.guidance === 'fursuit-profile' && incompleteGuidanceSuits.length > 0;
@@ -314,27 +231,6 @@ export default function MySuitsScreen() {
                         pathname: '/fursuits/[id]',
                         params: { id: suit.id },
                       })
-                    }
-                    actionSlot={
-                      <Pressable
-                        onPress={() => handleDelete(suit)}
-                        disabled={deletingId === suit.id}
-                        hitSlop={8}
-                        accessibilityRole="button"
-                        accessibilityLabel="Delete fursuit"
-                        style={({ pressed }) => [
-                          styles.deleteAction,
-                          {
-                            opacity: deletingId === suit.id ? 0.6 : pressed ? 0.8 : 1,
-                          },
-                        ]}
-                      >
-                        {deletingId === suit.id ? (
-                          <Text style={styles.deleteLink}>Deleting…</Text>
-                        ) : (
-                          <Text style={styles.deleteLink}>Delete</Text>
-                        )}
-                      </Pressable>
                     }
                   />
                 </View>

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Keyboard, Pressable, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, Keyboard, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -15,6 +15,7 @@ import {
   fetchFursuitDetail,
   fursuitDetailQueryKey,
   MY_SUITS_QUERY_KEY,
+  MY_SUITS_COUNT_QUERY_KEY,
 } from '../../../src/features/suits';
 import type { EditableSocialLink } from '../../../src/features/suits/forms/socialLinks';
 import {
@@ -202,6 +203,7 @@ export default function EditFursuitScreen() {
   );
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [selectedSpecies, setSelectedSpecies] = useState<FursuitSpeciesOption | null>(null);
   const [selectedColors, setSelectedColors] = useState<FursuitColorOption[]>([]);
   const [initialColors, setInitialColors] = useState<FursuitColorOption[]>([]);
@@ -438,6 +440,74 @@ export default function EditFursuitScreen() {
   const handleCancel = () => {
     router.back();
   };
+
+  const handleDelete = useCallback(() => {
+    if (!detail || !fursuitId || !userId || isSubmitting || isDeleting) {
+      return;
+    }
+
+    Alert.alert(
+      'Delete fursuit?',
+      `Delete ${detail.name} from your fursuits? This removes the suit profile and cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete fursuit',
+          style: 'destructive',
+          onPress: async () => {
+            setIsDeleting(true);
+            setSubmitError(null);
+
+            try {
+              const objectPath =
+                detail.avatar_path ?? extractStoragePath(detail.avatar_url ?? null, FURSUIT_BUCKET);
+
+              if (objectPath) {
+                const { error: storageError } = await supabase.storage
+                  .from(FURSUIT_BUCKET)
+                  .remove([objectPath]);
+
+                if (storageError) {
+                  console.warn('Failed to remove fursuit avatar from storage', storageError);
+                }
+              }
+
+              const { error: deleteError } = await (supabase as any)
+                .from('fursuits')
+                .delete()
+                .eq('id', fursuitId)
+                .eq('owner_id', userId);
+
+              if (deleteError) {
+                throw deleteError;
+              }
+
+              queryClient.invalidateQueries({
+                queryKey: fursuitDetailQueryKey(fursuitId),
+              });
+              queryClient.invalidateQueries({ queryKey: [MY_SUITS_QUERY_KEY, userId] });
+              queryClient.invalidateQueries({
+                queryKey: [MY_SUITS_COUNT_QUERY_KEY, userId],
+              });
+              queryClient.invalidateQueries({
+                queryKey: [CAUGHT_SUITS_QUERY_KEY, userId],
+              });
+
+              router.replace('/suits');
+            } catch (caught) {
+              const message =
+                caught instanceof Error
+                  ? caught.message
+                  : "We couldn't delete that fursuit. Please try again.";
+              setSubmitError(message);
+            } finally {
+              setIsDeleting(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [detail, fursuitId, isDeleting, isSubmitting, queryClient, router, userId]);
 
   const handleSubmit = async () => {
     if (!detail || !fursuitId || !userId || isSubmitting) {
@@ -770,7 +840,7 @@ export default function EditFursuitScreen() {
     }
   };
 
-  const disableForm = isLoading || !detail || !isOwner || isSubmitting;
+  const disableForm = isLoading || !detail || !isOwner || isSubmitting || isDeleting;
 
   const handleConventionToggle = useCallback(
     (conventionId: string, nextSelected: boolean) => {
@@ -1385,21 +1455,28 @@ export default function EditFursuitScreen() {
 
               {submitError ? <Text style={styles.errorText}>{submitError}</Text> : null}
 
-              <View style={styles.buttonRow}>
+              <View style={styles.buttonStack}>
+                <TailTagButton
+                  onPress={handleSubmit}
+                  loading={isSubmitting}
+                  disabled={isSubmitting || isDeleting}
+                >
+                  Save changes
+                </TailTagButton>
                 <TailTagButton
                   variant="ghost"
                   onPress={handleCancel}
-                  disabled={isSubmitting}
-                  style={styles.inlineButtonSpacing}
+                  disabled={isSubmitting || isDeleting}
                 >
                   Cancel
                 </TailTagButton>
                 <TailTagButton
-                  onPress={handleSubmit}
-                  loading={isSubmitting}
-                  disabled={isSubmitting}
+                  variant="destructive"
+                  onPress={handleDelete}
+                  loading={isDeleting}
+                  disabled={isSubmitting || isDeleting}
                 >
-                  Save changes
+                  Delete fursuit
                 </TailTagButton>
               </View>
             </>

--- a/src/app-styles/(tabs)/suits/index.styles.ts
+++ b/src/app-styles/(tabs)/suits/index.styles.ts
@@ -137,15 +137,4 @@ export const styles = StyleSheet.create({
   listItemSpacing: {
     marginBottom: spacing.md,
   },
-  deleteAction: {
-    alignItems: 'flex-end',
-    minWidth: IS_SMALL_SCREEN ? 104 : 112,
-  },
-  deleteLink: {
-    fontSize: IS_SMALL_SCREEN ? 10 : 11,
-    textTransform: 'uppercase',
-    letterSpacing: IS_SMALL_SCREEN ? 2 : 3,
-    color: colors.destructive,
-    fontWeight: '600',
-  },
 });

--- a/src/app-styles/fursuits/[id]/edit.styles.ts
+++ b/src/app-styles/fursuits/[id]/edit.styles.ts
@@ -214,12 +214,9 @@ export const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
   },
-  buttonRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+  buttonStack: {
+    gap: spacing.sm,
   },
-  inlineButtonSpacing: {},
   errorText: {
     color: '#fca5a5',
     fontSize: 14,

--- a/src/app-styles/fursuits/[id]/index.styles.ts
+++ b/src/app-styles/fursuits/[id]/index.styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-import { colors, radius, spacing } from '../../../theme';
+import { colors, radius, spacing, typography } from '../../../theme';
 
 export const styles = StyleSheet.create({
   screen: {
@@ -72,8 +72,7 @@ export const styles = StyleSheet.create({
     fontSize: 12,
   },
   codeValue: {
-    fontFamily: 'Courier',
-    fontWeight: '600',
+    ...typography.code,
     color: colors.primary,
     fontSize: 16,
     backgroundColor: colors.surfaceMuted,

--- a/src/components/ui/KeyboardAwareFormWrapper.tsx
+++ b/src/components/ui/KeyboardAwareFormWrapper.tsx
@@ -27,7 +27,7 @@ export function KeyboardAwareFormWrapper({
       style={styles.wrapper}
       contentContainerStyle={[styles.defaultContainer, contentContainerStyle]}
       keyboardDismissMode="interactive"
-      keyboardShouldPersistTaps="handled"
+      keyboardShouldPersistTaps="always"
       showsVerticalScrollIndicator
       bottomOffset={spacing.xl}
     >

--- a/src/features/suits/components/FursuitCard.styles.ts
+++ b/src/features/suits/components/FursuitCard.styles.ts
@@ -1,6 +1,6 @@
 import { Dimensions, StyleSheet } from 'react-native';
 
-import { colors, radius, spacing } from '../../../theme';
+import { colors, radius, spacing, typography } from '../../../theme';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const IS_COMPACT_SCREEN = SCREEN_WIDTH <= 430;
@@ -94,8 +94,7 @@ export const styles = StyleSheet.create({
     marginRight: spacing.xs,
   },
   codeValue: {
-    fontFamily: 'Courier',
-    fontWeight: '600',
+    ...typography.code,
     color: colors.primary,
     fontSize: IS_COMPACT_SCREEN ? 14 : 16,
     backgroundColor: colors.surfaceMuted,

--- a/src/theme/layout.ts
+++ b/src/theme/layout.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 export const spacing = {
   xs: 6,
   sm: 10,
@@ -26,5 +28,13 @@ export const typography = {
   body: {
     fontFamily: 'System',
     fontWeight: '400' as const,
+  },
+  code: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: 'monospace',
+      default: 'monospace',
+    }),
+    fontWeight: '600' as const,
   },
 };


### PR DESCRIPTION
## Summary
- Standardize fursuit catch code typography by moving code font styling into a shared `typography.code` token.
- Move fursuit deletion out of the suit card and into the bottom of the full edit screen.
- Stack edit screen actions full-width in the order: Save changes, Cancel, Delete fursuit.
- Style Delete fursuit with the same destructive button variant used by Delete account.
- Fix keyboard-aware form tap handling so chips/buttons remain responsive while text inputs are focused.

## Validation
- Ran `npm run ci:validate`