### PR TITLE
Refine convention fursuit roster rollout

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -307,7 +307,7 @@ export default function HomeScreen() {
   });
 
   const mySuitsQuery = useQuery<FursuitSummary[], Error>({
-    queryKey: userId ? mySuitsQueryKey(userId) : ['my-suits', 'guest'],
+    queryKey: mySuitsQueryKey(userId ?? 'guest'),
     enabled: Boolean(userId),
     staleTime: MY_SUITS_STALE_TIME,
     refetchOnWindowFocus: false,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1145,7 +1145,7 @@ export default function HomeScreen() {
                     }
                     style={styles.leaderboardCta}
                   >
-                    Suiter roster
+                    Fursuit roster
                   </TailTagButton>
 
                   <View>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -96,6 +96,7 @@ import {
   FURSUIT_DETAIL_QUERY_KEY,
   MY_SUITS_QUERY_KEY,
   MY_SUITS_STALE_TIME,
+  mySuitsQueryKey,
 } from '../../src/features/suits';
 import type { FursuitSummary } from '../../src/features/suits';
 import type { CaughtRecord } from '../../src/features/suits/api/caughtSuits';
@@ -247,7 +248,7 @@ export default function SettingsScreen() {
     queryFn: () => fetchCaughtSuits(userId!),
   });
   const { data: mySuits = [], isLoading: isMySuitsLoading } = useQuery<FursuitSummary[], Error>({
-    queryKey: [MY_SUITS_QUERY_KEY, userId],
+    queryKey: mySuitsQueryKey(userId ?? 'guest'),
     enabled: Boolean(userId),
     staleTime: MY_SUITS_STALE_TIME,
     refetchOnWindowFocus: false,
@@ -1091,6 +1092,36 @@ export default function SettingsScreen() {
             conventions.find((convention) => convention.id === conventionId)?.name ??
             'this convention';
           setSuitListingPromptConvention({ id: conventionId, name: conventionName });
+          Alert.alert(
+            'Your suits were added',
+            hasMySuits
+              ? `TailTag listed every suit in your account for ${conventionName}. If a suit is not catchable there, review your suits and remove that convention from the suit.`
+              : `TailTag will list your suits for ${conventionName} by default. If you add a suit that is not catchable there, remove that convention from the suit.`,
+            [
+              { text: 'Not now', style: 'cancel' },
+              {
+                text: hasMySuits ? 'Review suits' : 'Add a suit',
+                onPress: () => {
+                  if (hasMySuits) {
+                    router.push({
+                      pathname: '/suits',
+                      params: {
+                        guidance: 'convention-roster',
+                        conventionId,
+                        conventionName,
+                      },
+                    });
+                    return;
+                  }
+
+                  router.push({
+                    pathname: '/suits/add-fursuit',
+                    params: { conventionId },
+                  });
+                },
+              },
+            ],
+          );
         }
 
         await Promise.all([
@@ -1129,9 +1160,11 @@ export default function SettingsScreen() {
     },
     [
       conventions,
+      hasMySuits,
       pendingMemberships,
       queryClient,
       refetchProfileConventions,
+      router,
       selectedConventionIdSet,
       userId,
     ],
@@ -1809,13 +1842,13 @@ export default function SettingsScreen() {
           {shouldShowSuitListingPrompt && suitListingPromptConvention ? (
             <View style={styles.suitListingPrompt}>
               <View style={styles.suitListingPromptText}>
-                <Text style={styles.suitListingPromptTitle}>List suits for this convention</Text>
+                <Text style={styles.suitListingPromptTitle}>Review suits for this convention</Text>
                 <Text style={styles.suitListingPromptBody}>
                   {isMySuitsLoading
-                    ? `You’re attending ${suitListingPromptConvention.name}. TailTag is checking your suits so you can list the ones you’re bringing.`
+                    ? `You’re attending ${suitListingPromptConvention.name}. TailTag is checking which suits were listed by default.`
                     : hasMySuits
-                      ? `You’re attending ${suitListingPromptConvention.name}. List the suits you’re bringing so other players can catch them.`
-                      : `You’re attending ${suitListingPromptConvention.name}. If you’re bringing a suit, add it so other players can catch it.`}
+                      ? `TailTag listed every suit in your account for ${suitListingPromptConvention.name}. Remove any suit that is not catchable there.`
+                      : `TailTag will list new suits for ${suitListingPromptConvention.name} by default. If a suit is not catchable there, remove that convention from the suit.`}
                 </Text>
               </View>
               <View style={styles.suitListingPromptActions}>
@@ -1827,7 +1860,7 @@ export default function SettingsScreen() {
                   {isMySuitsLoading
                     ? 'Checking suits…'
                     : hasMySuits
-                      ? 'Choose suits'
+                      ? 'Review suits'
                       : 'Add a suit'}
                 </TailTagButton>
                 <TailTagButton

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Keyboard, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { TailTagButton } from '../../../src/components/ui/TailTagButton';
@@ -108,9 +108,6 @@ const DEFAULT_ROSTER_SETTINGS: FursuitConventionRosterSettings = {
 
 export default function AddFursuitScreen() {
   const router = useRouter();
-  const params = useLocalSearchParams<{ conventionId?: string }>();
-  const requestedConventionId =
-    typeof params.conventionId === 'string' ? params.conventionId : null;
   const { session } = useAuth();
   const userId = session?.user.id ?? null;
   const queryClient = useQueryClient();
@@ -384,15 +381,10 @@ export default function AddFursuitScreen() {
     }
 
     if (!hasHydratedConventions && !isConventionsBusy) {
-      const requestedConventionIsAllowed =
-        requestedConventionId !== null && profileConventionIdSet.has(requestedConventionId);
-      setSelectedConventionIds(
-        requestedConventionIsAllowed ? new Set([requestedConventionId]) : new Set(),
-      );
+      const defaultConventionIds = [...profileConventionIdSet];
+      setSelectedConventionIds(new Set(defaultConventionIds));
       setConventionRosterSettingsById(
-        requestedConventionIsAllowed && requestedConventionId
-          ? { [requestedConventionId]: DEFAULT_ROSTER_SETTINGS }
-          : {},
+        Object.fromEntries(defaultConventionIds.map((id) => [id, DEFAULT_ROSTER_SETTINGS])),
       );
       setHasHydratedConventions(true);
       return;
@@ -408,13 +400,7 @@ export default function AddFursuitScreen() {
       );
       return Object.keys(next).length === Object.keys(current).length ? current : next;
     });
-  }, [
-    hasHydratedConventions,
-    profileConventionIdSet,
-    isConventionsBusy,
-    requestedConventionId,
-    userId,
-  ]);
+  }, [hasHydratedConventions, profileConventionIdSet, isConventionsBusy, userId]);
 
   const handleConventionToggle = useCallback(
     (conventionId: string, nextSelected: boolean) => {

--- a/app/(tabs)/suits/add-fursuit.tsx
+++ b/app/(tabs)/suits/add-fursuit.tsx
@@ -104,7 +104,6 @@ const PRONOUN_OPTIONS = [
 
 const DEFAULT_ROSTER_SETTINGS: FursuitConventionRosterSettings = {
   rosterVisible: true,
-  catchableNow: false,
 };
 
 export default function AddFursuitScreen() {

--- a/app/(tabs)/suits/index.tsx
+++ b/app/(tabs)/suits/index.tsx
@@ -1,13 +1,16 @@
-import { useCallback, useMemo, useState } from 'react';
-import { Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   FursuitCard,
   fetchMySuits,
-  MY_SUITS_QUERY_KEY,
+  consumeSuitAutoEnrollNotice,
+  hasSeenSuitAutoEnrollMigrationNotice,
+  markSuitAutoEnrollMigrationNoticeSeen,
   MY_SUITS_STALE_TIME,
+  mySuitsQueryKey,
 } from '../../../src/features/suits';
 import {
   PENDING_CATCHES_STALE_TIME,
@@ -35,8 +38,9 @@ export default function MySuitsScreen() {
   }>();
   const { session } = useAuth();
   const userId = session?.user.id ?? null;
-  const suitsQueryKey = useMemo(() => [MY_SUITS_QUERY_KEY, userId] as const, [userId]);
+  const suitsQueryKey = useMemo(() => mySuitsQueryKey(userId ?? 'guest'), [userId]);
   const pendingCatchesKey = useMemo(() => pendingCatchesQueryKey(userId ?? ''), [userId]);
+  const autoEnrollNoticeShownRef = useRef(false);
 
   const queryClient = useQueryClient();
   const {
@@ -118,6 +122,10 @@ export default function MySuitsScreen() {
   }, [refetch, refetchPendingCatches]);
 
   const hasSuits = suits.length > 0;
+  const hasConventionListedSuits = useMemo(
+    () => suits.some((suit) => suit.conventions.length > 0),
+    [suits],
+  );
   const suitCount = suits.length;
   const isAtFursuitLimit = suitCount >= MAX_FURSUITS_PER_USER;
   const combinedError = error?.message ?? null;
@@ -132,17 +140,56 @@ export default function MySuitsScreen() {
     typeof params.conventionName === 'string' && params.conventionName.trim().length > 0
       ? params.conventionName
       : 'this convention';
-  const rosterGuidanceSuits = useMemo(
-    () =>
-      rosterGuidanceConventionId
-        ? suits.filter(
-            (suit) =>
-              !suit.conventions.some((convention) => convention.id === rosterGuidanceConventionId),
-          )
-        : [],
-    [rosterGuidanceConventionId, suits],
-  );
+  const rosterGuidanceSuits = rosterGuidanceConventionId ? suits : [];
   const showRosterGuidance = Boolean(rosterGuidanceConventionId);
+
+  useEffect(() => {
+    if (!userId || isLoading || error || !hasSuits || autoEnrollNoticeShownRef.current) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const showNotice = (conventionName?: string | null) => {
+      autoEnrollNoticeShownRef.current = true;
+      const target = conventionName?.trim() || 'your convention';
+      Alert.alert(
+        'Your suits are listed by default',
+        `TailTag now adds every suit in your account to ${target} automatically. If a suit is not catchable there, open that suit, edit its convention roster, and remove it or turn off “Show on roster.”`,
+        [{ text: 'Review suits' }, { text: 'Got it', style: 'cancel' }],
+      );
+    };
+
+    void (async () => {
+      const pendingNotice = await consumeSuitAutoEnrollNotice(userId);
+      if (cancelled) {
+        return;
+      }
+
+      if (pendingNotice) {
+        showNotice(pendingNotice.conventionName);
+        return;
+      }
+
+      if (!hasConventionListedSuits) {
+        return;
+      }
+
+      const hasSeenMigrationNotice = await hasSeenSuitAutoEnrollMigrationNotice(userId);
+      if (cancelled || hasSeenMigrationNotice) {
+        return;
+      }
+
+      await markSuitAutoEnrollMigrationNoticeSeen(userId);
+      if (!cancelled) {
+        showNotice();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [error, hasConventionListedSuits, hasSuits, isLoading, userId]);
 
   return (
     <ScrollView
@@ -203,10 +250,11 @@ export default function MySuitsScreen() {
 
       {showRosterGuidance ? (
         <TailTagCard style={styles.guidanceCard}>
-          <Text style={styles.guidanceEyebrow}>Next step</Text>
-          <Text style={styles.guidanceTitle}>List suits for {rosterGuidanceConventionName}</Text>
+          <Text style={styles.guidanceEyebrow}>Roster update</Text>
+          <Text style={styles.guidanceTitle}>Review suits for {rosterGuidanceConventionName}</Text>
           <Text style={styles.guidanceBody}>
-            Choose which suits you&apos;re bringing so other players can catch them there.
+            TailTag listed every suit in your account for this convention. Open any suit that should
+            not be catchable there and remove the convention or turn off Show on roster.
           </Text>
           {isLoading ? (
             <Text style={styles.message}>Loading your suits…</Text>
@@ -221,36 +269,39 @@ export default function MySuitsScreen() {
                 Try again
               </TailTagButton>
             </View>
-          ) : hasSuits && rosterGuidanceSuits.length === 0 ? (
-            <Text style={styles.guidanceSuccess}>
-              All of your suits are listed for {rosterGuidanceConventionName}.
-            </Text>
           ) : hasSuits ? (
             <View style={styles.guidanceSuitList}>
-              {rosterGuidanceSuits.map((suit) => (
-                <Pressable
-                  key={suit.id}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Edit ${suit.name}`}
-                  accessibilityHint="Opens the fursuit editor"
-                  onPress={() =>
-                    router.push({
-                      pathname: '/fursuits/[id]/edit',
-                      params: { id: suit.id },
-                    })
-                  }
-                  style={({ pressed }) => [
-                    styles.guidanceSuitRow,
-                    pressed ? styles.guidanceSuitRowPressed : null,
-                  ]}
-                >
-                  <View style={styles.guidanceSuitTextBlock}>
-                    <Text style={styles.guidanceSuitName}>{suit.name}</Text>
-                    <Text style={styles.guidanceSuitMeta}>Not listed yet</Text>
-                  </View>
-                  <Text style={styles.guidanceSuitAction}>Edit</Text>
-                </Pressable>
-              ))}
+              {rosterGuidanceSuits.map((suit) => {
+                const isListed = suit.conventions.some(
+                  (convention) => convention.id === rosterGuidanceConventionId,
+                );
+                return (
+                  <Pressable
+                    key={suit.id}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Edit ${suit.name}`}
+                    accessibilityHint="Opens the fursuit editor"
+                    onPress={() =>
+                      router.push({
+                        pathname: '/fursuits/[id]/edit',
+                        params: { id: suit.id },
+                      })
+                    }
+                    style={({ pressed }) => [
+                      styles.guidanceSuitRow,
+                      pressed ? styles.guidanceSuitRowPressed : null,
+                    ]}
+                  >
+                    <View style={styles.guidanceSuitTextBlock}>
+                      <Text style={styles.guidanceSuitName}>{suit.name}</Text>
+                      <Text style={styles.guidanceSuitMeta}>
+                        {isListed ? 'Listed by default' : 'Not listed'}
+                      </Text>
+                    </View>
+                    <Text style={styles.guidanceSuitAction}>Edit</Text>
+                  </Pressable>
+                );
+              })}
             </View>
           ) : (
             <Text style={styles.guidanceBody}>

--- a/app/catches/[id].tsx
+++ b/app/catches/[id].tsx
@@ -171,7 +171,7 @@ export default function CatchDetailScreen() {
                 avatarUrl={details.avatar_url}
                 uniqueCode={details.unique_code}
                 timelineLabel={timelineLabel}
-                codeLabel={undefined}
+                codeLabel={null}
               />
             </Pressable>
             {record.catchPhotoUrl ? (

--- a/app/conventions/[conventionId]/roster.tsx
+++ b/app/conventions/[conventionId]/roster.tsx
@@ -172,7 +172,7 @@ export default function ConventionSuitRosterScreen() {
     return 'No roster matches.';
   })();
 
-  const title = conventionName ? `${conventionName} Suiter Roster` : 'Suiter Roster';
+  const title = conventionName ? `${conventionName} Fursuit Roster` : 'Fursuit Roster';
 
   return (
     <View style={styles.wrapper}>

--- a/app/conventions/[conventionId]/roster.tsx
+++ b/app/conventions/[conventionId]/roster.tsx
@@ -133,13 +133,11 @@ export default function ConventionSuitRosterScreen() {
 
   const counts = useMemo(() => {
     const caught = rosterEntries.filter((entry) => entry.caughtByCurrentUser).length;
-    const catchable = rosterEntries.filter((entry) => entry.catchableNow).length;
 
     return {
       all: rosterEntries.length,
       notCaught: rosterEntries.length - caught,
       caught,
-      catchable,
     };
   }, [rosterEntries]);
 
@@ -154,9 +152,6 @@ export default function ConventionSuitRosterScreen() {
         return buildSearchText(entry).includes(normalizedSearch);
       })
       .sort((a, b) => {
-        const catchableDiff = Number(b.catchableNow) - Number(a.catchableNow);
-        if (catchableDiff !== 0) return catchableDiff;
-
         const notCaughtDiff = Number(!b.caughtByCurrentUser) - Number(!a.caughtByCurrentUser);
         if (notCaughtDiff !== 0) return notCaughtDiff;
 
@@ -198,10 +193,6 @@ export default function ConventionSuitRosterScreen() {
           <View style={styles.summaryPill}>
             <Text style={styles.summaryValue}>{counts.caught}</Text>
             <Text style={styles.summaryLabel}>Caught</Text>
-          </View>
-          <View style={styles.summaryPill}>
-            <Text style={styles.summaryValue}>{counts.catchable}</Text>
-            <Text style={styles.summaryLabel}>Catchable</Text>
           </View>
         </View>
 
@@ -310,13 +301,6 @@ export default function ConventionSuitRosterScreen() {
                       </Text>
                     ) : null}
                     <View style={styles.badgeRow}>
-                      {entry.catchableNow ? (
-                        <View style={[styles.badge, styles.badgePrimary]}>
-                          <Text style={[styles.badgeText, styles.badgeTextPrimary]}>
-                            Catchable now
-                          </Text>
-                        </View>
-                      ) : null}
                       {entry.caughtByCurrentUser ? (
                         <View style={[styles.badge, styles.badgeSuccess]}>
                           <Text style={[styles.badgeText, styles.badgeTextSuccess]}>Caught</Text>

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -89,7 +89,6 @@ const PRONOUN_OPTIONS = [
 
 const DEFAULT_ROSTER_SETTINGS: FursuitConventionRosterSettings = {
   rosterVisible: true,
-  catchableNow: false,
 };
 
 const ASK_ME_ABOUT_SUGGESTIONS = [
@@ -349,7 +348,6 @@ export default function EditFursuitScreen() {
         entry.id,
         {
           rosterVisible: entry.roster_visible !== false,
-          catchableNow: entry.catchable_now === true,
         } satisfies FursuitConventionRosterSettings,
       ]),
     );
@@ -605,10 +603,7 @@ export default function EditFursuitScreen() {
 
       const current = conventionRosterSettingsById[id] ?? DEFAULT_ROSTER_SETTINGS;
       const initial = initialConventionRosterSettingsById[id] ?? DEFAULT_ROSTER_SETTINGS;
-      return (
-        current.rosterVisible !== initial.rosterVisible ||
-        current.catchableNow !== initial.catchableNow
-      );
+      return current.rosterVisible !== initial.rosterVisible;
     });
 
     setIsSubmitting(true);

--- a/app/fursuits/[id]/edit.tsx
+++ b/app/fursuits/[id]/edit.tsx
@@ -148,9 +148,9 @@ export default function EditFursuitScreen() {
     error,
     refetch,
   } = useQuery({
-    enabled: Boolean(fursuitId),
-    queryKey: fursuitDetailQueryKey(fursuitId ?? ''),
-    queryFn: () => fetchFursuitDetail(fursuitId ?? ''),
+    enabled: Boolean(fursuitId && userId),
+    queryKey: fursuitDetailQueryKey(fursuitId ?? '', userId),
+    queryFn: () => fetchFursuitDetail(fursuitId ?? '', userId),
     staleTime: 0,
   });
 

--- a/app/fursuits/[id]/index.tsx
+++ b/app/fursuits/[id]/index.tsx
@@ -71,8 +71,8 @@ export default function FursuitDetailScreen() {
 
   const fursuitDetailQuery = useQuery({
     enabled: Boolean(fursuitId),
-    queryKey: fursuitDetailQueryKey(fursuitId ?? ''),
-    queryFn: () => fetchFursuitDetail(fursuitId ?? ''),
+    queryKey: fursuitDetailQueryKey(fursuitId ?? '', userId),
+    queryFn: () => fetchFursuitDetail(fursuitId ?? '', userId),
     staleTime: 2 * 60_000,
   });
   const { data: detail, error, refetch } = fursuitDetailQuery;
@@ -269,7 +269,7 @@ export default function FursuitDetailScreen() {
                       <Text style={styles.leadTimeline}>Added on {addedDate}</Text>
                     ) : null}
                   </View>
-                  {detail.unique_code?.trim() ? (
+                  {isOwner && detail.unique_code?.trim() ? (
                     <View style={styles.section}>
                       <Text style={styles.sectionTitle}>Catch code</Text>
                       <Pressable

--- a/app/leaderboard/[conventionId].tsx
+++ b/app/leaderboard/[conventionId].tsx
@@ -157,7 +157,12 @@ export default function FullLeaderboardScreen() {
                         router.push({ pathname: '/profile/[id]', params: { id: entry.profileId } })
                       }
                     >
-                      <Text style={styles.rank}>#{rank}</Text>
+                      <Text
+                        style={styles.rank}
+                        numberOfLines={1}
+                      >
+                        #{rank}
+                      </Text>
                       <View style={styles.details}>
                         <Text
                           style={styles.name}
@@ -221,7 +226,12 @@ export default function FullLeaderboardScreen() {
                     accessibilityRole="button"
                     accessibilityLabel={`View ${entry.name}'s fursuit profile`}
                   >
-                    <Text style={styles.rank}>#{index + 1}</Text>
+                    <Text
+                      style={styles.rank}
+                      numberOfLines={1}
+                    >
+                      #{index + 1}
+                    </Text>
                     <AppAvatar
                       url={entry.avatarUrl}
                       size="xs"

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -13,7 +13,11 @@ import {
   fetchProfileConventionMemberships,
   type ConventionMembership,
 } from '../../src/features/conventions';
-import { createMySuitsQueryOptions } from '../../src/features/suits';
+import {
+  createMySuitsQueryOptions,
+  mySuitsQueryKey,
+  type FursuitSummary,
+} from '../../src/features/suits';
 import { ProgressDots } from '../../src/features/onboarding/components/ProgressDots';
 import { WelcomeStep } from '../../src/features/onboarding/components/WelcomeStep';
 import { ConventionStep } from '../../src/features/onboarding/components/ConventionStep';
@@ -85,8 +89,8 @@ export default function OnboardingScreen() {
     ...(userId
       ? createMySuitsQueryOptions(userId)
       : {
-          queryKey: ['my-suits', 'guest'],
-          queryFn: async () => [],
+          queryKey: mySuitsQueryKey('guest'),
+          queryFn: async (): Promise<FursuitSummary[]> => [],
         }),
     enabled: Boolean(userId),
   });

--- a/app/profile/[id]/index.tsx
+++ b/app/profile/[id]/index.tsx
@@ -72,8 +72,8 @@ export default function PublicProfileScreen() {
   const { data: profile, error: profileError, refetch: refetchProfile } = profileQuery;
 
   const fursuitsQuery = useQuery({
-    queryKey: mySuitsQueryKey(profileId ?? ''),
-    queryFn: () => fetchMySuits(profileId ?? ''),
+    queryKey: mySuitsQueryKey(profileId ?? '', isSelf),
+    queryFn: () => fetchMySuits(profileId ?? '', isSelf),
     staleTime: MY_SUITS_STALE_TIME,
     enabled: Boolean(profileId),
     refetchOnWindowFocus: false,
@@ -304,7 +304,8 @@ export default function PublicProfileScreen() {
                       species={fursuit.species}
                       colors={fursuit.colors}
                       avatarUrl={fursuit.avatar_url}
-                      uniqueCode={fursuit.unique_code}
+                      uniqueCode={isSelf ? fursuit.unique_code : null}
+                      codeLabel={isSelf ? 'Catch code' : null}
                     />
                   </Pressable>
                 ))}

--- a/src/app-styles/(tabs)/suits/index.styles.ts
+++ b/src/app-styles/(tabs)/suits/index.styles.ts
@@ -68,12 +68,6 @@ export const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
   },
-  guidanceSuccess: {
-    color: colors.primary,
-    fontSize: 14,
-    fontWeight: '700',
-    lineHeight: 20,
-  },
   guidanceActions: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/src/app-styles/conventions/roster.styles.ts
+++ b/src/app-styles/conventions/roster.styles.ts
@@ -122,10 +122,6 @@ export const styles = StyleSheet.create({
     paddingHorizontal: spacing.sm,
     paddingVertical: 3,
   },
-  badgePrimary: {
-    borderColor: colors.primaryBorder,
-    backgroundColor: colors.primarySurface,
-  },
   badgeSuccess: {
     borderColor: 'rgba(74,222,128,0.38)',
     backgroundColor: 'rgba(22,101,52,0.24)',
@@ -134,9 +130,6 @@ export const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: 11,
     fontWeight: '700',
-  },
-  badgeTextPrimary: {
-    color: colors.primary,
   },
   badgeTextSuccess: {
     color: '#86efac',

--- a/src/app-styles/leaderboard/[conventionId].styles.ts
+++ b/src/app-styles/leaderboard/[conventionId].styles.ts
@@ -38,9 +38,11 @@ export const styles = StyleSheet.create({
     opacity: 0.7,
   },
   rank: {
-    width: 36,
+    width: 56,
+    flexShrink: 0,
     fontSize: 16,
     fontWeight: '600',
+    fontVariant: ['tabular-nums'],
     color: colors.primary,
   },
   details: {

--- a/src/components/conventions/FursuitConventionRosterControls.tsx
+++ b/src/components/conventions/FursuitConventionRosterControls.tsx
@@ -5,7 +5,6 @@ import { styles } from './FursuitConventionRosterControls.styles';
 
 export type FursuitConventionRosterControlValue = {
   rosterVisible: boolean;
-  catchableNow: boolean;
 };
 
 type FursuitConventionRosterControlsProps = {
@@ -22,18 +21,8 @@ export function FursuitConventionRosterControls({
   const handleVisibleChange = (rosterVisible: boolean) => {
     onChange({
       rosterVisible,
-      catchableNow: rosterVisible ? value.catchableNow : false,
     });
   };
-
-  const handleCatchableChange = (catchableNow: boolean) => {
-    onChange({
-      rosterVisible: true,
-      catchableNow,
-    });
-  };
-
-  const catchableDisabled = disabled || !value.rosterVisible;
 
   return (
     <View style={styles.container}>
@@ -51,25 +40,6 @@ export function FursuitConventionRosterControls({
           trackColor={{ false: colors.borderDefault, true: colors.primarySurfaceStrong }}
           thumbColor={value.rosterVisible ? colors.primary : 'rgba(203,213,225,0.9)'}
           accessibilityLabel="Show this suit on the convention roster"
-        />
-      </View>
-
-      <View style={styles.row}>
-        <View style={styles.textBlock}>
-          <Text style={[styles.label, catchableDisabled && styles.disabledText]}>
-            Catchable now
-          </Text>
-          <Text style={[styles.helper, catchableDisabled && styles.disabledText]}>
-            Mark this suit as actively available to catch.
-          </Text>
-        </View>
-        <Switch
-          value={value.rosterVisible && value.catchableNow}
-          disabled={catchableDisabled}
-          onValueChange={handleCatchableChange}
-          trackColor={{ false: colors.borderDefault, true: colors.primarySurfaceStrong }}
-          thumbColor={value.catchableNow ? colors.primary : 'rgba(203,213,225,0.9)'}
-          accessibilityLabel="Mark this suit catchable now"
         />
       </View>
     </View>

--- a/src/features/conventions/api/conventions.ts
+++ b/src/features/conventions/api/conventions.ts
@@ -178,7 +178,6 @@ export type ConventionRecapDetail = {
 
 export type FursuitConventionRosterSettings = {
   rosterVisible: boolean;
-  catchableNow: boolean;
 };
 
 export type ConventionSuitRosterEntry = {
@@ -192,8 +191,6 @@ export type ConventionSuitRosterEntry = {
   ownerProfileId: string | null;
   ownerUsername: string | null;
   rosterVisible: boolean;
-  catchableNow: boolean;
-  catchableUpdatedAt: string | null;
   conventionCatchCount: number;
   caughtByCurrentUser: boolean;
 };
@@ -610,8 +607,6 @@ export async function fetchConventionSuitRoster(
       ownerProfileId: row.owner_id ?? null,
       ownerUsername: row.owner_username ?? null,
       rosterVisible: row.roster_visible !== false,
-      catchableNow: row.catchable_now === true,
-      catchableUpdatedAt: row.catchable_updated_at ?? null,
       conventionCatchCount: Number(row.convention_catch_count ?? 0),
       caughtByCurrentUser: row.caught_by_current_user === true,
     }));
@@ -734,7 +729,6 @@ export async function addFursuitConvention(
   conventionId: string,
   settings: FursuitConventionRosterSettings = {
     rosterVisible: true,
-    catchableNow: false,
   },
 ): Promise<void> {
   const client = supabase as SupabaseClient<Database>;
@@ -744,7 +738,6 @@ export async function addFursuitConvention(
       fursuit_id: fursuitId,
       convention_id: conventionId,
       roster_visible: rosterVisible,
-      catchable_now: rosterVisible && settings.catchableNow === true,
     },
     { onConflict: 'fursuit_id, convention_id' },
   );

--- a/src/features/conventions/api/conventions.ts
+++ b/src/features/conventions/api/conventions.ts
@@ -585,7 +585,7 @@ export async function fetchConventionSuitRoster(
       scope: 'conventions.fetchConventionSuitRoster',
       conventionId,
     });
-    throw new Error(`We couldn't load the suiter roster: ${error.message}`);
+    throw new Error(`We couldn't load the fursuit roster: ${error.message}`);
   }
 
   type RosterRow = Database['public']['Functions']['get_convention_suit_roster']['Returns'][number];

--- a/src/features/onboarding/components/ConventionStep.tsx
+++ b/src/features/onboarding/components/ConventionStep.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { Alert, ScrollView, Text, View } from 'react-native';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -218,6 +218,19 @@ export function ConventionStep({ userId, onComplete, onSkip }: ConventionStepPro
       });
 
       onComplete(selections);
+      if (toAdd.length > 0) {
+        const addedConventionNames = toAdd
+          .map((conventionId) => conventions.find((convention) => convention.id === conventionId))
+          .filter((convention): convention is ConventionSummary => Boolean(convention))
+          .map((convention) => convention.name);
+        const target =
+          addedConventionNames.length === 1 ? addedConventionNames[0] : 'your conventions';
+        Alert.alert(
+          'Your suits will be listed by default',
+          `TailTag now adds every suit in your account to ${target}. If a suit is not catchable there, open My Suits later and remove that convention from the suit.`,
+          [{ text: 'Got it' }],
+        );
+      }
     } catch (caught) {
       void queryClient.invalidateQueries({
         queryKey: [PROFILE_CONVENTION_MEMBERSHIPS_QUERY_KEY, userId],

--- a/src/features/onboarding/components/FursuitStep.tsx
+++ b/src/features/onboarding/components/FursuitStep.tsx
@@ -151,6 +151,7 @@ export function FursuitStep({
     new Set(draft.selectedConventionIds),
   );
   const isMountedRef = useRef(true);
+  const hasAppliedDefaultConventionsRef = useRef(draft.selectedConventionIds.length > 0);
   const colorLoadError = colorError?.message ?? null;
   const isColorBusy = isColorLoading;
 
@@ -321,6 +322,11 @@ export function FursuitStep({
     }
 
     setSelectedConventionIds((current) => {
+      if (!hasAppliedDefaultConventionsRef.current && current.size === 0) {
+        hasAppliedDefaultConventionsRef.current = true;
+        return new Set(profileConventionIdSet);
+      }
+
       const filtered = new Set([...current].filter((id) => profileConventionIdSet.has(id)));
       return filtered.size === current.size ? current : filtered;
     });
@@ -438,11 +444,15 @@ export function FursuitStep({
     setSpeciesInput(emptyDraft.speciesInput);
     setDescriptionInput(emptyDraft.descriptionInput);
     setSelectedColorIds(emptyDraft.selectedColorIds);
-    setSelectedConventionIds(new Set(emptyDraft.selectedConventionIds));
+    setSelectedConventionIds(new Set(profileConventionIdSet));
+    hasAppliedDefaultConventionsRef.current = true;
     setSelectedPhoto(null);
     setPhotoError(null);
     setSubmitError(null);
-    onDraftChange(emptyDraft);
+    onDraftChange({
+      ...emptyDraft,
+      selectedConventionIds: [...profileConventionIdSet],
+    });
   };
 
   const handleSkip = () => {

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -42,8 +42,6 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       ),
       fursuit_conventions:fursuit_conventions (
         roster_visible,
-        catchable_now,
-        catchable_updated_at,
         convention:conventions (
           id,
           slug,
@@ -108,8 +106,6 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       geofence_enabled: Boolean(entry.convention.geofence_enabled),
       location_verification_required: Boolean(entry.convention.location_verification_required),
       roster_visible: entry.roster_visible !== false,
-      catchable_now: entry.catchable_now === true,
-      catchable_updated_at: entry.catchable_updated_at ?? null,
     }));
 
   const bio = mapLatestFursuitBio(data.fursuit_bios ?? null);

--- a/src/features/suits/api/fursuitDetails.ts
+++ b/src/features/suits/api/fursuitDetails.ts
@@ -7,10 +7,15 @@ import { FURSUIT_BUCKET } from '../../../constants/storage';
 import { resolveStorageMediaUrl } from '../../../utils/supabase-image';
 
 export const FURSUIT_DETAIL_QUERY_KEY = 'fursuit-detail';
-export const fursuitDetailQueryKey = (fursuitId: string) =>
-  [FURSUIT_DETAIL_QUERY_KEY, fursuitId] as const;
+export const fursuitDetailQueryKey = (fursuitId: string, viewerId?: string | null) =>
+  viewerId
+    ? ([FURSUIT_DETAIL_QUERY_KEY, fursuitId, viewerId] as const)
+    : ([FURSUIT_DETAIL_QUERY_KEY, fursuitId] as const);
 
-export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDetail> {
+export async function fetchFursuitDetail(
+  fursuitId: string,
+  viewerId?: string | null,
+): Promise<FursuitDetail> {
   const client = supabase as any;
   const { data, error } = await client
     .from('fursuits')
@@ -24,7 +29,6 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       avatar_url,
       is_tutorial,
       description,
-      unique_code,
       catch_count,
       created_at,
       species_entry:fursuit_species (
@@ -115,6 +119,22 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
   const colors = mapFursuitColors(data.color_assignments ?? null);
   const makersByFursuitId = await fetchFursuitMakersByFursuitIds([data.id]);
   const makers = makersByFursuitId.get(data.id) ?? [];
+  let uniqueCode: string | null = null;
+
+  if (viewerId && data.owner_id === viewerId) {
+    const { data: codeData, error: codeError } = await client
+      .from('fursuits')
+      .select('unique_code')
+      .eq('id', data.id)
+      .eq('owner_id', viewerId)
+      .maybeSingle();
+
+    if (codeError) {
+      throw new Error("We couldn't load that fursuit right now. Please try again.");
+    }
+
+    uniqueCode = codeData?.unique_code ?? null;
+  }
 
   let resolvedCatchCount = typeof data.catch_count === 'number' ? data.catch_count : 0;
 
@@ -146,7 +166,7 @@ export async function fetchFursuitDetail(fursuitId: string): Promise<FursuitDeta
       legacyUrl: data.avatar_url ?? null,
     }),
     description: data.description ?? null,
-    unique_code: data.unique_code ?? null,
+    unique_code: uniqueCode,
     catchCount: resolvedCatchCount,
     created_at: data.created_at ?? null,
     conventions,

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -9,10 +9,14 @@ export const MY_SUITS_QUERY_KEY = 'my-suits';
 export const MY_SUITS_COUNT_QUERY_KEY = 'my-suits-count';
 export const MY_SUITS_STALE_TIME = 2 * 60_000;
 
-export const mySuitsQueryKey = (userId: string) => [MY_SUITS_QUERY_KEY, userId] as const;
+export const mySuitsQueryKey = (userId: string, includeUniqueCodes = true) =>
+  [MY_SUITS_QUERY_KEY, userId, includeUniqueCodes ? 'with-codes' : 'public'] as const;
 export const mySuitsCountQueryKey = (userId: string) => [MY_SUITS_COUNT_QUERY_KEY, userId] as const;
 
-export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
+export async function fetchMySuits(
+  userId: string,
+  includeUniqueCodes = true,
+): Promise<FursuitSummary[]> {
   const client = supabase as any;
   const { data, error } = await client
     .from('fursuits')
@@ -24,7 +28,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       avatar_path,
       avatar_url,
       description,
-      unique_code,
+      ${includeUniqueCodes ? 'unique_code,' : ''}
       catch_count,
       created_at,
       species_entry:fursuit_species (
@@ -121,7 +125,7 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
         legacyUrl: item.avatar_url ?? null,
       }),
       description: item.description ?? null,
-      unique_code: item.unique_code ?? null,
+      unique_code: includeUniqueCodes ? (item.unique_code ?? null) : null,
       catchCount: typeof item.catch_count === 'number' ? item.catch_count : 0,
       created_at: item.created_at ?? null,
       conventions,

--- a/src/features/suits/api/mySuits.ts
+++ b/src/features/suits/api/mySuits.ts
@@ -42,8 +42,6 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
       ),
       fursuit_conventions:fursuit_conventions (
         roster_visible,
-        catchable_now,
-        catchable_updated_at,
         convention:conventions (
           id,
           slug,
@@ -101,8 +99,6 @@ export async function fetchMySuits(userId: string): Promise<FursuitSummary[]> {
         geofence_enabled: Boolean(entry.convention.geofence_enabled),
         location_verification_required: Boolean(entry.convention.location_verification_required),
         roster_visible: entry.roster_visible !== false,
-        catchable_now: entry.catchable_now === true,
-        catchable_updated_at: entry.catchable_updated_at ?? null,
       }));
 
     const bio = mapLatestFursuitBio(item.fursuit_bios ?? null);

--- a/src/features/suits/autoEnrollNotice.ts
+++ b/src/features/suits/autoEnrollNotice.ts
@@ -1,0 +1,61 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const NOTICE_VERSION = 'v1';
+
+const migrationNoticeKey = (userId: string) =>
+  `tailtag:suits:auto-enroll-migration-notice:${NOTICE_VERSION}:${userId}`;
+
+const pendingJoinNoticeKey = (userId: string) =>
+  `tailtag:suits:auto-enroll-pending-join-notice:${NOTICE_VERSION}:${userId}`;
+
+export type SuitAutoEnrollNotice = {
+  conventionId?: string | null;
+  conventionName?: string | null;
+};
+
+export async function queueSuitAutoEnrollNotice(
+  userId: string,
+  notice: SuitAutoEnrollNotice,
+): Promise<void> {
+  try {
+    await AsyncStorage.setItem(pendingJoinNoticeKey(userId), JSON.stringify(notice));
+  } catch (error) {
+    console.warn('Failed to queue suit auto-enroll notice', error);
+  }
+}
+
+export async function consumeSuitAutoEnrollNotice(
+  userId: string,
+): Promise<SuitAutoEnrollNotice | null> {
+  try {
+    const key = pendingJoinNoticeKey(userId);
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+
+    await AsyncStorage.removeItem(key);
+    const parsed = JSON.parse(raw) as SuitAutoEnrollNotice;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    console.warn('Failed to consume suit auto-enroll notice', error);
+    return null;
+  }
+}
+
+export async function hasSeenSuitAutoEnrollMigrationNotice(userId: string): Promise<boolean> {
+  try {
+    return (await AsyncStorage.getItem(migrationNoticeKey(userId))) === 'true';
+  } catch (error) {
+    console.warn('Failed to read suit auto-enroll migration notice', error);
+    return true;
+  }
+}
+
+export async function markSuitAutoEnrollMigrationNoticeSeen(userId: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(migrationNoticeKey(userId), 'true');
+  } catch (error) {
+    console.warn('Failed to mark suit auto-enroll migration notice seen', error);
+  }
+}

--- a/src/features/suits/components/FursuitCard.tsx
+++ b/src/features/suits/components/FursuitCard.tsx
@@ -16,7 +16,7 @@ type FursuitCardProps = {
   avatarUrl?: string | null;
   uniqueCode?: string | null;
   timelineLabel?: string | null;
-  codeLabel?: string;
+  codeLabel?: string | null;
   actionSlot?: ReactNode;
   onPress?: () => void;
   onCodeCopied?: () => void;
@@ -123,7 +123,7 @@ export function FursuitCard({
         </View>
       </View>
       <View style={styles.metaRow}>
-        {codeLabel ? (
+        {codeLabel !== null ? (
           <View style={styles.codeBlock}>
             <Text style={styles.codeLabel}>{codeLabel}</Text>
             <Pressable

--- a/src/features/suits/index.ts
+++ b/src/features/suits/index.ts
@@ -52,3 +52,10 @@ export {
   FURSUIT_DETAIL_QUERY_KEY,
   fursuitDetailQueryKey,
 } from './api/fursuitDetails';
+export {
+  consumeSuitAutoEnrollNotice,
+  hasSeenSuitAutoEnrollMigrationNotice,
+  markSuitAutoEnrollMigrationNoticeSeen,
+  queueSuitAutoEnrollNotice,
+  type SuitAutoEnrollNotice,
+} from './autoEnrollNotice';

--- a/src/features/suits/types.ts
+++ b/src/features/suits/types.ts
@@ -23,8 +23,6 @@ export type FursuitMaker = {
 
 export type FursuitConvention = ConventionSummary & {
   roster_visible: boolean;
-  catchable_now: boolean;
-  catchable_updated_at: string | null;
 };
 
 export type FursuitSummary = {

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -508,24 +508,18 @@ export type Database = {
       };
       fursuit_conventions: {
         Row: {
-          catchable_now: boolean;
-          catchable_updated_at: string | null;
           convention_id: string;
           created_at: string;
           fursuit_id: string;
           roster_visible: boolean;
         };
         Insert: {
-          catchable_now?: boolean;
-          catchable_updated_at?: string | null;
           convention_id: string;
           created_at?: string;
           fursuit_id: string;
           roster_visible?: boolean;
         };
         Update: {
-          catchable_now?: boolean;
-          catchable_updated_at?: string | null;
           convention_id?: string;
           created_at?: string;
           fursuit_id?: string;
@@ -953,8 +947,6 @@ export type Database = {
       get_convention_suit_roster: {
         Args: { p_convention_id: string };
         Returns: {
-          catchable_now: boolean;
-          catchable_updated_at: string | null;
           color_assignments: Json;
           convention_catch_count: number;
           convention_id: string;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -930,24 +930,18 @@ export type Database = {
       }
       fursuit_conventions: {
         Row: {
-          catchable_now: boolean
-          catchable_updated_at: string | null
           convention_id: string
           created_at: string
           fursuit_id: string
           roster_visible: boolean
         }
         Insert: {
-          catchable_now?: boolean
-          catchable_updated_at?: string | null
           convention_id: string
           created_at?: string
           fursuit_id: string
           roster_visible?: boolean
         }
         Update: {
-          catchable_now?: boolean
-          catchable_updated_at?: string | null
           convention_id?: string
           created_at?: string
           fursuit_id?: string
@@ -2255,8 +2249,6 @@ export type Database = {
       get_convention_suit_roster: {
         Args: { p_convention_id: string }
         Returns: {
-          catchable_now: boolean
-          catchable_updated_at: string
           caught_by_current_user: boolean
           color_assignments: Json
           convention_catch_count: number

--- a/supabase/migrations/20260508140000_remove_fursuit_roster_catchable.sql
+++ b/supabase/migrations/20260508140000_remove_fursuit_roster_catchable.sql
@@ -1,0 +1,113 @@
+DROP FUNCTION IF EXISTS public.get_convention_suit_roster(uuid);
+
+CREATE OR REPLACE FUNCTION public.get_convention_suit_roster(p_convention_id uuid)
+RETURNS TABLE (
+  fursuit_id uuid,
+  convention_id uuid,
+  fursuit_name text,
+  fursuit_avatar_path text,
+  fursuit_avatar_url text,
+  owner_id uuid,
+  owner_username text,
+  species_id uuid,
+  species_name text,
+  color_assignments jsonb,
+  roster_visible boolean,
+  convention_catch_count bigint,
+  caught_by_current_user boolean
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    f.id AS fursuit_id,
+    fc.convention_id,
+    f.name AS fursuit_name,
+    f.avatar_path AS fursuit_avatar_path,
+    f.avatar_url AS fursuit_avatar_url,
+    f.owner_id,
+    p.username AS owner_username,
+    fs.id AS species_id,
+    fs.name AS species_name,
+    colors.color_assignments,
+    fc.roster_visible,
+    coalesce(catch_counts.convention_catch_count, 0) AS convention_catch_count,
+    coalesce(current_user_catches.caught_by_current_user, false) AS caught_by_current_user
+  FROM public.fursuit_conventions fc
+  JOIN public.fursuits f ON f.id = fc.fursuit_id
+  JOIN public.profiles p ON p.id = f.owner_id
+  LEFT JOIN public.fursuit_species fs ON fs.id = f.species_id
+  LEFT JOIN LATERAL (
+    SELECT coalesce(
+      jsonb_agg(
+        jsonb_build_object(
+          'position', fca.position,
+          'color', jsonb_build_object(
+            'id', fursuit_colors.id,
+            'name', fursuit_colors.name,
+            'normalized_name', fursuit_colors.normalized_name
+          )
+        )
+        ORDER BY fca.position ASC, fursuit_colors.name ASC
+      ),
+      '[]'::jsonb
+    ) AS color_assignments
+    FROM public.fursuit_color_assignments fca
+    JOIN public.fursuit_colors ON fursuit_colors.id = fca.color_id
+    WHERE fca.fursuit_id = f.id
+  ) colors ON true
+  LEFT JOIN LATERAL (
+    SELECT count(*) AS convention_catch_count
+    FROM public.catches c
+    WHERE c.fursuit_id = f.id
+      AND c.convention_id = p_convention_id
+      AND c.status = 'ACCEPTED'
+      AND c.is_tutorial = false
+  ) catch_counts ON true
+  LEFT JOIN LATERAL (
+    SELECT true AS caught_by_current_user
+    FROM public.catches c
+    WHERE c.fursuit_id = f.id
+      AND c.convention_id = p_convention_id
+      AND c.catcher_id = auth.uid()
+      AND c.status = 'ACCEPTED'
+      AND c.is_tutorial = false
+    LIMIT 1
+  ) current_user_catches ON true
+  WHERE fc.convention_id = p_convention_id
+    AND fc.roster_visible = true
+    AND f.is_tutorial = false
+    AND f.is_flagged = false
+    AND (
+      p.is_suspended = false
+      OR (p.suspended_until IS NOT NULL AND p.suspended_until <= now())
+    )
+    AND (
+      auth.uid() = f.owner_id
+      OR public.is_blocked(auth.uid(), f.owner_id) = false
+    )
+  ORDER BY f.name ASC, f.id ASC;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_convention_suit_roster(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_convention_suit_roster(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_convention_suit_roster(uuid) TO authenticated;
+
+DROP TRIGGER IF EXISTS normalize_fursuit_convention_roster_state_trigger
+ON public.fursuit_conventions;
+
+DROP FUNCTION IF EXISTS public.normalize_fursuit_convention_roster_state();
+
+ALTER TABLE public.fursuit_conventions
+  DROP CONSTRAINT IF EXISTS fursuit_conventions_catchable_requires_visible,
+  DROP COLUMN IF EXISTS catchable_now,
+  DROP COLUMN IF EXISTS catchable_updated_at;

--- a/supabase/migrations/20260508150000_auto_enroll_suits_for_convention_memberships.sql
+++ b/supabase/migrations/20260508150000_auto_enroll_suits_for_convention_memberships.sql
@@ -1,0 +1,166 @@
+create or replace function public.opt_in_to_convention(
+  p_profile_id uuid,
+  p_convention_id uuid,
+  p_verified_location jsonb default null::jsonb,
+  p_verification_method text default 'none'::text,
+  p_override_reason text default null::text
+)
+returns void
+language plpgsql
+security definer
+set search_path to 'public', 'extensions'
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_actor_is_admin boolean := auth.role() = 'service_role';
+  v_convention record;
+  v_verification jsonb;
+  v_method text := coalesce(p_verification_method, 'none');
+  v_stored_location jsonb := p_verified_location;
+  v_requires_live_verification boolean := false;
+  v_was_member boolean := false;
+begin
+  if not v_actor_is_admin then
+    v_actor_is_admin := coalesce(public.is_admin(v_actor_id), false);
+  end if;
+
+  if auth.role() <> 'service_role' and v_actor_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if auth.role() <> 'service_role' and v_actor_id is distinct from p_profile_id and not v_actor_is_admin then
+    raise exception 'Not authorized to join conventions for this profile';
+  end if;
+
+  if v_method in ('manual_override', 'grandfathered') and not v_actor_is_admin then
+    raise exception 'Admin privileges required for this verification method';
+  end if;
+
+  select *
+    into v_convention
+    from public.conventions
+   where id = p_convention_id;
+
+  if not found then
+    raise exception 'Convention not found';
+  end if;
+
+  if not public.is_convention_prejoinable(p_convention_id) then
+    raise exception 'Convention is not open for registration';
+  end if;
+
+  select exists (
+    select 1
+      from public.profile_conventions pc
+     where pc.profile_id = p_profile_id
+       and pc.convention_id = p_convention_id
+  )
+  into v_was_member;
+
+  v_requires_live_verification :=
+    public.is_convention_joinable(p_convention_id)
+    and coalesce(v_convention.location_verification_required, false);
+
+  if v_requires_live_verification then
+    if not v_convention.geofence_enabled or v_convention.latitude is null or v_convention.longitude is null then
+      raise exception 'Convention geofence not configured';
+    end if;
+
+    if v_method in ('manual_override', 'grandfathered') then
+      if v_method = 'manual_override' and p_override_reason is null then
+        raise exception 'Override reason required';
+      end if;
+    else
+      if p_verified_location is null then
+        raise exception 'Location verification required';
+      end if;
+
+      v_verification := public.verify_convention_location(
+        p_profile_id,
+        p_convention_id,
+        (p_verified_location->>'lat')::double precision,
+        (p_verified_location->>'lng')::double precision,
+        coalesce((p_verified_location->>'accuracy')::integer, 0)
+      );
+
+      if (v_verification->>'verified')::boolean is distinct from true then
+        raise exception 'Location verification failed: %', coalesce(v_verification->>'error', 'unknown');
+      end if;
+
+      v_method := 'gps';
+      v_stored_location := p_verified_location;
+    end if;
+  else
+    if v_method not in ('manual_override', 'grandfathered') then
+      v_method := 'none';
+      v_stored_location := null;
+    end if;
+  end if;
+
+  insert into public.profile_conventions (
+    profile_id,
+    convention_id,
+    verified_location,
+    verification_method,
+    verified_at,
+    override_actor_id,
+    override_reason,
+    override_at,
+    created_at
+  )
+  values (
+    p_profile_id,
+    p_convention_id,
+    v_stored_location,
+    v_method,
+    case when v_method = 'gps' then now() else null end,
+    case when v_method = 'manual_override' then auth.uid() else null end,
+    case when v_method = 'manual_override' then p_override_reason else null end,
+    case when v_method = 'manual_override' then now() else null end,
+    now()
+  )
+  on conflict (profile_id, convention_id) do update
+  set
+    verified_location = excluded.verified_location,
+    verification_method = excluded.verification_method,
+    verified_at = excluded.verified_at,
+    override_actor_id = excluded.override_actor_id,
+    override_reason = excluded.override_reason,
+    override_at = excluded.override_at;
+
+  if not v_was_member then
+    insert into public.fursuit_conventions (
+      fursuit_id,
+      convention_id,
+      roster_visible
+    )
+    select
+      f.id,
+      p_convention_id,
+      true
+    from public.fursuits f
+    where f.owner_id = p_profile_id
+      and f.is_tutorial = false
+    on conflict (fursuit_id, convention_id) do update
+    set roster_visible = true;
+  end if;
+end;
+$$;
+
+grant execute on function public.opt_in_to_convention(uuid, uuid, jsonb, text, text)
+  to authenticated, service_role;
+
+insert into public.fursuit_conventions (
+  fursuit_id,
+  convention_id,
+  roster_visible
+)
+select
+  f.id,
+  pc.convention_id,
+  true
+from public.profile_conventions pc
+join public.fursuits f on f.owner_id = pc.profile_id
+where f.is_tutorial = false
+on conflict (fursuit_id, convention_id) do update
+set roster_visible = true;


### PR DESCRIPTION
## Summary
- Remove the manual “catchable now” roster setting and related roster badges/sorting
- Hide catch codes from roster-adjacent public browsing flows
- Auto-enroll a player’s suits into conventions they join, with review guidance
- Rename the roster UI to “Fursuit Roster”
- Fix full leaderboard rank formatting for 4+ digit ranks

## Database
- Drops the roster `catchable_now` / `catchable_updated_at` fields and updates the roster RPC shape
- Updates `opt_in_to_convention` to auto-enroll all non-tutorial owned suits for newly joined conventions
- Backfills existing convention memberships into `fursuit_conventions`

## Validation
- npm run ci:validate
- git diff --check