### PR TITLE
V1 gallery photo catch flow

### DIFF
--- a/src/features/catch-confirmations/api/confirmations.ts
+++ b/src/features/catch-confirmations/api/confirmations.ts
@@ -17,6 +17,7 @@ import {
 import { emitLocalGameplayEvent } from '../../events/localGameplayEventsBus';
 import type { Json } from '../../../types/database';
 import type {
+  CatchPhotoSource,
   PendingCatch,
   ConfirmCatchResult,
   CreateCatchResult,
@@ -104,6 +105,10 @@ function normalizeColorNames(raw: unknown): string[] {
   );
 }
 
+function normalizeCatchPhotoSource(raw: unknown): CatchPhotoSource | null {
+  return raw === 'camera' || raw === 'gallery' ? raw : null;
+}
+
 async function wakeGameplayQueue(): Promise<void> {
   const { error } = await supabase.rpc('process_gameplay_queue_if_active');
   if (error) {
@@ -156,6 +161,7 @@ export async function fetchPendingCatches(userId: string): Promise<PendingCatch[
       path: null,
       legacyUrl: row.catch_photo_url ?? null,
     }),
+    catchPhotoSource: normalizeCatchPhotoSource(row.catch_photo_source),
   }));
 }
 
@@ -255,6 +261,7 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
           Boolean(params.hasPhoto) || Boolean(params.photoPath) || Boolean(params.photoUrl),
         catch_photo_path: params.photoPath ?? null,
         catch_photo_url: params.photoUrl ?? null,
+        catch_photo_source: params.photoSource ?? null,
       }),
       signal: controller.signal,
     });
@@ -285,6 +292,11 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
       if (errorMessage.includes('share a playable convention')) {
         throw new Error(
           'This suit is not catchable at your playable convention yet. Both players must be Ready to catch for the same live event, and the fursuit owner must list that specific suit for the event.',
+        );
+      }
+      if (errorMessage.includes('not accepting gallery catches')) {
+        throw new Error(
+          'This convention is no longer accepting gallery catches. Gallery catches can be submitted during the event and for three local days after it ends.',
         );
       }
       if (errorMessage.includes('already caught') || errorMessage.includes('pending')) {
@@ -380,7 +392,7 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
  */
 export async function updateCatchPhoto(
   catchId: string,
-  params: { photoPath: string; photoUrl?: string | null },
+  params: { photoPath: string; photoUrl?: string | null; photoSource?: 'camera' | 'gallery' },
 ): Promise<void> {
   const { data: sessionData } = await supabase.auth.getSession();
   const accessToken = sessionData.session?.access_token;
@@ -413,6 +425,7 @@ export async function updateCatchPhoto(
         catch_id: catchId,
         catch_photo_path: params.photoPath,
         catch_photo_url: resolvedPhotoUrl,
+        catch_photo_source: params.photoSource ?? 'camera',
       }),
       signal: controller.signal,
     });

--- a/src/features/catch-confirmations/api/confirmations.ts
+++ b/src/features/catch-confirmations/api/confirmations.ts
@@ -413,6 +413,20 @@ export async function updateCatchPhoto(
   try {
     const resolvedPhotoUrl =
       params.photoUrl ?? buildAuthenticatedStorageObjectUrl(CATCH_PHOTO_BUCKET, params.photoPath);
+    const requestBody: {
+      catch_id: string;
+      catch_photo_path: string;
+      catch_photo_url: string;
+      catch_photo_source?: 'camera' | 'gallery';
+    } = {
+      catch_id: catchId,
+      catch_photo_path: params.photoPath,
+      catch_photo_url: resolvedPhotoUrl,
+    };
+
+    if (params.photoSource) {
+      requestBody.catch_photo_source = params.photoSource;
+    }
 
     const response = await fetch(`${supabaseUrl}/functions/v1/create-catch`, {
       method: 'PATCH',
@@ -421,12 +435,7 @@ export async function updateCatchPhoto(
         apikey: supabaseKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        catch_id: catchId,
-        catch_photo_path: params.photoPath,
-        catch_photo_url: resolvedPhotoUrl,
-        catch_photo_source: params.photoSource ?? 'camera',
-      }),
+      body: JSON.stringify(requestBody),
       signal: controller.signal,
     });
 

--- a/src/features/catch-confirmations/api/confirmations.ts
+++ b/src/features/catch-confirmations/api/confirmations.ts
@@ -22,7 +22,7 @@ import type {
   ConfirmCatchResult,
   CreateCatchResult,
   CreateCatchParams,
-} from '../types';
+} from '@/features/catch-confirmations/types';
 
 // Query keys
 export const PENDING_CATCHES_QUERY_KEY = 'pending-catches';
@@ -281,9 +281,6 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
       });
 
       // Return user-friendly messages for known errors
