### PR TITLE
Add catch performance traces

### DIFF
--- a/app/(tabs)/catch.tsx
+++ b/app/(tabs)/catch.tsx
@@ -49,6 +49,7 @@ import { DAILY_TASKS_QUERY_KEY } from '../../src/features/daily-tasks/hooks';
 import { achievementsStatusQueryKey } from '../../src/features/achievements';
 import { supabase } from '../../src/lib/supabase';
 import { captureHandledException, addMonitoringBreadcrumb } from '../../src/lib/sentry';
+import { createCatchPerformanceTrace } from '../../src/features/catch-confirmations/lib/catchPerformance';
 import { spacing } from '../../src/theme';
 import { useBlockedIds } from '../../src/features/moderation';
 import { isValidUniqueCodeInput, normalizeUniqueCodeInput } from '../../src/utils/code';
@@ -225,14 +226,32 @@ export default function CatchScreen() {
     setSubmitError(null);
     resetCatchState();
 
+    const catchTrace = createCatchPerformanceTrace({ method: 'code' });
+    let catchTraceFinished = false;
+    const finishCatchTrace = (options: {
+      result: 'success' | 'pending_approval' | 'failed' | 'timeout';
+      catchId?: string | null;
+      conventionId?: string | null;
+      errorCode?: string | null;
+    }) => {
+      if (catchTraceFinished) {
+        return;
+      }
+      catchTraceFinished = true;
+      catchTrace.finish(options);
+    };
+
     try {
       const client = supabase as any;
 
       // Fetch fursuit details by code
-      const { data: fursuit, error: fursuitError } = await client
-        .from('fursuits')
-        .select(
-          `
+      const { data: fursuit, error: fursuitError } = await catchTrace.measure(
+        'code_lookup_ms',
+        async () =>
+          await client
+            .from('fursuits')
+            .select(
+              `
           id,
           name,
           species_id,
@@ -271,12 +290,13 @@ export default function CatchScreen() {
             social_links
           )
         `,
-        )
-        .ilike('unique_code', normalizedCode)
-        .order('version', { ascending: false, foreignTable: 'fursuit_bios' })
-        .limit(1, { foreignTable: 'fursuit_bios' })
-        .eq('is_tutorial', false)
-        .maybeSingle();
+            )
+            .ilike('unique_code', normalizedCode)
+            .order('version', { ascending: false, foreignTable: 'fursuit_bios' })
+            .limit(1, { foreignTable: 'fursuit_bios' })
+            .eq('is_tutorial', false)
+            .maybeSingle(),
+      );
 
       if (fursuitError) {
         throw fursuitError;
@@ -287,10 +307,13 @@ export default function CatchScreen() {
         setSubmitError(
           "We couldn't find a fursuit with that code. Double-check the letters and try again.",
         );
+        finishCatchTrace({ result: 'failed', errorCode: 'code_not_found' });
         return;
       }
 
-      const makersByFursuitId = await fetchFursuitMakersByFursuitIds([fursuit.id]);
+      const makersByFursuitId = await catchTrace.measure('maker_fetch_ms', () =>
+        fetchFursuitMakersByFursuitIds([fursuit.id]),
+      );
 
       const initialCatchCount =
         typeof (fursuit as any)?.catch_count === 'number' ? (fursuit as any).catch_count : 0;
@@ -322,18 +345,22 @@ export default function CatchScreen() {
       if (normalizedFursuit.is_tutorial) {
         resetCatchState();
         setSubmitError('Tutorial suits cannot be caught by scanning codes.');
+        finishCatchTrace({ result: 'failed', errorCode: 'tutorial_suit' });
         return;
       }
 
       if (blockedIds.has(normalizedFursuit.owner_id)) {
         resetCatchState();
         setSubmitError('You cannot catch this fursuit.');
+        finishCatchTrace({ result: 'failed', errorCode: 'blocked_user' });
         return;
       }
 
       const [activeProfileConventions, sharedConventions] = await Promise.all([
-        fetchActiveProfileConventionIds(userId),
-        fetchActiveSharedConventionIds(userId, normalizedFursuit.id),
+        catchTrace.measure('active_conventions_ms', () => fetchActiveProfileConventionIds(userId)),
+        catchTrace.measure('shared_conventions_ms', () =>
+          fetchActiveSharedConventionIds(userId, normalizedFursuit.id),
+        ),
       ]);
 
       if (activeProfileConventions.length === 0) {
@@ -345,12 +372,14 @@ export default function CatchScreen() {
               ? `${verificationRequiredConvention.name} is live. Verify your location before catching fursuits.`
               : 'Join or verify a playable convention in Settings before catching fursuits.',
         );
+        finishCatchTrace({ result: 'failed', errorCode: 'no_active_convention' });
         return;
       }
 
       if (sharedConventions.length === 0) {
         resetCatchState();
         setSubmitError(SHARED_CONVENTION_HELP);
+        finishCatchTrace({ result: 'failed', errorCode: 'no_shared_convention' });
         return;
       }
 
@@ -370,8 +399,13 @@ export default function CatchScreen() {
       const catchResult = await createCatch({
         fursuitId: normalizedFursuit.id,
         conventionId: primaryConventionId,
+        clientAttemptId: catchTrace.clientAttemptId,
+        method: 'code',
         isTutorial: Boolean(normalizedFursuit.is_tutorial),
       });
+      catchTrace.recordTiming('edge_request_ms', catchResult.edgeRequestMs);
+
+      const stopPostCreateRenderTiming = catchTrace.startTiming('post_create_render_ms');
 
       const promptCandidate = normalizedFursuit.bio
         ? [normalizedFursuit.bio.askMeAbout, normalizedFursuit.bio.likesAndInterests]
@@ -419,6 +453,12 @@ export default function CatchScreen() {
       setLastCatchConventionIds(sharedConventions);
       setCatchNumber(normalizedCatchRecord.catch_number ?? latestCatchCount);
       setConversationPrompt(promptCandidate ?? null);
+      stopPostCreateRenderTiming();
+      finishCatchTrace({
+        result: catchResult.requiresApproval ? 'pending_approval' : 'success',
+        catchId: catchResult.catchId,
+        conventionId: primaryConventionId,
+      });
 
       // Invalidate queries
       void queryClient.invalidateQueries({ queryKey: [DAILY_TASKS_QUERY_KEY] });
@@ -458,6 +498,15 @@ export default function CatchScreen() {
 
       // Events are now fired by the Edge Function, no need to emit here
     } catch (caught) {
+      const caughtWithTiming = caught as {
+        catchPerformanceResult?: 'failed' | 'timeout';
+        edgeRequestMs?: number | null;
+      };
+      catchTrace.recordTiming('edge_request_ms', caughtWithTiming.edgeRequestMs);
+      finishCatchTrace({
+        result: caughtWithTiming.catchPerformanceResult ?? 'failed',
+        errorCode: caughtWithTiming.catchPerformanceResult === 'timeout' ? 'edge_timeout' : 'error',
+      });
       const fallbackMessage =
         caught instanceof Error ? caught.message : "We couldn't save that catch. Please try again.";
       setSubmitError(fallbackMessage);

--- a/src/features/catch-confirmations/api/confirmations.ts
+++ b/src/features/catch-confirmations/api/confirmations.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { supabase } from '../../../lib/supabase';
 import { captureFeatureError } from '../../../lib/sentry';
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../../../lib/runtimeConfig';
@@ -15,6 +17,11 @@ import {
   type ImmediateAchievementAward,
 } from '../../achievements/immediateAwardsBus';
 import { emitLocalGameplayEvent } from '../../events/localGameplayEventsBus';
+import {
+  createClientAttemptId,
+  getCatchPerformanceAppVersion,
+  type CatchPerformanceResult,
+} from '../lib/catchPerformance';
 import type { Json } from '../../../types/database';
 import type {
   CatchPhotoSource,
@@ -33,6 +40,31 @@ export const pendingCatchesQueryKey = (userId: string) =>
 // Stale times
 export const PENDING_CATCHES_STALE_TIME = 15 * 1000; // 15 seconds
 const EDGE_FUNCTION_TIMEOUT_MS = 15 * 1000;
+
+type CreateCatchError = Error & {
+  catchPerformanceResult?: CatchPerformanceResult;
+  edgeRequestMs?: number | null;
+};
+
+const now = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+const roundMs = (duration: number) => Math.max(0, Math.round(duration));
+
+function withCatchPerformanceError(
+  error: Error,
+  options: {
+    result: CatchPerformanceResult;
+    edgeRequestMs?: number | null;
+  },
+): CreateCatchError {
+  const enrichedError = error as CreateCatchError;
+  enrichedError.catchPerformanceResult = options.result;
+  enrichedError.edgeRequestMs = options.edgeRequestMs ?? null;
+  return enrichedError;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -230,6 +262,7 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
   const accessToken = sessionData.session?.access_token;
   const currentUserId = sessionData.session?.user.id ?? null;
   const supabaseKey = SUPABASE_ANON_KEY;
+  const clientAttemptId = params.clientAttemptId ?? createClientAttemptId();
 
   if (!accessToken) {
     throw new Error('You must be signed in to catch fursuits.');
@@ -243,6 +276,8 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
   // Edge Functions can commit the catch before slower notification/achievement work finishes.
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), EDGE_FUNCTION_TIMEOUT_MS);
+  const edgeRequestStartedAt = now();
+  let edgeRequestMs: number | null = null;
 
   try {
     const response = await fetch(`${supabaseUrl}/functions/v1/create-catch`, {
@@ -251,8 +286,20 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
         Authorization: `Bearer ${accessToken}`,
         apikey: supabaseKey,
         'Content-Type': 'application/json',
+        'x-client-attempt-id': clientAttemptId,
       },
       body: JSON.stringify({
+        client_attempt_id: clientAttemptId,
+        app_version: getCatchPerformanceAppVersion(),
+        platform: Platform.OS,
+        network_type: null,
+        method:
+          params.method ??
+          (params.photoSource === 'gallery'
+            ? 'gallery_photo'
+            : params.photoSource === 'camera'
+              ? 'camera_photo'
+              : 'code'),
         fursuit_id: params.fursuitId,
         convention_id: params.conventionId,
         is_tutorial: params.isTutorial ?? false,
@@ -266,6 +313,7 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
       signal: controller.signal,
     });
 
+    edgeRequestMs = roundMs(now() - edgeRequestStartedAt);
     clearTimeout(timeoutId);
 
     const responseData = await response.json();
@@ -276,50 +324,78 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
       captureFeatureError(new Error(errorMessage), {
         scope: 'catch-confirmations.createCatch',
         action: 'edge-function',
+        clientAttemptId,
         fursuitId: params.fursuitId,
         statusCode: response.status,
+        edgeRequestMs,
       });
 
       // Return user-friendly messages for known errors
       if (errorMessage.includes('Cannot catch your own')) {
-        throw new Error(
-          'That tag belongs to one of your own suits. Trade codes with friends to grow your collection.',
+        throw withCatchPerformanceError(
+          new Error(
+            'That tag belongs to one of your own suits. Trade codes with friends to grow your collection.',
+          ),
+          { result: 'failed', edgeRequestMs },
         );
       }
       if (errorMessage.includes('share a playable convention')) {
-        throw new Error(
-          'This suit is not catchable at your playable convention yet. Both players must be Ready to catch for the same live event, and the fursuit owner must list that specific suit for the event.',
+        throw withCatchPerformanceError(
+          new Error(
+            'This suit is not catchable at your playable convention yet. Both players must be Ready to catch for the same live event, and the fursuit owner must list that specific suit for the event.',
+          ),
+          { result: 'failed', edgeRequestMs },
         );
       }
       if (errorMessage.includes('not accepting gallery catches')) {
-        throw new Error(
-          'This convention is no longer accepting gallery catches. Gallery catches can be submitted during the event and for three local days after it ends.',
+        throw withCatchPerformanceError(
+          new Error(
+            'This convention is no longer accepting gallery catches. Gallery catches can be submitted during the event and for three local days after it ends.',
+          ),
+          { result: 'failed', edgeRequestMs },
         );
       }
       if (errorMessage.includes('already caught') || errorMessage.includes('pending')) {
-        throw new Error(
-          'You already caught this suit at this convention. Try catching them at another con!',
+        throw withCatchPerformanceError(
+          new Error(
+            'You already caught this suit at this convention. Try catching them at another con!',
+          ),
+          { result: 'failed', edgeRequestMs },
         );
       }
       if (errorMessage.includes('not found')) {
-        throw new Error(
-          "We couldn't find a fursuit with that code. Double-check the letters and try again.",
+        throw withCatchPerformanceError(
+          new Error(
+            "We couldn't find a fursuit with that code. Double-check the letters and try again.",
+          ),
+          { result: 'failed', edgeRequestMs },
         );
       }
       if (response.status === 403) {
-        throw new Error('You cannot catch this fursuit.');
+        throw withCatchPerformanceError(new Error('You cannot catch this fursuit.'), {
+          result: 'failed',
+          edgeRequestMs,
+        });
       }
 
-      throw new Error("We couldn't save that catch. Please try again.");
+      throw withCatchPerformanceError(new Error("We couldn't save that catch. Please try again."), {
+        result: 'failed',
+        edgeRequestMs,
+      });
     }
 
     const result: CreateCatchResult = {
       catchId: responseData.catch_id,
+      clientAttemptId:
+        typeof responseData.client_attempt_id === 'string' && responseData.client_attempt_id
+          ? responseData.client_attempt_id
+          : clientAttemptId,
       status: responseData.status,
       expiresAt: responseData.expires_at ?? null,
       catchNumber: responseData.catch_number ?? null,
       requiresApproval: responseData.requires_approval ?? false,
       fursuitOwnerId: responseData.fursuit_owner_id,
+      edgeRequestMs,
     };
 
     const immediateAwards = normalizeInlineAwards(responseData?.awards, currentUserId);
@@ -372,13 +448,19 @@ export async function createCatch(params: CreateCatchParams): Promise<CreateCatc
 
     // Handle timeout/abort
     if (error instanceof Error && error.name === 'AbortError') {
+      edgeRequestMs = roundMs(now() - edgeRequestStartedAt);
       captureFeatureError(new Error('Create catch request timed out'), {
         scope: 'catch-confirmations.createCatch',
         action: 'timeout',
+        clientAttemptId,
         fursuitId: params.fursuitId,
         timeoutMs: EDGE_FUNCTION_TIMEOUT_MS,
+        edgeRequestMs,
       });
-      throw new Error('The request took too long. Please check your connection and try again.');
+      throw withCatchPerformanceError(
+        new Error('The request took too long. Please check your connection and try again.'),
+        { result: 'timeout', edgeRequestMs },
+      );
     }
 
     // Re-throw other errors

--- a/src/features/catch-confirmations/components/PhotoCatchCard.tsx
+++ b/src/features/catch-confirmations/components/PhotoCatchCard.tsx
@@ -13,6 +13,7 @@ import { loadUriAsUint8Array } from '../../../utils/files';
 import { processImageForUpload, IMAGE_UPLOAD_PRESETS } from '../../../utils/images';
 import { buildAuthenticatedStorageObjectUrl } from '../../../utils/supabase-image';
 import { createCatch, fetchConventionFursuits } from '../api/confirmations';
+import { createCatchPerformanceTrace } from '../lib/catchPerformance';
 import {
   fetchActiveProfileConventionIds,
   fetchActiveSharedConventionIds,
@@ -63,6 +64,7 @@ export function PhotoCatchCard({
   const [localError, setLocalError] = useState<string | null>(null);
   const [isProcessingPhoto, setIsProcessingPhoto] = useState(false);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
+  const [photoProcessingMs, setPhotoProcessingMs] = useState<number | null>(null);
 
   // Load user's currently playable conventions once mounted for the default camera path.
   useEffect(() => {
@@ -115,10 +117,12 @@ export function PhotoCatchCard({
     setLocalError(null);
     setFursuits([]);
     try {
+      const processingStartedAt = Date.now();
       const processed = await processImageForUpload(asset.uri, {
         ...IMAGE_UPLOAD_PRESETS.catchPhoto,
         flipHorizontal: true,
       });
+      setPhotoProcessingMs(Math.max(0, Date.now() - processingStartedAt));
       const activeConventionIds = await fetchActiveProfileConventionIds(userId);
       setPhoto({
         uri: processed.uri,
@@ -132,6 +136,7 @@ export function PhotoCatchCard({
       setStep('photo_taken');
       setSelectedFursuit(null);
     } catch {
+      setPhotoProcessingMs(null);
       setLocalError("We couldn't process your photo. Please try again.");
     } finally {
       setIsProcessingPhoto(false);
@@ -165,7 +170,9 @@ export function PhotoCatchCard({
     setLocalError(null);
     setFursuits([]);
     try {
+      const processingStartedAt = Date.now();
       const processed = await processImageForUpload(asset.uri, IMAGE_UPLOAD_PRESETS.catchPhoto);
+      setPhotoProcessingMs(Math.max(0, Date.now() - processingStartedAt));
       const galleryConventionIds = await fetchGalleryProfileConventionIds(userId);
       setPhoto({
         uri: processed.uri,
@@ -179,6 +186,7 @@ export function PhotoCatchCard({
       setStep('photo_taken');
       setSelectedFursuit(null);
     } catch {
+      setPhotoProcessingMs(null);
       setLocalError("We couldn't process that gallery photo. Please try another.");
     } finally {
       setIsProcessingPhoto(false);
@@ -190,6 +198,7 @@ export function PhotoCatchCard({
 
     setPhoto(null);
     setPhotoSource(null);
+    setPhotoProcessingMs(null);
     setSelectedFursuit(null);
     setFursuits([]);
     setStep('idle');
@@ -206,15 +215,32 @@ export function PhotoCatchCard({
     if (disabled || !photo || !selectedFursuit) return;
     setLocalError(null);
     setIsUploadingPhoto(true);
+    const catchMethod = photoSource === 'gallery' ? 'gallery_photo' : 'camera_photo';
+    const catchTrace = createCatchPerformanceTrace({ method: catchMethod });
+    let catchTraceFinished = false;
+    const finishCatchTrace = (options: {
+      result: 'success' | 'pending_approval' | 'failed' | 'timeout';
+      catchId?: string | null;
+      conventionId?: string | null;
+      errorCode?: string | null;
+    }) => {
+      if (catchTraceFinished) {
+        return;
+      }
+      catchTraceFinished = true;
+      catchTrace.finish(options);
+    };
+    catchTrace.recordTiming('photo_processing_ms', photoProcessingMs);
 
     // Step 1: Validate shared convention before doing any uploads
     let sharedConventionId: string | null = null;
 
     try {
-      const sharedConventionIds =
+      const sharedConventionIds = await catchTrace.measure('shared_conventions_ms', () =>
         photoSource === 'gallery'
-          ? await fetchGallerySharedConventionIds(userId, selectedFursuit.id)
-          : await fetchActiveSharedConventionIds(userId, selectedFursuit.id);
+          ? fetchGallerySharedConventionIds(userId, selectedFursuit.id)
+          : fetchActiveSharedConventionIds(userId, selectedFursuit.id),
+      );
       sharedConventionId = sharedConventionIds[0] ?? null;
 
       if (!sharedConventionId) {
@@ -224,11 +250,13 @@ export function PhotoCatchCard({
             : 'This suit is not catchable at your playable convention yet. Both players must be Ready to catch for the same live event, and the fursuit owner must list that specific suit for the event.',
         );
         setIsUploadingPhoto(false);
+        finishCatchTrace({ result: 'failed', errorCode: 'no_shared_convention' });
         return;
       }
     } catch {
       setLocalError("Couldn't verify convention. Please try again.");
       setIsUploadingPhoto(false);
+      finishCatchTrace({ result: 'failed', errorCode: 'shared_convention_check_failed' });
       return;
     }
 
@@ -237,24 +265,36 @@ export function PhotoCatchCard({
     let photoUrl: string;
     let storagePath: string;
     try {
-      const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      storagePath = `${userId}/${uniqueSuffix}.jpg`;
+      const uploadResult = await catchTrace.measure('photo_upload_ms', async () => {
+        const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const nextStoragePath = `${userId}/${uniqueSuffix}.jpg`;
 
-      const fileBytes = await loadUriAsUint8Array(photo.uri);
+        const fileBytes = await loadUriAsUint8Array(photo.uri);
 
-      const { error: uploadError } = await supabase.storage
-        .from(CATCH_PHOTO_BUCKET)
-        .upload(storagePath, fileBytes, {
-          contentType: 'image/jpeg',
-          upsert: false,
-        });
+        const { error: uploadError } = await supabase.storage
+          .from(CATCH_PHOTO_BUCKET)
+          .upload(nextStoragePath, fileBytes, {
+            contentType: 'image/jpeg',
+            upsert: false,
+          });
 
-      if (uploadError) throw uploadError;
+        if (uploadError) throw uploadError;
 
-      photoUrl = buildAuthenticatedStorageObjectUrl(CATCH_PHOTO_BUCKET, storagePath);
+        return {
+          photoUrl: buildAuthenticatedStorageObjectUrl(CATCH_PHOTO_BUCKET, nextStoragePath),
+          storagePath: nextStoragePath,
+        };
+      });
+      photoUrl = uploadResult.photoUrl;
+      storagePath = uploadResult.storagePath;
     } catch {
       setLocalError("Couldn't upload your photo. Please check your connection and try again.");
       setIsUploadingPhoto(false);
+      finishCatchTrace({
+        result: 'failed',
+        conventionId: sharedConventionId,
+        errorCode: 'photo_upload_failed',
+      });
       return;
     }
 
@@ -264,6 +304,8 @@ export function PhotoCatchCard({
       catchResult = await createCatch({
         fursuitId: selectedFursuit.id,
         conventionId: sharedConventionId,
+        clientAttemptId: catchTrace.clientAttemptId,
+        method: catchMethod,
         isTutorial: false,
         forcePending: photoSource === 'gallery',
         hasPhoto: true,
@@ -271,7 +313,13 @@ export function PhotoCatchCard({
         photoUrl,
         photoSource,
       });
+      catchTrace.recordTiming('edge_request_ms', catchResult.edgeRequestMs);
     } catch (error) {
+      const caughtWithTiming = error as {
+        catchPerformanceResult?: 'failed' | 'timeout';
+        edgeRequestMs?: number | null;
+      };
+      catchTrace.recordTiming('edge_request_ms', caughtWithTiming.edgeRequestMs);
       await supabase.storage
         .from(CATCH_PHOTO_BUCKET)
         .remove([storagePath])
@@ -280,16 +328,28 @@ export function PhotoCatchCard({
         error instanceof Error ? error.message : "Couldn't create catch. Please try again.",
       );
       setIsUploadingPhoto(false);
+      finishCatchTrace({
+        result: caughtWithTiming.catchPerformanceResult ?? 'failed',
+        conventionId: sharedConventionId,
+        errorCode: caughtWithTiming.catchPerformanceResult === 'timeout' ? 'edge_timeout' : 'error',
+      });
       return;
     }
 
     setIsUploadingPhoto(false);
 
+    const stopPostCreateRenderTiming = catchTrace.startTiming('post_create_render_ms');
     await onCatchSubmit({
       fursuitId: selectedFursuit.id,
       conventionId: sharedConventionId,
       photoUrl,
       catchResult,
+    });
+    stopPostCreateRenderTiming();
+    finishCatchTrace({
+      result: catchResult.requiresApproval ? 'pending_approval' : 'success',
+      catchId: catchResult.catchId,
+      conventionId: sharedConventionId,
     });
   };
 

--- a/src/features/catch-confirmations/lib/catchPerformance.ts
+++ b/src/features/catch-confirmations/lib/catchPerformance.ts
@@ -1,0 +1,137 @@
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+
+import { addMonitoringBreadcrumb, captureHandledMessage } from '../../../lib/sentry';
+
+export type CatchPerformanceMethod = 'code' | 'camera_photo' | 'gallery_photo';
+export type CatchPerformanceResult = 'success' | 'pending_approval' | 'failed' | 'timeout';
+
+export type CatchPerformanceTimingKey =
+  | 'code_lookup_ms'
+  | 'maker_fetch_ms'
+  | 'active_conventions_ms'
+  | 'shared_conventions_ms'
+  | 'photo_processing_ms'
+  | 'photo_upload_ms'
+  | 'edge_request_ms'
+  | 'post_create_render_ms';
+
+type CatchPerformanceTraceOptions = {
+  clientAttemptId?: string;
+  method: CatchPerformanceMethod;
+};
+
+type FinishOptions = {
+  result: CatchPerformanceResult;
+  catchId?: string | null;
+  conventionId?: string | null;
+  errorCode?: string | null;
+};
+
+const SLOW_TOTAL_MS = 5000;
+const SLOW_EDGE_REQUEST_MS = 3000;
+
+const now = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+const roundMs = (duration: number) => Math.max(0, Math.round(duration));
+
+export function createClientAttemptId(): string {
+  const randomUUID =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID.bind(crypto)
+      : null;
+
+  if (randomUUID) {
+    return randomUUID();
+  }
+
+  return `attempt-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function getCatchPerformanceAppVersion(): string | null {
+  return (
+    Constants.expoConfig?.version ??
+    Constants.expoConfig?.runtimeVersion?.toString() ??
+    Constants.expoConfig?.extra?.appVersion ??
+    null
+  );
+}
+
+export function createCatchPerformanceTrace(options: CatchPerformanceTraceOptions) {
+  const clientAttemptId = options.clientAttemptId ?? createClientAttemptId();
+  const startedAt = now();
+  const timings: Partial<Record<CatchPerformanceTimingKey, number>> = {};
+
+  const recordTiming = (key: CatchPerformanceTimingKey, durationMs: number | null | undefined) => {
+    if (typeof durationMs !== 'number' || !Number.isFinite(durationMs)) {
+      return;
+    }
+
+    timings[key] = roundMs(durationMs);
+  };
+
+  const startTiming = (key: CatchPerformanceTimingKey) => {
+    const phaseStartedAt = now();
+    return () => recordTiming(key, now() - phaseStartedAt);
+  };
+
+  const measure = async <T>(key: CatchPerformanceTimingKey, operation: () => Promise<T>) => {
+    const stop = startTiming(key);
+    try {
+      return await operation();
+    } finally {
+      stop();
+    }
+  };
+
+  const finish = (finishOptions: FinishOptions) => {
+    const totalMs = roundMs(now() - startedAt);
+    const appVersion = getCatchPerformanceAppVersion();
+    const payload = {
+      client_attempt_id: clientAttemptId,
+      method: options.method,
+      result: finishOptions.result,
+      total_ms: totalMs,
+      timings,
+      app_version: appVersion,
+      platform: Platform.OS,
+      network_type: null,
+      catch_id: finishOptions.catchId ?? null,
+      convention_id: finishOptions.conventionId ?? null,
+      error_code: finishOptions.errorCode ?? null,
+    };
+
+    addMonitoringBreadcrumb({
+      category: 'catch.performance',
+      message: 'Catch performance trace completed',
+      data: payload,
+      level:
+        finishOptions.result === 'success' || finishOptions.result === 'pending_approval'
+          ? 'info'
+          : 'warning',
+    });
+
+    if (
+      totalMs >= SLOW_TOTAL_MS ||
+      (timings.edge_request_ms ?? 0) >= SLOW_EDGE_REQUEST_MS ||
+      finishOptions.result === 'failed' ||
+      finishOptions.result === 'timeout'
+    ) {
+      captureHandledMessage('Catch performance trace completed', payload, 'warning');
+    }
+
+    return payload;
+  };
+
+  return {
+    clientAttemptId,
+    timings,
+    finish,
+    measure,
+    recordTiming,
+    startTiming,
+  };
+}

--- a/src/features/catch-confirmations/lib/catchPerformance.ts
+++ b/src/features/catch-confirmations/lib/catchPerformance.ts
@@ -39,13 +39,8 @@ const now = () =>
 const roundMs = (duration: number) => Math.max(0, Math.round(duration));
 
 export function createClientAttemptId(): string {
-  const randomUUID =
-    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID.bind(crypto)
-      : null;
-
-  if (randomUUID) {
-    return randomUUID();
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
   }
 
   return `attempt-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;

--- a/src/features/catch-confirmations/types.ts
+++ b/src/features/catch-confirmations/types.ts
@@ -47,16 +47,20 @@ export type ConfirmCatchResult = {
 
 export type CreateCatchResult = {
   catchId: string;
+  clientAttemptId: string;
   status: CatchStatus;
   expiresAt: string | null;
   catchNumber: number | null;
   requiresApproval: boolean;
   fursuitOwnerId: string;
+  edgeRequestMs: number | null;
 };
 
 export type CreateCatchParams = {
   fursuitId: string;
   conventionId: string | null;
+  clientAttemptId?: string;
+  method?: 'code' | 'camera_photo' | 'gallery_photo';
   isTutorial?: boolean;
   forcePending?: boolean;
   hasPhoto?: boolean;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -237,6 +237,79 @@ export type Database = {
           },
         ]
       }
+      catch_performance_events: {
+        Row: {
+          app_version: string | null
+          catch_id: string | null
+          client_attempt_id: string
+          convention_id: string | null
+          created_at: string
+          error_code: string | null
+          id: string
+          method: string
+          network_type: string | null
+          platform: string | null
+          result: string
+          timings: Json
+          total_ms: number | null
+          user_id: string | null
+        }
+        Insert: {
+          app_version?: string | null
+          catch_id?: string | null
+          client_attempt_id: string
+          convention_id?: string | null
+          created_at?: string
+          error_code?: string | null
+          id?: string
+          method: string
+          network_type?: string | null
+          platform?: string | null
+          result: string
+          timings?: Json
+          total_ms?: number | null
+          user_id?: string | null
+        }
+        Update: {
+          app_version?: string | null
+          catch_id?: string | null
+          client_attempt_id?: string
+          convention_id?: string | null
+          created_at?: string
+          error_code?: string | null
+          id?: string
+          method?: string
+          network_type?: string | null
+          platform?: string | null
+          result?: string
+          timings?: Json
+          total_ms?: number | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "catch_performance_events_catch_id_fkey"
+            columns: ["catch_id"]
+            isOneToOne: false
+            referencedRelation: "catches"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "catch_performance_events_convention_id_fkey"
+            columns: ["convention_id"]
+            isOneToOne: false
+            referencedRelation: "conventions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "catch_performance_events_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       catches: {
         Row: {
           catch_number: number | null

--- a/supabase/functions/_shared/achievements.ts
+++ b/supabase/functions/_shared/achievements.ts
@@ -890,25 +890,26 @@ async function insertNotificationsForAwards(
   results: RpcAwardResult[],
 ) {
   const notifications: NotificationInsert[] = [];
-  const awardedSummaries: RpcAwardResult[] = [];
+  const awardedSummaries: Array<RpcAwardResult & { achievement_id: string }> = [];
   const awardedNotificationKeys = new Set<string>();
 
   for (const summary of results) {
-    if (!summary.awarded || !summary.achievement_id) {
+    const achievementId = summary.achievement_id;
+    if (!summary.awarded || !achievementId) {
       continue;
     }
 
-    const notificationKey = `${summary.user_id}:${summary.achievement_id}`;
+    const notificationKey = `${summary.user_id}:${achievementId}`;
     if (awardedNotificationKeys.has(notificationKey)) {
       continue;
     }
 
     awardedNotificationKeys.add(notificationKey);
-    awardedSummaries.push(summary);
+    awardedSummaries.push({ ...summary, achievement_id: achievementId });
   }
 
   const awardedAchievementIds = Array.from(
-    new Set(awardedSummaries.map((summary) => summary.achievement_id as string)),
+    new Set(awardedSummaries.map((summary) => summary.achievement_id)),
   );
   const achievementInfoById = new Map<string, AchievementNotificationInfo>();
 

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -161,7 +161,7 @@ function createServerCatchPerformanceTrace(initialClientAttemptId: string | null
     }
   };
 
-  const finish = async (options: {
+  const finish = (options: {
     userId?: string | null;
     catchId?: string | null;
     conventionId?: string | null;
@@ -179,24 +179,30 @@ function createServerCatchPerformanceTrace(initialClientAttemptId: string | null
     const totalMs = roundMs(now() - startedAt);
     timings.edge_total_ms = totalMs;
 
-    const { error } = await supabaseAdmin.from('catch_performance_events').insert({
-      client_attempt_id: clientAttemptId,
-      user_id: options.userId ?? null,
-      catch_id: options.catchId ?? null,
-      convention_id: options.conventionId ?? null,
-      method: options.method,
-      result: options.result,
-      total_ms: totalMs,
-      timings,
-      app_version: options.appVersion ?? null,
-      platform: options.platform ?? null,
-      network_type: options.networkType ?? null,
-      error_code: options.errorCode ?? null,
-    });
-
-    if (error) {
-      console.error('[create-catch] Failed to record catch performance telemetry:', error);
-    }
+    void Promise.resolve(
+      supabaseAdmin.from('catch_performance_events').insert({
+        client_attempt_id: clientAttemptId,
+        user_id: options.userId ?? null,
+        catch_id: options.catchId ?? null,
+        convention_id: options.conventionId ?? null,
+        method: options.method,
+        result: options.result,
+        total_ms: totalMs,
+        timings: { ...timings },
+        app_version: options.appVersion ?? null,
+        platform: options.platform ?? null,
+        network_type: options.networkType ?? null,
+        error_code: options.errorCode ?? null,
+      }),
+    )
+      .then(({ error }) => {
+        if (error) {
+          console.error('[create-catch] Failed to record catch performance telemetry:', error);
+        }
+      })
+      .catch((error) => {
+        console.error('[create-catch] Failed to record catch performance telemetry:', error);
+      });
   };
 
   return {

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -18,7 +18,8 @@ import type { InsertableEventRow } from '../_shared/types.ts';
 
 const corsHeaders: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, x-client-attempt-id, apikey, content-type',
 };
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
@@ -42,6 +43,11 @@ const supabaseAdmin = createClient(resolvedSupabaseUrl, resolvedServiceRoleKey, 
 });
 
 interface CreateCatchRequest {
+  client_attempt_id?: string;
+  app_version?: string | null;
+  platform?: string | null;
+  network_type?: string | null;
+  method?: 'code' | 'camera_photo' | 'gallery_photo';
   fursuit_id: string;
   convention_id?: string | null;
   is_tutorial?: boolean;
@@ -60,6 +66,7 @@ interface UpdateCatchPhotoRequest {
 }
 
 interface CreateCatchResponse {
+  client_attempt_id?: string;
   catch_id: string;
   status: string;
   expires_at: string | null;
@@ -74,6 +81,20 @@ type FursuitMakerMetadata = {
   normalizedMakerNames: string[];
   hasSelfMadeMaker: boolean;
 };
+
+type CatchPerformanceMethod = 'code' | 'camera_photo' | 'gallery_photo';
+type CatchPerformanceResult = 'success' | 'pending_approval' | 'failed' | 'timeout';
+type ServerTimingKey =
+  | 'auth_ms'
+  | 'block_check_ms'
+  | 'catch_insert_ms'
+  | 'photo_attach_ms'
+  | 'metadata_ms'
+  | 'notification_ms'
+  | 'event_ingest_ms'
+  | 'queue_config_ms'
+  | 'inline_processing_ms'
+  | 'edge_total_ms';
 
 const SELF_MADE_MAKER_ALIASES = [
   'self-made',
@@ -99,6 +120,99 @@ type InlineEventRow = {
   processed_at: string | null;
   queue_message_id: number | string | null;
 };
+
+const now = () => performance.now();
+const roundMs = (duration: number) => Math.max(0, Math.round(duration));
+
+function normalizeClientAttemptId(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function normalizeCatchMethod(value: unknown): CatchPerformanceMethod {
+  if (value === 'camera_photo' || value === 'gallery_photo' || value === 'code') {
+    return value;
+  }
+
+  return 'code';
+}
+
+function createServerCatchPerformanceTrace(initialClientAttemptId: string | null) {
+  let clientAttemptId = initialClientAttemptId;
+  const startedAt = now();
+  const timings: Partial<Record<ServerTimingKey, number>> = {};
+
+  const recordTiming = (key: ServerTimingKey, durationMs: number | null | undefined) => {
+    if (typeof durationMs !== 'number' || !Number.isFinite(durationMs)) {
+      return;
+    }
+
+    timings[key] = roundMs(durationMs);
+  };
+
+  const measure = async <T>(
+    key: ServerTimingKey,
+    operation: () => T | PromiseLike<T>,
+  ): Promise<Awaited<T>> => {
+    const phaseStartedAt = now();
+    try {
+      return (await operation()) as Awaited<T>;
+    } finally {
+      recordTiming(key, now() - phaseStartedAt);
+    }
+  };
+
+  const finish = async (options: {
+    userId?: string | null;
+    catchId?: string | null;
+    conventionId?: string | null;
+    method: CatchPerformanceMethod;
+    result: CatchPerformanceResult;
+    appVersion?: string | null;
+    platform?: string | null;
+    networkType?: string | null;
+    errorCode?: string | null;
+  }) => {
+    if (!clientAttemptId) {
+      return;
+    }
+
+    const totalMs = roundMs(now() - startedAt);
+    timings.edge_total_ms = totalMs;
+
+    const { error } = await supabaseAdmin.from('catch_performance_events').insert({
+      client_attempt_id: clientAttemptId,
+      user_id: options.userId ?? null,
+      catch_id: options.catchId ?? null,
+      convention_id: options.conventionId ?? null,
+      method: options.method,
+      result: options.result,
+      total_ms: totalMs,
+      timings,
+      app_version: options.appVersion ?? null,
+      platform: options.platform ?? null,
+      network_type: options.networkType ?? null,
+      error_code: options.errorCode ?? null,
+    });
+
+    if (error) {
+      console.error('[create-catch] Failed to record catch performance telemetry:', error);
+    }
+  };
+
+  return {
+    get clientAttemptId() {
+      return clientAttemptId;
+    },
+    setClientAttemptId(value: string | null) {
+      if (value) {
+        clientAttemptId = value;
+      }
+    },
+    finish,
+    measure,
+    recordTiming,
+  };
+}
 
 function parseQueueMessageId(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
@@ -192,8 +306,13 @@ async function processEventInline(eventId: string): Promise<{
   };
 }
 
-function jsonResponse(status: number, payload: unknown) {
-  return new Response(JSON.stringify(payload), {
+function jsonResponse(status: number, payload: unknown, clientAttemptId?: string | null) {
+  const responsePayload =
+    clientAttemptId && typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+      ? { ...payload, client_attempt_id: clientAttemptId }
+      : payload;
+
+  return new Response(JSON.stringify(responsePayload), {
     status,
     headers: {
       ...corsHeaders,
@@ -361,79 +480,139 @@ async function getUserIdFromRequest(req: Request): Promise<string | null> {
 }
 
 async function handlePost(req: Request): Promise<Response> {
-  const userId = await getUserIdFromRequest(req);
+  const trace = createServerCatchPerformanceTrace(
+    normalizeClientAttemptId(req.headers.get('x-client-attempt-id')),
+  );
+  let userId: string | null = null;
+  let body: CreateCatchRequest | null = null;
+  let method: CatchPerformanceMethod = 'code';
+  let catchId: string | null = null;
+  let resolvedConventionId: string | null = null;
+
+  const finishTrace = async (options: {
+    result: CatchPerformanceResult;
+    errorCode?: string | null;
+  }) =>
+    await trace.finish({
+      userId,
+      catchId,
+      conventionId: resolvedConventionId ?? body?.convention_id ?? null,
+      method,
+      result: options.result,
+      appVersion:
+        typeof body?.app_version === 'string' && body.app_version.trim().length > 0
+          ? body.app_version
+          : null,
+      platform:
+        typeof body?.platform === 'string' && body.platform.trim().length > 0
+          ? body.platform
+          : null,
+      networkType:
+        typeof body?.network_type === 'string' && body.network_type.trim().length > 0
+          ? body.network_type
+          : null,
+      errorCode: options.errorCode ?? null,
+    });
+
+  const failureResponse = async (status: number, payload: unknown, errorCode: string) => {
+    await finishTrace({ result: 'failed', errorCode });
+    return jsonResponse(status, payload, trace.clientAttemptId);
+  };
+
+  userId = await trace.measure('auth_ms', () => getUserIdFromRequest(req));
   if (!userId) {
-    return jsonResponse(401, { error: 'Unauthorized' });
+    return failureResponse(401, { error: 'Unauthorized' }, 'unauthorized');
   }
 
-  let body: CreateCatchRequest;
   try {
     body = (await req.json()) as CreateCatchRequest;
+    trace.setClientAttemptId(normalizeClientAttemptId(body.client_attempt_id));
+    method = normalizeCatchMethod(body.method);
   } catch {
-    return jsonResponse(400, { error: 'Invalid JSON payload' });
+    return failureResponse(400, { error: 'Invalid JSON payload' }, 'invalid_json');
   }
 
-  if (!body.fursuit_id) {
-    return jsonResponse(400, { error: 'Missing fursuit_id' });
+  if (!body?.fursuit_id) {
+    return failureResponse(400, { error: 'Missing fursuit_id' }, 'missing_fursuit_id');
   }
 
   if (body.has_photo === true && !body.catch_photo_url) {
-    return jsonResponse(400, { error: 'Missing catch_photo_url' });
+    return failureResponse(400, { error: 'Missing catch_photo_url' }, 'missing_photo_url');
   }
 
   const catchPhotoSource = normalizeCatchPhotoSource(body.catch_photo_source);
 
   if (body.catch_photo_source && !catchPhotoSource) {
-    return jsonResponse(400, { error: 'Invalid catch_photo_source' });
+    return failureResponse(400, { error: 'Invalid catch_photo_source' }, 'invalid_photo_source');
   }
 
   if (catchPhotoSource === 'gallery' && (!body.has_photo || !body.catch_photo_url)) {
-    return jsonResponse(400, { error: 'Gallery catches require a photo' });
+    return failureResponse(
+      400,
+      { error: 'Gallery catches require a photo' },
+      'gallery_photo_required',
+    );
   }
 
   try {
     // Check if catcher and fursuit owner have blocked each other
-    const { data: fursuitRow } = await supabaseAdmin
-      .from('fursuits')
-      .select('owner_id')
-      .eq('id', body.fursuit_id)
-      .single();
+    const fursuitRow = await trace.measure('block_check_ms', async () => {
+      const { data: ownerRow } = await supabaseAdmin
+        .from('fursuits')
+        .select('owner_id')
+        .eq('id', body.fursuit_id)
+        .single();
 
-    if (fursuitRow?.owner_id) {
-      const { data: blocked } = await supabaseAdmin.rpc('is_blocked', {
-        p_user_a: userId,
-        p_user_b: fursuitRow.owner_id,
-      });
+      if (ownerRow?.owner_id) {
+        const { data: blocked } = await supabaseAdmin.rpc('is_blocked', {
+          p_user_a: userId,
+          p_user_b: ownerRow.owner_id,
+        });
 
-      if (blocked === true) {
-        return jsonResponse(403, { error: 'Cannot catch this fursuit' });
+        return { owner_id: ownerRow.owner_id, blocked };
       }
+
+      return { owner_id: ownerRow?.owner_id ?? null, blocked: false };
+    });
+
+    if (fursuitRow?.blocked === true) {
+      return failureResponse(403, { error: 'Cannot catch this fursuit' }, 'blocked_user');
     }
 
     // Call the create_catch_with_approval function. The RPC reads the fursuit owner's
     // profile-level catch mode preference.
-    const { data, error } = await supabaseAdmin.rpc('create_catch_with_approval', {
-      p_fursuit_id: body.fursuit_id,
-      p_catcher_id: userId,
-      p_convention_id: body.convention_id || null,
-      p_is_tutorial: body.is_tutorial || false,
-      p_force_pending: body.force_pending || catchPhotoSource === 'gallery',
-      p_catch_photo_source: catchPhotoSource,
-    });
+    const { data, error } = await trace.measure('catch_insert_ms', () =>
+      supabaseAdmin.rpc('create_catch_with_approval', {
+        p_fursuit_id: body.fursuit_id,
+        p_catcher_id: userId,
+        p_convention_id: body.convention_id || null,
+        p_is_tutorial: body.is_tutorial || false,
+        p_force_pending: body.force_pending || catchPhotoSource === 'gallery',
+        p_catch_photo_source: catchPhotoSource,
+      }),
+    );
 
     if (error) {
       // Handle specific error cases
       if (error.message?.includes('Cannot catch your own fursuit')) {
-        return jsonResponse(400, { error: 'Cannot catch your own fursuit' });
+        return failureResponse(400, { error: 'Cannot catch your own fursuit' }, 'self_catch');
       }
       if (error.message?.includes('already caught')) {
-        return jsonResponse(400, { error: 'Fursuit already caught at this convention' });
+        return failureResponse(
+          400,
+          { error: 'Fursuit already caught at this convention' },
+          'already_caught',
+        );
       }
       if (error.message?.includes('Convention is not live')) {
-        return jsonResponse(400, { error: 'Convention is not live' });
+        return failureResponse(400, { error: 'Convention is not live' }, 'convention_not_live');
       }
       if (error.message?.includes('Convention is not accepting gallery catches')) {
-        return jsonResponse(400, { error: 'Convention is not accepting gallery catches' });
+        return failureResponse(
+          400,
+          { error: 'Convention is not accepting gallery catches' },
+          'gallery_closed',
+        );
       }
       if (
         error.message?.includes('Catcher must join the live convention') ||
@@ -442,34 +621,41 @@ async function handlePost(req: Request): Promise<Response> {
         error.message?.includes('Fursuit owner must have a playable convention') ||
         error.message?.includes('Fursuit must be assigned to the live convention')
       ) {
-        return jsonResponse(400, {
-          error:
-            'You and this fursuit must share a playable convention, and the fursuit must be assigned to that convention before catching.',
-        });
+        return failureResponse(
+          400,
+          {
+            error:
+              'You and this fursuit must share a playable convention, and the fursuit must be assigned to that convention before catching.',
+          },
+          'shared_convention_required',
+        );
       }
       if (error.message?.includes('not found')) {
-        return jsonResponse(404, { error: 'Fursuit not found' });
+        return failureResponse(404, { error: 'Fursuit not found' }, 'fursuit_not_found');
       }
 
       console.error('[create-catch] RPC error:', error);
-      return jsonResponse(500, { error: 'Failed to create catch' });
+      return failureResponse(500, { error: 'Failed to create catch' }, 'catch_insert_failed');
     }
 
     const result = data as CreateCatchResponse;
-    const resolvedConventionId = await resolveCreatedCatchConventionId(
+    catchId = result.catch_id;
+    resolvedConventionId = await resolveCreatedCatchConventionId(
       result,
       body.convention_id ?? null,
     );
 
     if (body.has_photo === true) {
-      const { error: photoUpdateError } = await supabaseAdmin
-        .from('catches')
-        .update({
-          catch_photo_path: body.catch_photo_path ?? null,
-          catch_photo_url: body.catch_photo_url,
-          catch_photo_source: catchPhotoSource ?? 'camera',
-        })
-        .eq('id', result.catch_id);
+      const { error: photoUpdateError } = await trace.measure('photo_attach_ms', () =>
+        supabaseAdmin
+          .from('catches')
+          .update({
+            catch_photo_path: body.catch_photo_path ?? null,
+            catch_photo_url: body.catch_photo_url,
+            catch_photo_source: catchPhotoSource ?? 'camera',
+          })
+          .eq('id', result.catch_id),
+      );
 
       if (photoUpdateError) {
         await supabaseAdmin.from('catches').delete().eq('id', result.catch_id);
@@ -477,7 +663,11 @@ async function handlePost(req: Request): Promise<Response> {
           '[create-catch] Failed to attach photo during catch creation:',
           photoUpdateError,
         );
-        return jsonResponse(500, { error: 'Failed to attach photo to catch' });
+        return failureResponse(
+          500,
+          { error: 'Failed to attach photo to catch' },
+          'photo_attach_failed',
+        );
       }
     }
 
@@ -497,88 +687,94 @@ async function handlePost(req: Request): Promise<Response> {
     const shouldNotifyAcceptedCatch = !result.requires_approval && !body.is_tutorial;
 
     try {
-      const fursuitPromise = (async () =>
-        await supabaseAdmin
-          .from('fursuits')
-          .select('name, species:fursuit_species(name)')
-          .eq('id', body.fursuit_id)
-          .single())();
-      const colorsPromise = (async () =>
-        await supabaseAdmin
-          .from('fursuit_color_assignments')
-          .select('color:fursuit_colors(name)')
-          .eq('fursuit_id', body.fursuit_id)
-          .order('position', { ascending: true }))();
-      const makersPromise = fetchFursuitMakerMetadata(body.fursuit_id);
-      const catcherPromise =
-        shouldNotifyPendingCatch || shouldNotifyAcceptedCatch
-          ? (async () =>
-              await supabaseAdmin.from('profiles').select('username').eq('id', userId).single())()
-          : Promise.resolve(undefined);
+      await trace.measure('metadata_ms', async () => {
+        const fursuitPromise = (async () =>
+          await supabaseAdmin
+            .from('fursuits')
+            .select('name, species:fursuit_species(name)')
+            .eq('id', body.fursuit_id)
+            .single())();
+        const colorsPromise = (async () =>
+          await supabaseAdmin
+            .from('fursuit_color_assignments')
+            .select('color:fursuit_colors(name)')
+            .eq('fursuit_id', body.fursuit_id)
+            .order('position', { ascending: true }))();
+        const makersPromise = fetchFursuitMakerMetadata(body.fursuit_id);
+        const catcherPromise =
+          shouldNotifyPendingCatch || shouldNotifyAcceptedCatch
+            ? (async () =>
+                await supabaseAdmin.from('profiles').select('username').eq('id', userId).single())()
+            : Promise.resolve(undefined);
 
-      const [fursuitResult, colorsResult, makerResult, catcherResult] = await Promise.all([
-        fursuitPromise,
-        colorsPromise,
-        makersPromise,
-        catcherPromise,
-      ]);
+        const [fursuitResult, colorsResult, makerResult, catcherResult] = await Promise.all([
+          fursuitPromise,
+          colorsPromise,
+          makersPromise,
+          catcherPromise,
+        ]);
 
-      const speciesRow = Array.isArray(fursuitResult.data?.species)
-        ? fursuitResult.data?.species[0]
-        : fursuitResult.data?.species;
+        const speciesRow = Array.isArray(fursuitResult.data?.species)
+          ? fursuitResult.data?.species[0]
+          : fursuitResult.data?.species;
 
-      speciesName = speciesRow?.name ?? null;
-      colorNames = (colorsResult.data ?? [])
-        .map((row) => {
-          const colorRow = Array.isArray(row.color) ? row.color[0] : row.color;
-          return colorRow?.name;
-        })
-        .filter((name): name is string => !!name);
-      makerMetadata = makerResult;
-      const [makerMatch, hasNewMaker] = await Promise.all([
-        hasCatcherOwnedMakerMatch(userId, makerMetadata.normalizedMakerNames),
-        hasNewMakerForCatcherAtConvention({
-          catcherId: userId,
-          conventionId: resolvedConventionId,
-          catchId: result.catch_id,
-          normalizedMakerNames: makerMetadata.normalizedMakerNames,
-        }),
-      ]);
-      hasMakerMatchWithCatcherOwnedSuit = makerMatch;
-      isNewMakerForCatcherAtConvention = hasNewMaker;
+        speciesName = speciesRow?.name ?? null;
+        colorNames = (colorsResult.data ?? [])
+          .map((row) => {
+            const colorRow = Array.isArray(row.color) ? row.color[0] : row.color;
+            return colorRow?.name;
+          })
+          .filter((name): name is string => !!name);
+        makerMetadata = makerResult;
+        const [makerMatch, hasNewMaker] = await Promise.all([
+          hasCatcherOwnedMakerMatch(userId, makerMetadata.normalizedMakerNames),
+          hasNewMakerForCatcherAtConvention({
+            catcherId: userId,
+            conventionId: resolvedConventionId,
+            catchId: result.catch_id,
+            normalizedMakerNames: makerMetadata.normalizedMakerNames,
+          }),
+        ]);
+        hasMakerMatchWithCatcherOwnedSuit = makerMatch;
+        isNewMakerForCatcherAtConvention = hasNewMaker;
 
-      if (shouldNotifyPendingCatch && fursuitResult.data && catcherResult?.data) {
-        const { error: notifError } = await supabaseAdmin.rpc('notify_catch_pending', {
-          p_catch_id: result.catch_id,
-          p_fursuit_owner_id: result.fursuit_owner_id,
-          p_catcher_id: userId,
-          p_fursuit_name: fursuitResult.data.name,
-          p_catcher_username: catcherResult.data.username || 'Someone',
-        });
+        if (shouldNotifyPendingCatch && fursuitResult.data && catcherResult?.data) {
+          const { error: notifError } = await trace.measure('notification_ms', () =>
+            supabaseAdmin.rpc('notify_catch_pending', {
+              p_catch_id: result.catch_id,
+              p_fursuit_owner_id: result.fursuit_owner_id,
+              p_catcher_id: userId,
+              p_fursuit_name: fursuitResult.data.name,
+              p_catcher_username: catcherResult.data.username || 'Someone',
+            }),
+          );
 
-        if (notifError) {
-          console.error('[create-catch] Failed to send notification:', notifError);
+          if (notifError) {
+            console.error('[create-catch] Failed to send notification:', notifError);
+          }
         }
-      }
 
-      if (shouldNotifyAcceptedCatch && fursuitResult.data && catcherResult?.data) {
-        const { error: notifError } = await supabaseAdmin.from('notifications').insert({
-          user_id: result.fursuit_owner_id,
-          type: 'fursuit_caught',
-          payload: {
-            catch_id: result.catch_id,
-            catcher_id: userId,
-            fursuit_id: body.fursuit_id,
-            fursuit_name: fursuitResult.data.name,
-            catcher_username: catcherResult.data.username || 'Someone',
-            convention_id: resolvedConventionId,
-          },
-        });
+        if (shouldNotifyAcceptedCatch && fursuitResult.data && catcherResult?.data) {
+          const { error: notifError } = await trace.measure('notification_ms', () =>
+            supabaseAdmin.from('notifications').insert({
+              user_id: result.fursuit_owner_id,
+              type: 'fursuit_caught',
+              payload: {
+                catch_id: result.catch_id,
+                catcher_id: userId,
+                fursuit_id: body.fursuit_id,
+                fursuit_name: fursuitResult.data.name,
+                catcher_username: catcherResult.data.username || 'Someone',
+                convention_id: resolvedConventionId,
+              },
+            }),
+          );
 
-        if (notifError) {
-          console.error('[create-catch] Failed to send accepted catch notification:', notifError);
+          if (notifError) {
+            console.error('[create-catch] Failed to send accepted catch notification:', notifError);
+          }
         }
-      }
+      });
     } catch (metadataError) {
       console.error('[create-catch] Metadata/notification error:', metadataError);
       // Don't fail the catch creation if metadata fetch fails
@@ -586,33 +782,37 @@ async function handlePost(req: Request): Promise<Response> {
 
     // Persist the canonical gameplay event before returning.
     const eventType = result.requires_approval ? 'catch_pending' : 'catch_performed';
-    const ingestResult = await ingestGameplayEvent(supabaseAdmin, {
-      type: eventType,
-      userId,
-      conventionId: resolvedConventionId,
-      payload: {
-        catch_id: result.catch_id,
-        fursuit_id: body.fursuit_id,
-        catcher_id: userId,
-        fursuit_owner_id: result.fursuit_owner_id,
-        convention_id: resolvedConventionId,
-        is_tutorial: body.is_tutorial ?? false,
-        status: result.status,
-        catch_photo_source: catchPhotoSource,
-        species: speciesName,
-        colors: colorNames,
-        maker_names: makerMetadata.makerNames,
-        normalized_maker_names: makerMetadata.normalizedMakerNames,
-        has_maker: makerMetadata.normalizedMakerNames.length > 0,
-        is_self_made: makerMetadata.hasSelfMadeMaker,
-        has_catcher_owned_maker_match: hasMakerMatchWithCatcherOwnedSuit,
-        is_new_maker_for_catcher_at_convention: isNewMakerForCatcherAtConvention,
-      },
-      occurredAt: new Date().toISOString(),
-      idempotencyKey: `catch:${result.catch_id}:${eventType}`,
-    });
+    const ingestResult = await trace.measure('event_ingest_ms', () =>
+      ingestGameplayEvent(supabaseAdmin, {
+        type: eventType,
+        userId,
+        conventionId: resolvedConventionId,
+        payload: {
+          catch_id: result.catch_id,
+          fursuit_id: body.fursuit_id,
+          catcher_id: userId,
+          fursuit_owner_id: result.fursuit_owner_id,
+          convention_id: resolvedConventionId,
+          is_tutorial: body.is_tutorial ?? false,
+          status: result.status,
+          catch_photo_source: catchPhotoSource,
+          species: speciesName,
+          colors: colorNames,
+          maker_names: makerMetadata.makerNames,
+          normalized_maker_names: makerMetadata.normalizedMakerNames,
+          has_maker: makerMetadata.normalizedMakerNames.length > 0,
+          is_self_made: makerMetadata.hasSelfMadeMaker,
+          has_catcher_owned_maker_match: hasMakerMatchWithCatcherOwnedSuit,
+          is_new_maker_for_catcher_at_convention: isNewMakerForCatcherAtConvention,
+        },
+        occurredAt: new Date().toISOString(),
+        idempotencyKey: `catch:${result.catch_id}:${eventType}`,
+      }),
+    );
 
-    const queueConfig = await loadGameplayQueueConfig(supabaseAdmin);
+    const queueConfig = await trace.measure('queue_config_ms', () =>
+      loadGameplayQueueConfig(supabaseAdmin),
+    );
     let inlineAwards: unknown[] = [];
     let processedInline = false;
 
@@ -622,7 +822,9 @@ async function handlePost(req: Request): Promise<Response> {
       eventType === 'catch_performed'
     ) {
       try {
-        const inlineResult = await processEventInline(ingestResult.eventId);
+        const inlineResult = await trace.measure('inline_processing_ms', () =>
+          processEventInline(ingestResult.eventId),
+        );
         processedInline = inlineResult.processed;
         inlineAwards = inlineResult.awards;
       } catch (inlineError) {
@@ -647,16 +849,23 @@ async function handlePost(req: Request): Promise<Response> {
       }
     }
 
-    return jsonResponse(201, {
-      ...result,
-      event_id: ingestResult.eventId,
-      awards: inlineAwards,
-      species: speciesName,
-      colors: colorNames,
-    });
+    await finishTrace({ result: result.requires_approval ? 'pending_approval' : 'success' });
+
+    return jsonResponse(
+      201,
+      {
+        ...result,
+        event_id: ingestResult.eventId,
+        awards: inlineAwards,
+        species: speciesName,
+        colors: colorNames,
+      },
+      trace.clientAttemptId,
+    );
   } catch (error) {
     console.error('[create-catch] Unexpected error:', error);
-    return jsonResponse(500, { error: 'Internal server error' });
+    await finishTrace({ result: 'failed', errorCode: 'internal_error' });
+    return jsonResponse(500, { error: 'Internal server error' }, trace.clientAttemptId);
   }
 }
 

--- a/supabase/migrations/20260513130000_add_catch_performance_events.sql
+++ b/supabase/migrations/20260513130000_add_catch_performance_events.sql
@@ -1,0 +1,32 @@
+create table if not exists public.catch_performance_events (
+  id uuid primary key default gen_random_uuid(),
+  client_attempt_id text not null,
+  user_id uuid null references public.profiles(id) on delete set null,
+  catch_id uuid null references public.catches(id) on delete set null,
+  convention_id uuid null references public.conventions(id) on delete set null,
+  method text not null,
+  result text not null,
+  total_ms integer null,
+  timings jsonb not null default '{}'::jsonb,
+  app_version text null,
+  platform text null,
+  network_type text null,
+  error_code text null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.catch_performance_events enable row level security;
+
+revoke all on table public.catch_performance_events from anon;
+revoke all on table public.catch_performance_events from authenticated;
+grant all on table public.catch_performance_events to service_role;
+
+create index if not exists catch_performance_events_created_at_idx
+  on public.catch_performance_events (created_at desc);
+
+create index if not exists catch_performance_events_method_created_at_idx
+  on public.catch_performance_events (method, created_at desc);
+
+create index if not exists catch_performance_events_convention_created_at_idx
+  on public.catch_performance_events (convention_id, created_at desc)
+  where convention_id is not null;

--- a/supabase/migrations/20260513131000_index_catch_performance_event_foreign_keys.sql
+++ b/supabase/migrations/20260513131000_index_catch_performance_event_foreign_keys.sql
@@ -1,0 +1,7 @@
+create index if not exists catch_performance_events_user_created_at_idx
+  on public.catch_performance_events (user_id, created_at desc)
+  where user_id is not null;
+
+create index if not exists catch_performance_events_catch_id_idx
+  on public.catch_performance_events (catch_id)
+  where catch_id is not null;


### PR DESCRIPTION
This PR adds traces to Sentry and Supabase to track to performance of in-game fursuit catches.

Resolves TAILTAG-103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end performance tracing for catch confirmations, including photo and code flows.
  * Client-attempt IDs now correlate client requests with server-side events.
  * New server-side storage for catch performance events and related indexes.

* **Bug Fixes / Reliability**
  * Improved error mapping and timeout handling to provide clearer outcomes and preserve timing info.
  * Safer photo upload/cleanup on failure.

* **Chores**
  * Minor notification/award deduplication robustness improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FinnThePanther/tailtag/pull/104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->