-      if (response.status === 403) {
-        throw new Error('You cannot catch this fursuit.');
-      }
       if (errorMessage.includes('Cannot catch your own')) {
         throw new Error(
           'That tag belongs to one of your own suits. Trade codes with friends to grow your collection.',
@@ -308,6 +305,9 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
         throw new Error(
           "We couldn't find a fursuit with that code. Double-check the letters and try again.",
         );
+      }
+      if (response.status === 403) {
+        throw new Error('You cannot catch this fursuit.');
       }
 
       throw new Error("We couldn't save that catch. Please try again.");
@@ -392,7 +392,7 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
  */
 export async function updateCatchPhoto(
   catchId: string,
-  params: { photoPath: string; photoUrl?: string | null; photoSource?: 'camera' | 'gallery' },
+  params: { photoPath: string; photoUrl?: string | null; photoSource?: CatchPhotoSource },
 ): Promise<void> {
   const { data: sessionData } = await supabase.auth.getSession();
   const accessToken = sessionData.session?.access_token;
@@ -417,7 +417,7 @@ export async function updateCatchPhoto(
       catch_id: string;
       catch_photo_path: string;
       catch_photo_url: string;
-      catch_photo_source?: 'camera' | 'gallery';
+      catch_photo_source?: CatchPhotoSource;
     } = {
       catch_id: catchId,
       catch_photo_path: params.photoPath,

--- a/src/features/catch-confirmations/api/myPendingCatches.ts
+++ b/src/features/catch-confirmations/api/myPendingCatches.ts
@@ -1,5 +1,5 @@
 import { supabase } from '../../../lib/supabase';
-import type { MyPendingCatch } from '../types';
+import type { CatchPhotoSource, MyPendingCatch } from '../types';
 import { FURSUIT_BUCKET } from '../../../constants/storage';
 import { resolveStorageMediaUrl } from '../../../utils/supabase-image';
 
@@ -9,6 +9,10 @@ export const myPendingCatchesQueryKey = (userId: string) =>
   [MY_PENDING_CATCHES_QUERY_KEY, userId] as const;
 
 export const MY_PENDING_CATCHES_STALE_TIME = 15 * 1000; // 15 seconds
+
+function normalizeCatchPhotoSource(raw: unknown): CatchPhotoSource | null {
+  return raw === 'camera' || raw === 'gallery' ? raw : null;
+}
 
 /**
  * Fetch catches the current user made that are pending owner approval (catcher's view).
@@ -22,6 +26,7 @@ export async function fetchMyPendingCatches(userId: string): Promise<MyPendingCa
       id,
       caught_at,
       expires_at,
+      catch_photo_source,
       convention_id,
       fursuit:fursuits (
         id,
@@ -60,6 +65,7 @@ export async function fetchMyPendingCatches(userId: string): Promise<MyPendingCa
       conventionName: convention?.name ?? 'Unknown Convention',
       caughtAt: row.caught_at ?? '',
       expiresAt: row.expires_at ?? null,
+      catchPhotoSource: normalizeCatchPhotoSource(row.catch_photo_source),
     } satisfies MyPendingCatch;
   });
 }

--- a/src/features/catch-confirmations/components/CatchModeSwitch.tsx
+++ b/src/features/catch-confirmations/components/CatchModeSwitch.tsx
@@ -24,8 +24,10 @@ export function CatchModeSwitch({
     scope === 'profile'
       ? {
           label: 'Auto-catching for all suits',
-          autoDescription: 'Catches for your suits are recorded instantly without your approval.',
-          manualDescription: 'Players must wait for you to approve catches for your suits.',
+          autoDescription:
+            'Catch codes and in-app camera catches are recorded instantly. Gallery photo catches always require approval.',
+          manualDescription:
+            'Players must wait for you to approve catches for your suits. Gallery photo catches always require approval.',
           accessibilityLabel: 'Auto-catching for all suits',
           autoHint:
             'Currently enabled for all your suits. Toggle to require manual approval for catches.',
@@ -34,8 +36,10 @@ export function CatchModeSwitch({
         }
       : {
           label: 'Auto-catching',
-          autoDescription: 'Catches are recorded instantly without requiring your approval.',
-          manualDescription: 'Players must wait for you to approve their catch before it counts.',
+          autoDescription:
+            'Catch codes and in-app camera catches are recorded instantly. Gallery photo catches always require approval.',
+          manualDescription:
+            'Players must wait for you to approve their catch before it counts. Gallery photo catches always require approval.',
           accessibilityLabel: 'Auto-catching',
           autoHint:
             'Currently enabled. Catches are recorded instantly. Toggle to require manual approval.',

--- a/src/features/catch-confirmations/components/PendingCatchCard.styles.ts
+++ b/src/features/catch-confirmations/components/PendingCatchCard.styles.ts
@@ -94,6 +94,23 @@ export const styles = StyleSheet.create({
     marginBottom: spacing.sm,
     backgroundColor: colors.surfaceMuted,
   },
+  sourceNotice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.xs,
+    backgroundColor: 'rgba(251,191,36,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.35)',
+    borderRadius: radius.md,
+    padding: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  sourceNoticeText: {
+    color: colors.textSubtle,
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 17,
+  },
   reportActionRow: {
     alignItems: 'flex-start',
     marginBottom: spacing.sm,

--- a/src/features/catch-confirmations/components/PendingCatchCard.tsx
+++ b/src/features/catch-confirmations/components/PendingCatchCard.tsx
@@ -192,7 +192,9 @@ export function PendingCatchCard({
               width={screenWidth}
               height={screenWidth}
               style={styles.catchPhoto}
-              accessibilityLabel="Selfie taken by catcher"
+              accessibilityLabel={
+                isGalleryCatch ? 'Photo uploaded from gallery' : 'Selfie taken by catcher'
+              }
             />
           </Pressable>
           <Modal

--- a/src/features/catch-confirmations/components/PendingCatchCard.tsx
+++ b/src/features/catch-confirmations/components/PendingCatchCard.tsx
@@ -92,6 +92,7 @@ export function PendingCatchCard({
   const isExpired = useMemo(() => {
     return timeDisplay === 'Expired';
   }, [timeDisplay]);
+  const isGalleryCatch = pendingCatch.catchPhotoSource === 'gallery';
 
   const handleViewProfile = () => {
     router.push({
@@ -168,6 +169,19 @@ export function PendingCatchCard({
 
       {pendingCatch.catchPhotoUrl ? (
         <>
+          {isGalleryCatch ? (
+            <View style={styles.sourceNotice}>
+              <Ionicons
+                name="images-outline"
+                size={14}
+                color={colors.amber}
+              />
+              <Text style={styles.sourceNoticeText}>
+                Gallery photo catch · Gallery catches always require your approval, even if
+                auto-catching is on.
+              </Text>
+            </View>
+          ) : null}
           <Pressable
             onPress={() => setPhotoFullscreen(true)}
             accessibilityLabel="Tap to view catch photo fullscreen"

--- a/src/features/catch-confirmations/components/PendingCatchesList.tsx
+++ b/src/features/catch-confirmations/components/PendingCatchesList.tsx
@@ -49,8 +49,8 @@ export function PendingCatchesList({
       </View>
       {isEmpty ? (
         <Text style={styles.description}>
-          No pending requests right now. When someone catches your suit and you have manual approval
-          enabled, their requests will appear here for you to approve or decline.
+          No pending requests right now. Manual-approval catches and gallery photo catches will
+          appear here for you to approve or decline.
         </Text>
       ) : (
         <>

--- a/src/features/catch-confirmations/components/PendingConfirmationsList.tsx
+++ b/src/features/catch-confirmations/components/PendingConfirmationsList.tsx
@@ -32,7 +32,9 @@ function PendingConfirmationRow({ item }: { item: MyPendingCatch }) {
           style={styles.subtitle}
           numberOfLines={1}
         >
-          Awaiting owner approval
+          {item.catchPhotoSource === 'gallery'
+            ? 'Awaiting owner approval · Gallery catch'
+            : 'Awaiting owner approval'}
         </Text>
         {displayDate ? (
           <Text
@@ -85,13 +87,14 @@ export function PendingConfirmationsList({ pendingCatches }: PendingConfirmation
       </View>
       {isEmpty ? (
         <Text style={styles.description}>
-          No pending confirmations. When you catch a fursuit that requires owner approval, it will
-          appear here until they approve or decline.
+          No pending confirmations. Manual-approval catches and gallery catches will appear here
+          until the owner approves or declines them.
         </Text>
       ) : (
         <>
           <Text style={styles.description}>
-            These catches are waiting for the fursuit owner to approve.
+            These catches are waiting for the fursuit owner to approve. Gallery catches need
+            approval before they count.
           </Text>
           <View style={styles.list}>
             {pendingCatches.map((item, index) => (

--- a/src/features/catch-confirmations/components/PhotoCatchCard.styles.ts
+++ b/src/features/catch-confirmations/components/PhotoCatchCard.styles.ts
@@ -24,6 +24,9 @@ export const styles = StyleSheet.create({
   cameraButton: {
     borderColor: colors.primary,
   },
+  entryActions: {
+    gap: spacing.sm,
+  },
   buttonContent: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -64,6 +67,11 @@ export const styles = StyleSheet.create({
     color: colors.foreground,
     fontWeight: '600',
     fontSize: 14,
+  },
+  previewHint: {
+    color: colors.textDim,
+    fontSize: 12,
+    lineHeight: 17,
   },
   retakeButton: {
     flexDirection: 'row',

--- a/src/features/catch-confirmations/components/PhotoCatchCard.tsx
+++ b/src/features/catch-confirmations/components/PhotoCatchCard.tsx
@@ -13,10 +13,15 @@ import { loadUriAsUint8Array } from '../../../utils/files';
 import { processImageForUpload, IMAGE_UPLOAD_PRESETS } from '../../../utils/images';
 import { buildAuthenticatedStorageObjectUrl } from '../../../utils/supabase-image';
 import { createCatch, fetchConventionFursuits } from '../api/confirmations';
-import { fetchActiveProfileConventionIds, fetchActiveSharedConventionIds } from '../../conventions';
+import {
+  fetchActiveProfileConventionIds,
+  fetchActiveSharedConventionIds,
+  fetchGalleryProfileConventionIds,
+  fetchGallerySharedConventionIds,
+} from '../../conventions';
 import { FursuitPicker } from './FursuitPicker';
 import type { FursuitPickerItem } from '../api';
-import type { CreateCatchResult } from '../types';
+import type { CatchPhotoSource, CreateCatchResult } from '../types';
 import { styles } from './PhotoCatchCard.styles';
 
 type PhotoCandidate = {
@@ -50,6 +55,7 @@ export function PhotoCatchCard({
 }: PhotoCatchCardProps) {
   const [step, setStep] = useState<Step>('idle');
   const [photo, setPhoto] = useState<PhotoCandidate | null>(null);
+  const [photoSource, setPhotoSource] = useState<CatchPhotoSource | null>(null);
   const [selectedFursuit, setSelectedFursuit] = useState<FursuitPickerItem | null>(null);
   const [fursuits, setFursuits] = useState<FursuitPickerItem[]>([]);
   const [conventionIds, setConventionIds] = useState<string[]>([]);
@@ -58,7 +64,7 @@ export function PhotoCatchCard({
   const [isProcessingPhoto, setIsProcessingPhoto] = useState(false);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
 
-  // Load user's conventions once mounted
+  // Load user's currently playable conventions once mounted for the default camera path.
   useEffect(() => {
     fetchActiveProfileConventionIds(userId)
       .then(setConventionIds)
@@ -69,6 +75,7 @@ export function PhotoCatchCard({
   useEffect(() => {
     if (step !== 'photo_taken') return;
     if (conventionIds.length === 0) {
+      setFursuits([]);
       setIsLoadingFursuits(false);
       return;
     }
@@ -106,17 +113,21 @@ export function PhotoCatchCard({
 
     setIsProcessingPhoto(true);
     setLocalError(null);
+    setFursuits([]);
     try {
       const processed = await processImageForUpload(asset.uri, {
         ...IMAGE_UPLOAD_PRESETS.catchPhoto,
         flipHorizontal: true,
       });
+      const activeConventionIds = await fetchActiveProfileConventionIds(userId);
       setPhoto({
         uri: processed.uri,
         mimeType: 'image/jpeg',
         fileName: `catch-${Date.now()}.jpg`,
         fileSize: 0,
       });
+      setPhotoSource('camera');
+      setConventionIds(activeConventionIds);
       setIsLoadingFursuits(true);
       setStep('photo_taken');
       setSelectedFursuit(null);
@@ -127,11 +138,60 @@ export function PhotoCatchCard({
     }
   };
 
+  const handleChooseGalleryPhoto = async () => {
+    if (disabled) return;
+
+    setLocalError(null);
+
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      setLocalError('Photo library permission is required to choose a catch photo.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: 'images',
+      allowsEditing: false,
+      quality: 1.0,
+    });
+
+    if (result.canceled || !result.assets[0]) {
+      return;
+    }
+
+    const asset = result.assets[0];
+
+    setIsProcessingPhoto(true);
+    setLocalError(null);
+    setFursuits([]);
+    try {
+      const processed = await processImageForUpload(asset.uri, IMAGE_UPLOAD_PRESETS.catchPhoto);
+      const galleryConventionIds = await fetchGalleryProfileConventionIds(userId);
+      setPhoto({
+        uri: processed.uri,
+        mimeType: 'image/jpeg',
+        fileName: `catch-${Date.now()}.jpg`,
+        fileSize: 0,
+      });
+      setPhotoSource('gallery');
+      setConventionIds(galleryConventionIds);
+      setIsLoadingFursuits(true);
+      setStep('photo_taken');
+      setSelectedFursuit(null);
+    } catch {
+      setLocalError("We couldn't process that gallery photo. Please try another.");
+    } finally {
+      setIsProcessingPhoto(false);
+    }
+  };
+
   const handleRetakePhoto = () => {
     if (disabled) return;
 
     setPhoto(null);
+    setPhotoSource(null);
     setSelectedFursuit(null);
+    setFursuits([]);
     setStep('idle');
     setLocalError(null);
   };
@@ -151,12 +211,17 @@ export function PhotoCatchCard({
     let sharedConventionId: string | null = null;
 
     try {
-      const sharedConventionIds = await fetchActiveSharedConventionIds(userId, selectedFursuit.id);
+      const sharedConventionIds =
+        photoSource === 'gallery'
+          ? await fetchGallerySharedConventionIds(userId, selectedFursuit.id)
+          : await fetchActiveSharedConventionIds(userId, selectedFursuit.id);
       sharedConventionId = sharedConventionIds[0] ?? null;
 
       if (!sharedConventionId) {
         setLocalError(
-          'This suit is not catchable at your playable convention yet. Both players must be Ready to catch for the same live event, and the fursuit owner must list that specific suit for the event.',
+          photoSource === 'gallery'
+            ? 'This suit is not eligible for a gallery catch at your convention. Both players must share the event, and the fursuit must be listed there within the post-convention gallery window.'
+            : 'This suit is not catchable at your playable convention yet. Both players must be Ready to catch for the same live event, and the fursuit owner must list that specific suit for the event.',
         );
         setIsUploadingPhoto(false);
         return;
@@ -200,9 +265,11 @@ export function PhotoCatchCard({
         fursuitId: selectedFursuit.id,
         conventionId: sharedConventionId,
         isTutorial: false,
+        forcePending: photoSource === 'gallery',
         hasPhoto: true,
         photoPath: storagePath,
         photoUrl,
+        photoSource,
       });
     } catch (error) {
       await supabase.storage
@@ -240,9 +307,7 @@ export function PhotoCatchCard({
         />
         <Text style={styles.title}>Photo Catch</Text>
       </View>
-      <Text style={styles.subtitle}>
-        Take a selfie with a fursuiter to log the catch. Approval follows their catch setting.
-      </Text>
+      <Text style={styles.subtitle}>Take or choose a photo with a fursuiter to log the catch.</Text>
 
       {step === 'idle' ? (
         isProcessingPhoto ? (
@@ -251,21 +316,38 @@ export function PhotoCatchCard({
             <Text style={styles.processingText}>Processing photo…</Text>
           </View>
         ) : (
-          <TailTagButton
-            variant="outline"
-            onPress={handleTakePhoto}
-            disabled={disabled}
-            style={styles.cameraButton}
-          >
-            <View style={styles.buttonContent}>
-              <Ionicons
-                name="camera-outline"
-                size={18}
-                color={colors.primary}
-              />
-              <Text style={styles.cameraButtonText}>Open Camera</Text>
-            </View>
-          </TailTagButton>
+          <View style={styles.entryActions}>
+            <TailTagButton
+              variant="outline"
+              onPress={handleTakePhoto}
+              disabled={disabled}
+              style={styles.cameraButton}
+            >
+              <View style={styles.buttonContent}>
+                <Ionicons
+                  name="camera-outline"
+                  size={18}
+                  color={colors.primary}
+                />
+                <Text style={styles.cameraButtonText}>Open Camera</Text>
+              </View>
+            </TailTagButton>
+            <TailTagButton
+              variant="outline"
+              onPress={handleChooseGalleryPhoto}
+              disabled={disabled}
+              style={styles.cameraButton}
+            >
+              <View style={styles.buttonContent}>
+                <Ionicons
+                  name="images-outline"
+                  size={18}
+                  color={colors.primary}
+                />
+                <Text style={styles.cameraButtonText}>Choose from Gallery</Text>
+              </View>
+            </TailTagButton>
+          </View>
         )
       ) : (
         <>
@@ -277,7 +359,12 @@ export function PhotoCatchCard({
               contentFit="cover"
             />
             <View style={styles.previewActions}>
-              <Text style={styles.previewLabel}>Selfie taken</Text>
+              <Text style={styles.previewLabel}>
+                {photoSource === 'gallery' ? 'Gallery photo selected' : 'Selfie taken'}
+              </Text>
+              {photoSource === 'gallery' ? (
+                <Text style={styles.previewHint}>Sent for approval before it counts.</Text>
+              ) : null}
               <Pressable
                 onPress={handleRetakePhoto}
                 disabled={disabled}
@@ -342,7 +429,8 @@ export function PhotoCatchCard({
           color="rgba(148,163,184,0.6)"
         />
         <Text style={styles.infoText}>
-          Photo catches use the fursuiter&apos;s approval setting.
+          Camera catches follow the fursuiter&apos;s approval setting. Gallery catches always need
+          approval.
         </Text>
       </View>
     </TailTagCard>

--- a/src/features/catch-confirmations/types.ts
+++ b/src/features/catch-confirmations/types.ts
@@ -2,6 +2,7 @@ import type { Database } from '../../types/database';
 
 export type CatchMode = Database['public']['Enums']['catch_mode'];
 export type CatchStatus = Database['public']['Enums']['catch_status'];
+export type CatchPhotoSource = 'camera' | 'gallery';
 
 export type PendingCatch = {
   catchId: string;
@@ -20,6 +21,7 @@ export type PendingCatch = {
   timeRemaining: string;
   catchPhotoPath?: string | null;
   catchPhotoUrl: string | null;
+  catchPhotoSource?: CatchPhotoSource | null;
 };
 
 /** Catches the current user made that are awaiting owner approval (catcher's view). */
@@ -33,6 +35,7 @@ export type MyPendingCatch = {
   conventionName: string;
   caughtAt: string;
   expiresAt: string | null;
+  catchPhotoSource?: CatchPhotoSource | null;
 };
 
 export type ConfirmCatchResult = {
@@ -59,4 +62,5 @@ export type CreateCatchParams = {
   hasPhoto?: boolean;
   photoPath?: string | null;
   photoUrl?: string | null;
+  photoSource?: CatchPhotoSource | null;
 };

--- a/src/features/conventions/api/conventions.ts
+++ b/src/features/conventions/api/conventions.ts
@@ -742,6 +742,38 @@ export async function fetchActiveSharedConventionIds(
   return (data ?? []).map((row: any) => row.convention_id);
 }
 
+export async function fetchGalleryProfileConventionIds(profileId: string): Promise<string[]> {
+  const client = supabase as any;
+  const { data, error } = await client.rpc('get_gallery_profile_convention_ids', {
+    p_profile_id: profileId,
+  });
+
+  if (error) {
+    throw new Error(`We couldn't load your gallery-eligible conventions: ${error.message}`);
+  }
+
+  return (data ?? []).map((row: any) => row.convention_id);
+}
+
+export async function fetchGallerySharedConventionIds(
+  profileId: string,
+  fursuitId: string,
+): Promise<string[]> {
+  const client = supabase as any;
+  const { data, error } = await client.rpc('get_gallery_shared_convention_ids', {
+    p_profile_id: profileId,
+    p_fursuit_id: fursuitId,
+  });
+
+  if (error) {
+    throw new Error(
+      `We couldn't resolve your gallery-eligible shared conventions: ${error.message}`,
+    );
+  }
+
+  return (data ?? []).map((row: any) => row.convention_id);
+}
+
 export async function optInToConvention(params: OptInParams): Promise<void> {
   const {
     profileId,

--- a/src/features/conventions/index.ts
+++ b/src/features/conventions/index.ts
@@ -43,6 +43,8 @@ export {
   fetchActiveProfileConventionIds,
   fetchProfileConventionMemberships,
   fetchActiveSharedConventionIds,
+  fetchGalleryProfileConventionIds,
+  fetchGallerySharedConventionIds,
   optInToConvention,
   optOutOfConvention,
   addFursuitConvention,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -241,6 +241,7 @@ export type Database = {
         Row: {
           catch_number: number | null
           catch_photo_path: string | null
+          catch_photo_source: string | null
           catch_photo_url: string | null
           catcher_id: string
           caught_at: string | null
@@ -257,6 +258,7 @@ export type Database = {
         Insert: {
           catch_number?: number | null
           catch_photo_path?: string | null
+          catch_photo_source?: string | null
           catch_photo_url?: string | null
           catcher_id: string
           caught_at?: string | null
@@ -273,6 +275,7 @@ export type Database = {
         Update: {
           catch_number?: number | null
           catch_photo_path?: string | null
+          catch_photo_source?: string | null
           catch_photo_url?: string | null
           catcher_id?: string
           caught_at?: string | null
@@ -2102,26 +2105,17 @@ export type Database = {
         Returns: number
       }
       count_user_fursuits: { Args: { p_user_id: string }; Returns: number }
-      create_catch_with_approval:
-        | {
-            Args: {
-              p_catcher_id: string
-              p_convention_id?: string
-              p_fursuit_id: string
-              p_is_tutorial?: boolean
-            }
-            Returns: Json
-          }
-        | {
-            Args: {
-              p_catcher_id: string
-              p_convention_id?: string
-              p_force_pending?: boolean
-              p_fursuit_id: string
-              p_is_tutorial?: boolean
-            }
-            Returns: Json
-          }
+      create_catch_with_approval: {
+        Args: {
+          p_catch_photo_source?: string
+          p_catcher_id: string
+          p_convention_id?: string
+          p_force_pending?: boolean
+          p_fursuit_id: string
+          p_is_tutorial?: boolean
+        }
+        Returns: Json
+      }
       current_user_has_password_credential: { Args: never; Returns: boolean }
       delete_archived_convention_in_dev: {
         Args: { p_actor_id: string; p_convention_id: string }
@@ -2288,6 +2282,18 @@ export type Database = {
           unique_catchers: number
         }[]
       }
+      get_gallery_profile_convention_ids: {
+        Args: { p_profile_id: string }
+        Returns: {
+          convention_id: string
+        }[]
+      }
+      get_gallery_shared_convention_ids: {
+        Args: { p_fursuit_id: string; p_profile_id: string }
+        Returns: {
+          convention_id: string
+        }[]
+      }
       get_global_dashboard_summary: {
         Args: never
         Returns: {
@@ -2398,6 +2404,7 @@ export type Database = {
         Args: { p_user_id: string }
         Returns: {
           catch_id: string
+          catch_photo_source: string
           catch_photo_url: string
           catcher_avatar_url: string
           catcher_id: string
@@ -2456,6 +2463,10 @@ export type Database = {
         Args: { p_user_a: string; p_user_b: string }
         Returns: boolean
       }
+      is_convention_gallery_catchable: {
+        Args: { p_convention_id: string }
+        Returns: boolean
+      }
       is_convention_joinable: {
         Args: { p_convention_id: string }
         Returns: boolean
@@ -2474,6 +2485,10 @@ export type Database = {
       }
       is_moderator_or_higher: {
         Args: { check_user_id: string }
+        Returns: boolean
+      }
+      is_profile_convention_gallery_catch_eligible: {
+        Args: { p_convention_id: string; p_profile_id: string }
         Returns: boolean
       }
       is_profile_convention_gameplay_eligible: {

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -417,7 +417,7 @@ async function handlePost(req: Request): Promise<Response> {
       p_catcher_id: userId,
       p_convention_id: body.convention_id || null,
       p_is_tutorial: body.is_tutorial || false,
-      p_force_pending: body.force_pending || catchPhotoSource === 'gallery' || false,
+      p_force_pending: body.force_pending || catchPhotoSource === 'gallery',
       p_catch_photo_source: catchPhotoSource,
     });
 

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -49,12 +49,14 @@ interface CreateCatchRequest {
   has_photo?: boolean;
   catch_photo_path?: string | null;
   catch_photo_url?: string | null;
+  catch_photo_source?: 'camera' | 'gallery' | null;
 }
 
 interface UpdateCatchPhotoRequest {
   catch_id: string;
   catch_photo_path?: string;
   catch_photo_url: string;
+  catch_photo_source?: 'camera' | 'gallery' | null;
 }
 
 interface CreateCatchResponse {
@@ -198,6 +200,14 @@ function jsonResponse(status: number, payload: unknown) {
       'Content-Type': 'application/json',
     },
   });
+}
+
+function normalizeCatchPhotoSource(value: unknown): 'camera' | 'gallery' | null {
+  if (value === 'camera' || value === 'gallery') {
+    return value;
+  }
+
+  return null;
 }
 
 async function fetchFursuitMakerMetadata(fursuitId: string): Promise<FursuitMakerMetadata> {
@@ -371,6 +381,16 @@ async function handlePost(req: Request): Promise<Response> {
     return jsonResponse(400, { error: 'Missing catch_photo_url' });
   }
 
+  const catchPhotoSource = normalizeCatchPhotoSource(body.catch_photo_source);
+
+  if (body.catch_photo_source && !catchPhotoSource) {
+    return jsonResponse(400, { error: 'Invalid catch_photo_source' });
+  }
+
+  if (catchPhotoSource === 'gallery' && (!body.has_photo || !body.catch_photo_url)) {
+    return jsonResponse(400, { error: 'Gallery catches require a photo' });
+  }
+
   try {
     // Check if catcher and fursuit owner have blocked each other
     const { data: fursuitRow } = await supabaseAdmin
@@ -397,7 +417,8 @@ async function handlePost(req: Request): Promise<Response> {
       p_catcher_id: userId,
       p_convention_id: body.convention_id || null,
       p_is_tutorial: body.is_tutorial || false,
-      p_force_pending: body.force_pending || false,
+      p_force_pending: body.force_pending || catchPhotoSource === 'gallery' || false,
+      p_catch_photo_source: catchPhotoSource,
     });
 
     if (error) {
@@ -411,9 +432,14 @@ async function handlePost(req: Request): Promise<Response> {
       if (error.message?.includes('Convention is not live')) {
         return jsonResponse(400, { error: 'Convention is not live' });
       }
+      if (error.message?.includes('Convention is not accepting gallery catches')) {
+        return jsonResponse(400, { error: 'Convention is not accepting gallery catches' });
+      }
       if (
         error.message?.includes('Catcher must join the live convention') ||
+        error.message?.includes('Catcher must have a playable convention') ||
         error.message?.includes('Fursuit owner must join the live convention') ||
+        error.message?.includes('Fursuit owner must have a playable convention') ||
         error.message?.includes('Fursuit must be assigned to the live convention')
       ) {
         return jsonResponse(400, {
@@ -441,6 +467,7 @@ async function handlePost(req: Request): Promise<Response> {
         .update({
           catch_photo_path: body.catch_photo_path ?? null,
           catch_photo_url: body.catch_photo_url,
+          catch_photo_source: catchPhotoSource ?? 'camera',
         })
         .eq('id', result.catch_id);
 
@@ -571,6 +598,7 @@ async function handlePost(req: Request): Promise<Response> {
         convention_id: resolvedConventionId,
         is_tutorial: body.is_tutorial ?? false,
         status: result.status,
+        catch_photo_source: catchPhotoSource,
         species: speciesName,
         colors: colorNames,
         maker_names: makerMetadata.makerNames,
@@ -669,6 +697,7 @@ async function handlePatch(req: Request): Promise<Response> {
     .update({
       catch_photo_path: body.catch_photo_path ?? null,
       catch_photo_url: body.catch_photo_url,
+      catch_photo_source: normalizeCatchPhotoSource(body.catch_photo_source) ?? 'camera',
     })
     .eq('id', body.catch_id);
 

--- a/supabase/migrations/20260512120000_gallery_catch_source.sql
+++ b/supabase/migrations/20260512120000_gallery_catch_source.sql
@@ -1,0 +1,329 @@
+-- Track photo catch source and allow gallery catches during the existing
+-- three-local-day post-convention review window.
+
+alter table public.catches
+  add column if not exists catch_photo_source text;
+
+update public.catches
+   set catch_photo_source = 'camera'
+ where catch_photo_source is null
+   and catch_photo_url is not null;
+
+alter table public.catches
+  drop constraint if exists catches_catch_photo_source_check,
+  add constraint catches_catch_photo_source_check
+    check (catch_photo_source is null or catch_photo_source in ('camera', 'gallery'));
+
+create or replace function public.is_convention_gallery_catchable(p_convention_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path to 'public'
+as $$
+  select coalesce((
+    select
+      c.status = 'live'
+      and (c.start_date is null or info.local_day >= c.start_date)
+      and (c.end_date is null or info.local_day <= c.end_date + 3)
+    from public.conventions c
+    cross join lateral (
+      select timezone(coalesce(nullif(c.timezone, ''), 'UTC'), now())::date as local_day
+    ) info
+    where c.id = p_convention_id
+  ), false);
+$$;
+
+create or replace function public.is_profile_convention_gallery_catch_eligible(
+  p_profile_id uuid,
+  p_convention_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path to 'public'
+as $$
+  select exists (
+    select 1
+    from public.profile_conventions pc
+    join public.conventions c on c.id = pc.convention_id
+    where pc.profile_id = p_profile_id
+      and pc.convention_id = p_convention_id
+      and public.is_convention_gallery_catchable(pc.convention_id)
+      and (
+        coalesce(c.location_verification_required, false) = false
+        or pc.verification_method = 'grandfathered'
+        or (pc.verification_method = 'manual_override' and pc.override_at is not null)
+        or (
+          pc.verification_method = 'gps'
+          and pc.verified_at is not null
+          and (c.started_at is null or pc.verified_at >= c.started_at)
+        )
+      )
+  );
+$$;
+
+create or replace function public.get_gallery_profile_convention_ids(p_profile_id uuid)
+returns table (convention_id uuid)
+language sql
+stable
+security definer
+set search_path to 'public'
+as $$
+  select pc.convention_id
+  from public.profile_conventions pc
+  join public.conventions c on c.id = pc.convention_id
+  where pc.profile_id = p_profile_id
+    and public.is_profile_convention_gallery_catch_eligible(pc.profile_id, pc.convention_id)
+  order by c.start_date asc nulls last, pc.created_at desc;
+$$;
+
+create or replace function public.get_gallery_shared_convention_ids(
+  p_profile_id uuid,
+  p_fursuit_id uuid
+)
+returns table (convention_id uuid)
+language sql
+stable
+security definer
+set search_path to 'public'
+as $$
+  select pc.convention_id
+  from public.profile_conventions pc
+  join public.fursuit_conventions fc
+    on fc.convention_id = pc.convention_id
+   and fc.fursuit_id = p_fursuit_id
+  join public.fursuits f on f.id = fc.fursuit_id
+  join public.conventions c on c.id = pc.convention_id
+  where pc.profile_id = p_profile_id
+    and public.is_profile_convention_gallery_catch_eligible(p_profile_id, pc.convention_id)
+    and public.is_profile_convention_gallery_catch_eligible(f.owner_id, pc.convention_id)
+  order by c.start_date asc nulls last, pc.created_at desc;
+$$;
+
+drop function if exists public.create_catch_with_approval(uuid, uuid, uuid, boolean);
+drop function if exists public.create_catch_with_approval(uuid, uuid, uuid, boolean, boolean);
+
+create or replace function public.create_catch_with_approval(
+  p_fursuit_id uuid,
+  p_catcher_id uuid,
+  p_convention_id uuid default null::uuid,
+  p_is_tutorial boolean default false,
+  p_force_pending boolean default false,
+  p_catch_photo_source text default null::text
+)
+returns json
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+declare
+  v_owner_catch_mode text;
+  v_fursuit_owner_id uuid;
+  v_catch_status text;
+  v_expires_at timestamptz;
+  v_catch_id uuid;
+  v_catch_number integer;
+  v_result json;
+  v_is_gallery_catch boolean := p_catch_photo_source = 'gallery';
+begin
+  if p_catch_photo_source is not null and p_catch_photo_source not in ('camera', 'gallery') then
+    raise exception 'Invalid catch photo source';
+  end if;
+
+  if auth.role() <> 'service_role' and auth.uid() is distinct from p_catcher_id then
+    raise exception 'Catcher must match the authenticated user';
+  end if;
+
+  select
+    coalesce(p.default_catch_mode, 'AUTO_ACCEPT'),
+    f.owner_id
+  into
+    v_owner_catch_mode,
+    v_fursuit_owner_id
+  from public.fursuits f
+  left join public.profiles p on p.id = f.owner_id
+  where f.id = p_fursuit_id;
+
+  if not found then
+    raise exception 'Fursuit not found';
+  end if;
+
+  if v_fursuit_owner_id = p_catcher_id then
+    raise exception 'Cannot catch your own fursuit';
+  end if;
+
+  if v_is_gallery_catch and p_convention_id is null then
+    raise exception 'Gallery catches require a convention';
+  end if;
+
+  if p_convention_id is not null then
+    if v_is_gallery_catch then
+      if not public.is_convention_gallery_catchable(p_convention_id) then
+        raise exception 'Convention is not accepting gallery catches';
+      end if;
+
+      if not public.is_profile_convention_gallery_catch_eligible(p_catcher_id, p_convention_id) then
+        raise exception 'Catcher must have a playable convention before catching';
+      end if;
+
+      if not public.is_profile_convention_gallery_catch_eligible(v_fursuit_owner_id, p_convention_id) then
+        raise exception 'Fursuit owner must have a playable convention before catching';
+      end if;
+    else
+      if not public.is_convention_joinable(p_convention_id) then
+        raise exception 'Convention is not live';
+      end if;
+
+      if not public.is_profile_convention_gameplay_eligible(p_catcher_id, p_convention_id) then
+        raise exception 'Catcher must join the live convention before catching';
+      end if;
+
+      if not public.is_profile_convention_gameplay_eligible(v_fursuit_owner_id, p_convention_id) then
+        raise exception 'Fursuit owner must join the live convention before catching';
+      end if;
+    end if;
+
+    if not exists (
+      select 1
+        from public.fursuit_conventions fc
+       where fc.fursuit_id = p_fursuit_id
+         and fc.convention_id = p_convention_id
+    ) then
+      raise exception 'Fursuit must be assigned to the live convention before it can be caught there';
+    end if;
+
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id = p_convention_id
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught at this convention';
+    end if;
+  else
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id is null
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught or pending';
+    end if;
+  end if;
+
+  if (v_owner_catch_mode = 'MANUAL_APPROVAL' or p_force_pending or v_is_gallery_catch) and not p_is_tutorial then
+    v_catch_status := 'PENDING';
+    if p_convention_id is not null then
+      v_expires_at := public.calculate_catch_expiration(p_convention_id);
+    else
+      v_expires_at := public.calculate_catch_expiration();
+    end if;
+  else
+    v_catch_status := 'ACCEPTED';
+    v_expires_at := null;
+  end if;
+
+  begin
+    insert into public.catches (
+      fursuit_id,
+      catcher_id,
+      convention_id,
+      is_tutorial,
+      status,
+      expires_at,
+      caught_at,
+      catch_photo_source
+    )
+    values (
+      p_fursuit_id,
+      p_catcher_id,
+      p_convention_id,
+      p_is_tutorial,
+      v_catch_status,
+      v_expires_at,
+      now(),
+      p_catch_photo_source
+    )
+    returning id, catch_number into v_catch_id, v_catch_number;
+  exception
+    when unique_violation then
+      if p_convention_id is not null then
+        raise exception 'Fursuit already caught at this convention';
+      end if;
+
+      raise exception 'Fursuit already caught or pending';
+  end;
+
+select json_build_object(
+    'catch_id', v_catch_id,
+    'status', v_catch_status,
+    'expires_at', v_expires_at,
+    'catch_number', v_catch_number,
+    'requires_approval', v_catch_status = 'PENDING',
+    'fursuit_owner_id', v_fursuit_owner_id
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+drop function if exists public.get_pending_catches(uuid);
+
+create or replace function public.get_pending_catches(p_user_id uuid)
+returns table (
+  catch_id uuid,
+  catcher_id uuid,
+  catcher_username text,
+  catcher_avatar_url text,
+  fursuit_id uuid,
+  fursuit_name text,
+  fursuit_avatar_url text,
+  caught_at timestamp with time zone,
+  expires_at timestamp with time zone,
+  convention_id uuid,
+  convention_name text,
+  time_remaining interval,
+  catch_photo_url text,
+  catch_photo_source text
+)
+language sql
+security definer
+set search_path to 'public'
+as $$
+  select
+    c.id as catch_id,
+    c.catcher_id,
+    p.username as catcher_username,
+    p.avatar_url as catcher_avatar_url,
+    c.fursuit_id,
+    f.name as fursuit_name,
+    f.avatar_url as fursuit_avatar_url,
+    c.caught_at,
+    c.expires_at,
+    c.convention_id,
+    conv.name as convention_name,
+    (c.expires_at - now()) as time_remaining,
+    c.catch_photo_url,
+    c.catch_photo_source
+  from public.catches c
+  join public.fursuits f on c.fursuit_id = f.id
+  join public.profiles p on c.catcher_id = p.id
+  left join public.conventions conv on c.convention_id = conv.id
+  where f.owner_id = p_user_id
+    and c.status = 'PENDING'
+    and c.expires_at > now()
+  order by c.caught_at desc;
+$$;
+
+grant execute on function public.is_convention_gallery_catchable(uuid) to authenticated, service_role;
+grant execute on function public.is_profile_convention_gallery_catch_eligible(uuid, uuid) to authenticated, service_role;
+grant execute on function public.get_gallery_profile_convention_ids(uuid) to authenticated, service_role;
+grant execute on function public.get_gallery_shared_convention_ids(uuid, uuid) to authenticated, service_role;
+grant execute on function public.create_catch_with_approval(uuid, uuid, uuid, boolean, boolean, text) to service_role;
+grant execute on function public.get_pending_catches(uuid) to authenticated, service_role;


### PR DESCRIPTION
This PR allow photo catches to be completed with gallery photos.

Resolves TAILTAG-94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for Camera vs Gallery photo catches: choose source, gallery catches marked as requiring approval, and UI shows source notices and source-aware preview/subtitle text.
  * Pending items and empty states now surface photo source and clearer gallery-specific messaging.
  * Server-side gallery eligibility checks enable gallery-only convention restrictions.

* **Bug Fixes**
  * Clearer error messaging when a convention is not accepting gallery catches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FinnThePanther/tailtag/pull/103)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->