### PR TITLE
Fix non-critical work in catch path

### DIFF
--- a/admin-v2/src/types/database.ts
+++ b/admin-v2/src/types/database.ts
@@ -2616,6 +2616,10 @@ export type Database = {
           event_id: string;
         }[];
       };
+      insert_catch_notification_once: {
+        Args: { p_payload: Json; p_type: string; p_user_id: string };
+        Returns: undefined;
+      };
       finish_onboarding: { Args: { target_user_id?: string }; Returns: Json };
       generate_profile_avatar_url: {
         Args: { app_meta: Json; user_meta: Json };

--- a/admin-v2/src/types/database.ts
+++ b/admin-v2/src/types/database.ts
@@ -2525,6 +2525,20 @@ export type Database = {
             };
             Returns: Json;
           };
+      create_catch_with_event: {
+        Args: {
+          p_catch_photo_path?: string;
+          p_catch_photo_source?: string;
+          p_catch_photo_url?: string;
+          p_catcher_id: string;
+          p_client_attempt_id?: string;
+          p_convention_id?: string;
+          p_force_pending?: boolean;
+          p_fursuit_id: string;
+          p_is_tutorial?: boolean;
+        };
+        Returns: Json;
+      };
       delete_gameplay_event_queue_message: {
         Args: { p_message_id: number };
         Returns: boolean;

--- a/admin/types/database.ts
+++ b/admin/types/database.ts
@@ -2528,6 +2528,20 @@ export type Database = {
             };
             Returns: Json;
           };
+      create_catch_with_event: {
+        Args: {
+          p_catch_photo_path?: string;
+          p_catch_photo_source?: string;
+          p_catch_photo_url?: string;
+          p_catcher_id: string;
+          p_client_attempt_id?: string;
+          p_convention_id?: string;
+          p_force_pending?: boolean;
+          p_fursuit_id: string;
+          p_is_tutorial?: boolean;
+        };
+        Returns: Json;
+      };
       delete_gameplay_event_queue_message: {
         Args: { p_message_id: number };
         Returns: boolean;

--- a/admin/types/database.ts
+++ b/admin/types/database.ts
@@ -2619,6 +2619,10 @@ export type Database = {
           event_id: string;
         }[];
       };
+      insert_catch_notification_once: {
+        Args: { p_payload: Json; p_type: string; p_user_id: string };
+        Returns: undefined;
+      };
       finish_onboarding: { Args: { target_user_id?: string }; Returns: Json };
       generate_profile_avatar_url: {
         Args: { app_meta: Json; user_meta: Json };

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -1021,6 +1021,10 @@ export type Database = {
         };
         Returns: undefined;
       };
+      insert_catch_notification_once: {
+        Args: { p_payload: Json; p_type: string; p_user_id: string };
+        Returns: undefined;
+      };
       refresh_convention_leaderboard: {
         Args: { convention_uuid?: string };
         Returns: undefined;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -935,6 +935,20 @@ export type Database = {
         };
         Returns: Json;
       };
+      create_catch_with_event: {
+        Args: {
+          p_catch_photo_path?: string;
+          p_catch_photo_source?: string;
+          p_catch_photo_url?: string;
+          p_catcher_id: string;
+          p_client_attempt_id?: string;
+          p_convention_id?: string;
+          p_force_pending?: boolean;
+          p_fursuit_id: string;
+          p_is_tutorial?: boolean;
+        };
+        Returns: Json;
+      };
       expire_pending_catches: { Args: Record<PropertyKey, never>; Returns: Json };
       finish_onboarding: { Args: { target_user_id?: string }; Returns: Json };
       get_fursuit_convention_stats: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2544,6 +2544,10 @@ export type Database = {
           event_id: string
         }[]
       }
+      insert_catch_notification_once: {
+        Args: { p_payload: Json; p_type: string; p_user_id: string }
+        Returns: undefined
+      }
       is_admin: { Args: { user_id: string }; Returns: boolean }
       is_admin_user: { Args: { check_user_id: string }; Returns: boolean }
       is_blocked: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2189,6 +2189,20 @@ export type Database = {
         }
         Returns: Json
       }
+      create_catch_with_event: {
+        Args: {
+          p_catch_photo_path?: string
+          p_catch_photo_source?: string
+          p_catch_photo_url?: string
+          p_catcher_id: string
+          p_client_attempt_id?: string
+          p_convention_id?: string
+          p_force_pending?: boolean
+          p_fursuit_id: string
+          p_is_tutorial?: boolean
+        }
+        Returns: Json
+      }
       current_user_has_password_credential: { Args: never; Returns: boolean }
       delete_archived_convention_in_dev: {
         Args: { p_actor_id: string; p_convention_id: string }

--- a/src/types/database.ts.minimal
+++ b/src/types/database.ts.minimal
@@ -1208,6 +1208,10 @@ export type Database = {
         }[]
       }
       grant_achievements_batch: { Args: { awards: Json }; Returns: Json }
+      insert_catch_notification_once: {
+        Args: { p_payload: Json; p_type: string; p_user_id: string }
+        Returns: undefined
+      }
       opt_in_to_convention: {
         Args: {
           p_convention_id: string

--- a/src/types/database.ts.minimal
+++ b/src/types/database.ts.minimal
@@ -1166,6 +1166,20 @@ export type Database = {
         }
         Returns: Json
       }
+      create_catch_with_event: {
+        Args: {
+          p_catch_photo_path?: string
+          p_catch_photo_source?: string
+          p_catch_photo_url?: string
+          p_catcher_id: string
+          p_client_attempt_id?: string
+          p_convention_id?: string
+          p_force_pending?: boolean
+          p_fursuit_id: string
+          p_is_tutorial?: boolean
+        }
+        Returns: Json
+      }
       expire_pending_catches: { Args: Record<PropertyKey, never>; Returns: Json }
       finish_onboarding: { Args: { target_user_id?: string }; Returns: Json }
       get_fursuit_convention_stats: {

--- a/supabase/functions/_shared/catchNotifications.ts
+++ b/supabase/functions/_shared/catchNotifications.ts
@@ -52,11 +52,21 @@ async function loadCatchNotificationContext(
   ]);
 
   if (fursuitResult.error) {
-    throw new Error(`Failed loading fursuit notification metadata: ${fursuitResult.error.message}`);
+    console.error('[catchNotifications] Failed loading fursuit notification metadata', {
+      event_id: event.event_id,
+      fursuit_id: fursuitId,
+      error: fursuitResult.error.message,
+    });
+    return null;
   }
 
   if (catcherResult.error) {
-    throw new Error(`Failed loading catcher notification metadata: ${catcherResult.error.message}`);
+    console.error('[catchNotifications] Failed loading catcher notification metadata', {
+      event_id: event.event_id,
+      catcher_id: catcherId,
+      error: catcherResult.error.message,
+    });
+    return null;
   }
 
   return {
@@ -99,7 +109,12 @@ async function insertCatchNotification(
   });
 
   if (error) {
-    throw new Error(`Failed inserting deduped ${type} notification: ${error.message}`);
+    console.error('[catchNotifications] Failed inserting deduped catch notification', {
+      type,
+      catch_id: context.catchId,
+      user_id: context.fursuitOwnerId,
+      error: error.message,
+    });
   }
 }
 

--- a/supabase/functions/_shared/catchNotifications.ts
+++ b/supabase/functions/_shared/catchNotifications.ts
@@ -1,0 +1,165 @@
+// eslint-disable-next-line import/no-unresolved -- Supabase Edge Functions run in Deno.
+import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.45.1';
+import type { InsertableEventRow } from './types.ts';
+
+type CatchNotificationType = 'catch_pending' | 'fursuit_caught';
+
+type CatchNotificationContext = {
+  catchId: string;
+  catcherId: string;
+  fursuitId: string;
+  fursuitOwnerId: string;
+  fursuitName: string;
+  catcherUsername: string;
+  conventionId: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+async function notificationExists(
+  supabaseAdmin: SupabaseClient<any, 'public', any>,
+  options: {
+    userId: string;
+    type: CatchNotificationType;
+    catchId: string;
+  },
+): Promise<boolean> {
+  const { data, error } = await supabaseAdmin
+    .from('notifications')
+    .select('id')
+    .eq('user_id', options.userId)
+    .eq('type', options.type)
+    .contains('payload', { catch_id: options.catchId })
+    .limit(1);
+
+  if (error) {
+    throw new Error(`Failed checking existing catch notification: ${error.message}`);
+  }
+
+  return (data ?? []).length > 0;
+}
+
+async function loadCatchNotificationContext(
+  supabaseAdmin: SupabaseClient<any, 'public', any>,
+  event: InsertableEventRow,
+): Promise<CatchNotificationContext | null> {
+  const payload = isRecord(event.payload) ? event.payload : {};
+  const catchId = readString(payload.catch_id);
+  const fursuitId = readString(payload.fursuit_id);
+  const catcherId = readString(payload.catcher_id) ?? event.user_id;
+  const fursuitOwnerId = readString(payload.fursuit_owner_id);
+  const conventionId = readString(payload.convention_id) ?? event.convention_id;
+
+  if (!catchId || !fursuitId || !catcherId || !fursuitOwnerId) {
+    console.error('[catchNotifications] Missing catch notification payload fields', {
+      event_id: event.event_id,
+      type: event.type,
+      payload,
+    });
+    return null;
+  }
+
+  const [fursuitResult, catcherResult] = await Promise.all([
+    supabaseAdmin.from('fursuits').select('name').eq('id', fursuitId).maybeSingle(),
+    supabaseAdmin.from('profiles').select('username').eq('id', catcherId).maybeSingle(),
+  ]);
+
+  if (fursuitResult.error) {
+    throw new Error(`Failed loading fursuit notification metadata: ${fursuitResult.error.message}`);
+  }
+
+  if (catcherResult.error) {
+    throw new Error(`Failed loading catcher notification metadata: ${catcherResult.error.message}`);
+  }
+
+  return {
+    catchId,
+    catcherId,
+    fursuitId,
+    fursuitOwnerId,
+    fursuitName: (fursuitResult.data as { name?: string } | null)?.name ?? 'Unknown Fursuit',
+    catcherUsername: (catcherResult.data as { username?: string } | null)?.username ?? 'Someone',
+    conventionId,
+  };
+}
+
+async function insertCatchNotification(
+  supabaseAdmin: SupabaseClient<any, 'public', any>,
+  type: CatchNotificationType,
+  context: CatchNotificationContext,
+): Promise<void> {
+  const exists = await notificationExists(supabaseAdmin, {
+    userId: context.fursuitOwnerId,
+    type,
+    catchId: context.catchId,
+  });
+
+  if (exists) {
+    return;
+  }
+
+  const payload =
+    type === 'catch_pending'
+      ? {
+          catch_id: context.catchId,
+          catcher_id: context.catcherId,
+          fursuit_name: context.fursuitName,
+          catcher_username: context.catcherUsername,
+        }
+      : {
+          catch_id: context.catchId,
+          catcher_id: context.catcherId,
+          fursuit_id: context.fursuitId,
+          fursuit_name: context.fursuitName,
+          catcher_username: context.catcherUsername,
+          convention_id: context.conventionId,
+        };
+
+  const { error } = await supabaseAdmin.from('notifications').insert({
+    user_id: context.fursuitOwnerId,
+    type,
+    payload,
+  });
+
+  if (error) {
+    throw new Error(`Failed inserting ${type} notification: ${error.message}`);
+  }
+}
+
+export async function processCatchNotificationForEvent(
+  supabaseAdmin: SupabaseClient<any, 'public', any>,
+  event: InsertableEventRow,
+): Promise<void> {
+  if (event.type !== 'catch_pending' && event.type !== 'catch_performed') {
+    return;
+  }
+
+  const payload = isRecord(event.payload) ? event.payload : {};
+
+  if (event.type === 'catch_performed') {
+    if (readBoolean(payload.is_tutorial) || readString(payload.source) === 'catch_confirmed') {
+      return;
+    }
+  }
+
+  const context = await loadCatchNotificationContext(supabaseAdmin, event);
+  if (!context) {
+    return;
+  }
+
+  await insertCatchNotification(
+    supabaseAdmin,
+    event.type === 'catch_pending' ? 'catch_pending' : 'fursuit_caught',
+    context,
+  );
+}

--- a/supabase/functions/_shared/catchNotifications.ts
+++ b/supabase/functions/_shared/catchNotifications.ts
@@ -26,29 +26,6 @@ function readBoolean(value: unknown): boolean {
   return value === true;
 }
 
-async function notificationExists(
-  supabaseAdmin: SupabaseClient<any, 'public', any>,
-  options: {
-    userId: string;
-    type: CatchNotificationType;
-    catchId: string;
-  },
-): Promise<boolean> {
-  const { data, error } = await supabaseAdmin
-    .from('notifications')
-    .select('id')
-    .eq('user_id', options.userId)
-    .eq('type', options.type)
-    .contains('payload', { catch_id: options.catchId })
-    .limit(1);
-
-  if (error) {
-    throw new Error(`Failed checking existing catch notification: ${error.message}`);
-  }
-
-  return (data ?? []).length > 0;
-}
-
 async function loadCatchNotificationContext(
   supabaseAdmin: SupabaseClient<any, 'public', any>,
   event: InsertableEventRow,
@@ -98,16 +75,6 @@ async function insertCatchNotification(
   type: CatchNotificationType,
   context: CatchNotificationContext,
 ): Promise<void> {
-  const exists = await notificationExists(supabaseAdmin, {
-    userId: context.fursuitOwnerId,
-    type,
-    catchId: context.catchId,
-  });
-
-  if (exists) {
-    return;
-  }
-
   const payload =
     type === 'catch_pending'
       ? {
@@ -125,14 +92,14 @@ async function insertCatchNotification(
           convention_id: context.conventionId,
         };
 
-  const { error } = await supabaseAdmin.from('notifications').insert({
-    user_id: context.fursuitOwnerId,
-    type,
-    payload,
+  const { error } = await supabaseAdmin.rpc('insert_catch_notification_once', {
+    p_user_id: context.fursuitOwnerId,
+    p_type: type,
+    p_payload: payload,
   });
 
   if (error) {
-    throw new Error(`Failed inserting ${type} notification: ${error.message}`);
+    throw new Error(`Failed inserting deduped ${type} notification: ${error.message}`);
   }
 }
 

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -8,11 +8,7 @@
 
 // eslint-disable-next-line import/no-unresolved -- Deno edge functions import via remote URL
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.1';
-import {
-  ingestGameplayEvent,
-  loadGameplayQueueConfig,
-  scheduleGameplayQueueDrain,
-} from '../_shared/gameplayQueue.ts';
+import { loadGameplayQueueConfig, scheduleGameplayQueueDrain } from '../_shared/gameplayQueue.ts';
 
 const corsHeaders: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -72,6 +68,9 @@ interface CreateCatchResponse {
   requires_approval: boolean;
   fursuit_owner_id: string;
   convention_id?: string | null;
+  event_id: string;
+  event_duplicate?: boolean;
+  event_enqueued?: boolean;
 }
 
 type CatchPerformanceMethod = 'code' | 'camera_photo' | 'gallery_photo';
@@ -210,28 +209,6 @@ function normalizeCatchPhotoSource(value: unknown): 'camera' | 'gallery' | null 
   return null;
 }
 
-async function resolveCreatedCatchConventionId(
-  result: CreateCatchResponse,
-  fallbackConventionId: string | null,
-): Promise<string | null> {
-  if (typeof result.convention_id === 'string' && result.convention_id.length > 0) {
-    return result.convention_id;
-  }
-
-  const { data, error } = await supabaseAdmin
-    .from('catches')
-    .select('convention_id')
-    .eq('id', result.catch_id)
-    .maybeSingle();
-
-  if (error) {
-    console.error('[create-catch] Failed resolving created catch convention:', error);
-    return fallbackConventionId;
-  }
-
-  return data?.convention_id ?? fallbackConventionId;
-}
-
 function extractBearerToken(req: Request): string | null {
   const authHeader = req.headers.get('Authorization');
   if (!authHeader) {
@@ -278,83 +255,6 @@ function scheduleBackgroundTask(label: string, task: () => Promise<void>): void 
   }
 
   void promise;
-}
-
-async function sendCatchNotification(options: {
-  result: CreateCatchResponse;
-  userId: string;
-  fursuitId: string;
-  conventionId: string | null;
-  isTutorial: boolean;
-}): Promise<void> {
-  if (!options.result.requires_approval && options.isTutorial) {
-    return;
-  }
-
-  const shouldNotifyPendingCatch = options.result.requires_approval;
-  const shouldNotifyAcceptedCatch = !options.result.requires_approval;
-
-  if (!shouldNotifyPendingCatch && !shouldNotifyAcceptedCatch) {
-    return;
-  }
-
-  const loadMetadata = async () =>
-    await Promise.all([
-      supabaseAdmin.from('fursuits').select('name').eq('id', options.fursuitId).single(),
-      supabaseAdmin.from('profiles').select('username').eq('id', options.userId).single(),
-    ]);
-
-  let [fursuitResult, catcherResult] = await loadMetadata();
-
-  if (fursuitResult.error || catcherResult.error) {
-    console.error('[create-catch] Failed loading notification metadata:', {
-      fursuitError: fursuitResult.error,
-      catcherError: catcherResult.error,
-    });
-    [fursuitResult, catcherResult] = await loadMetadata();
-  }
-
-  if (fursuitResult.error || catcherResult.error) {
-    console.error('[create-catch] Failed loading notification metadata after retry:', {
-      fursuitError: fursuitResult.error,
-      catcherError: catcherResult.error,
-    });
-  }
-
-  const fursuitName = fursuitResult.data?.name || 'Unknown Fursuit';
-  const catcherUsername = catcherResult.data?.username || 'Someone';
-
-  if (shouldNotifyPendingCatch) {
-    const { error } = await supabaseAdmin.rpc('notify_catch_pending', {
-      p_catch_id: options.result.catch_id,
-      p_fursuit_owner_id: options.result.fursuit_owner_id,
-      p_catcher_id: options.userId,
-      p_fursuit_name: fursuitName,
-      p_catcher_username: catcherUsername,
-    });
-
-    if (error) {
-      console.error('[create-catch] Failed to send pending catch notification:', error);
-    }
-    return;
-  }
-
-  const { error } = await supabaseAdmin.from('notifications').insert({
-    user_id: options.result.fursuit_owner_id,
-    type: 'fursuit_caught',
-    payload: {
-      catch_id: options.result.catch_id,
-      catcher_id: options.userId,
-      fursuit_id: options.fursuitId,
-      fursuit_name: fursuitName,
-      catcher_username: catcherUsername,
-      convention_id: options.conventionId,
-    },
-  });
-
-  if (error) {
-    console.error('[create-catch] Failed to send accepted catch notification:', error);
-  }
 }
 
 function scheduleQueueWakeup(): void {
@@ -473,16 +373,19 @@ async function handlePost(req: Request): Promise<Response> {
       return failureResponse(403, { error: 'Cannot catch this fursuit' }, 'blocked_user');
     }
 
-    // Call the create_catch_with_approval function. The RPC reads the fursuit owner's
-    // profile-level catch mode preference.
+    // The RPC performs catch validation, inserts the catch/photo fields, and durably
+    // enqueues the canonical gameplay event in one database transaction.
     const { data, error } = await trace.measure('catch_insert_ms', () =>
-      supabaseAdmin.rpc('create_catch_with_approval', {
+      supabaseAdmin.rpc('create_catch_with_event', {
         p_fursuit_id: body.fursuit_id,
         p_catcher_id: userId,
         p_convention_id: body.convention_id || null,
         p_is_tutorial: body.is_tutorial || false,
         p_force_pending: body.force_pending || catchPhotoSource === 'gallery',
         p_catch_photo_source: catchPhotoSource,
+        p_catch_photo_path: body.catch_photo_path ?? null,
+        p_catch_photo_url: body.catch_photo_url ?? null,
+        p_client_attempt_id: trace.clientAttemptId ?? null,
       }),
     );
 
@@ -534,83 +437,15 @@ async function handlePost(req: Request): Promise<Response> {
 
     const result = data as CreateCatchResponse;
     catchId = result.catch_id;
-    resolvedConventionId = await resolveCreatedCatchConventionId(
-      result,
-      body.convention_id ?? null,
-    );
+    resolvedConventionId = result.convention_id ?? body.convention_id ?? null;
 
-    if (body.has_photo === true) {
-      const { error: photoUpdateError } = await trace.measure('photo_attach_ms', () =>
-        supabaseAdmin
-          .from('catches')
-          .update({
-            catch_photo_path: body.catch_photo_path ?? null,
-            catch_photo_url: body.catch_photo_url,
-            catch_photo_source: catchPhotoSource ?? 'camera',
-          })
-          .eq('id', result.catch_id),
-      );
-
-      if (photoUpdateError) {
-        await supabaseAdmin.from('catches').delete().eq('id', result.catch_id);
-        console.error(
-          '[create-catch] Failed to attach photo during catch creation:',
-          photoUpdateError,
-        );
-        return failureResponse(
-          500,
-          { error: 'Failed to attach photo to catch' },
-          'photo_attach_failed',
-        );
-      }
-    }
-
-    // Persist the canonical gameplay event before returning.
-    const eventType = result.requires_approval ? 'catch_pending' : 'catch_performed';
-    const ingestResult = await trace.measure('event_ingest_ms', () =>
-      ingestGameplayEvent(supabaseAdmin, {
-        type: eventType,
-        userId,
-        conventionId: resolvedConventionId,
-        payload: {
-          catch_id: result.catch_id,
-          fursuit_id: body.fursuit_id,
-          catcher_id: userId,
-          fursuit_owner_id: result.fursuit_owner_id,
-          convention_id: resolvedConventionId,
-          is_tutorial: body.is_tutorial ?? false,
-          status: result.status,
-          catch_photo_source: catchPhotoSource,
-        },
-        occurredAt: new Date().toISOString(),
-        idempotencyKey: `catch:${result.catch_id}:${eventType}`,
-      }),
-    );
-
-    if (ingestResult.enqueued && !ingestResult.duplicate) {
+    if (result.event_enqueued === true && result.event_duplicate !== true) {
       scheduleQueueWakeup();
     }
 
-    scheduleBackgroundTask('send catch notification', () =>
-      sendCatchNotification({
-        result,
-        userId,
-        fursuitId: body.fursuit_id,
-        conventionId: resolvedConventionId,
-        isTutorial: body.is_tutorial ?? false,
-      }),
-    );
-
     await finishTrace({ result: result.requires_approval ? 'pending_approval' : 'success' });
 
-    return jsonResponse(
-      201,
-      {
-        ...result,
-        event_id: ingestResult.eventId,
-      },
-      trace.clientAttemptId,
-    );
+    return jsonResponse(201, result, trace.clientAttemptId);
   } catch (error) {
     console.error('[create-catch] Unexpected error:', error);
     await finishTrace({ result: 'failed', errorCode: 'internal_error' });

--- a/supabase/functions/create-catch/index.ts
+++ b/supabase/functions/create-catch/index.ts
@@ -499,63 +499,6 @@ async function handlePatch(req: Request): Promise<Response> {
     return jsonResponse(500, { error: 'Failed to update catch photo' });
   }
 
-  // Now that the photo URL is attached, notify the fursuit owner.
-  // We do this here (not in POST) so the owner sees the photo immediately on their card.
-  try {
-    const { data: catchCtx, error: catchCtxError } = await supabaseAdmin
-      .from('catches')
-      .select(
-        'catcher_id, fursuit_id, status, fursuits!catches_fursuit_id_fkey(owner_id, name), profiles!catches_catcher_id_fkey(username)',
-      )
-      .eq('id', body.catch_id)
-      .single();
-
-    if (catchCtxError) {
-      throw catchCtxError;
-    }
-
-    if (catchCtx) {
-      const fursuit = Array.isArray(catchCtx.fursuits) ? catchCtx.fursuits[0] : catchCtx.fursuits;
-      const profile = Array.isArray(catchCtx.profiles) ? catchCtx.profiles[0] : catchCtx.profiles;
-      const fursuitOwnerId = (fursuit as { owner_id: string } | null)?.owner_id;
-      const fursuitName = (fursuit as { name: string } | null)?.name ?? 'Unknown Fursuit';
-      const catcherUsername = (profile as { username: string } | null)?.username ?? 'Someone';
-      const catchStatus = (catchCtx as { status?: string }).status;
-
-      if (fursuitOwnerId) {
-        const { error: notifError } =
-          catchStatus === 'PENDING'
-            ? await supabaseAdmin.rpc('notify_catch_pending', {
-                p_catch_id: body.catch_id,
-                p_fursuit_owner_id: fursuitOwnerId,
-                p_catcher_id: catchCtx.catcher_id,
-                p_fursuit_name: fursuitName,
-                p_catcher_username: catcherUsername,
-              })
-            : catchStatus === 'ACCEPTED'
-              ? await supabaseAdmin.from('notifications').insert({
-                  user_id: fursuitOwnerId,
-                  type: 'fursuit_caught',
-                  payload: {
-                    catch_id: body.catch_id,
-                    catcher_id: catchCtx.catcher_id,
-                    fursuit_id: catchCtx.fursuit_id,
-                    fursuit_name: fursuitName,
-                    catcher_username: catcherUsername,
-                  },
-                })
-              : { error: null };
-
-        if (notifError) {
-          console.error('[create-catch] Failed to send photo catch notification:', notifError);
-        }
-      }
-    }
-  } catch (notifError) {
-    console.error('[create-catch] Error sending photo catch notification:', notifError);
-    // Don't fail the response — the photo was attached successfully
-  }
-
   return jsonResponse(200, { success: true });
 }
 

--- a/supabase/functions/process-gameplay-queue/index.ts
+++ b/supabase/functions/process-gameplay-queue/index.ts
@@ -2,6 +2,7 @@
 // eslint-disable-next-line import/no-unresolved -- Supabase Edge Functions use remote esm.sh imports.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.1';
 import { processAchievementsForEvent } from '../_shared/achievements.ts';
+import { processCatchNotificationForEvent } from '../_shared/catchNotifications.ts';
 import { loadGameplayQueueConfig } from '../_shared/gameplayQueue.ts';
 import type { InsertableEventRow } from '../_shared/types.ts';
 
@@ -236,6 +237,7 @@ async function processQueueMessage(
   await updateEventAttempt(eventId, queueMessage.read_ct);
 
   try {
+    await processCatchNotificationForEvent(supabaseAdmin, eventRow);
     await processAchievementsForEvent(supabaseAdmin, eventRow);
     await markEventSuccess(eventId, queueMessage.read_ct);
     await deleteQueueMessage(queueMessage.msg_id);

--- a/supabase/migrations/20260514120000_create_catch_with_event.sql
+++ b/supabase/migrations/20260514120000_create_catch_with_event.sql
@@ -1,0 +1,244 @@
+create or replace function public.create_catch_with_event(
+  p_fursuit_id uuid,
+  p_catcher_id uuid,
+  p_convention_id uuid default null::uuid,
+  p_is_tutorial boolean default false,
+  p_force_pending boolean default false,
+  p_catch_photo_source text default null::text,
+  p_catch_photo_path text default null::text,
+  p_catch_photo_url text default null::text,
+  p_client_attempt_id text default null::text
+)
+returns json
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+declare
+  v_owner_catch_mode text;
+  v_fursuit_owner_id uuid;
+  v_catch_status text;
+  v_expires_at timestamptz;
+  v_catch_id uuid;
+  v_catch_number integer;
+  v_event_type text;
+  v_event_id uuid;
+  v_event_duplicate boolean;
+  v_event_enqueued boolean;
+  v_result json;
+  v_photo_source text := p_catch_photo_source;
+  v_is_gallery_catch boolean;
+begin
+  if v_photo_source is null and p_catch_photo_url is not null then
+    v_photo_source := 'camera';
+  end if;
+
+  if v_photo_source is not null and v_photo_source not in ('camera', 'gallery') then
+    raise exception 'Invalid catch photo source';
+  end if;
+
+  if p_catch_photo_path is not null and p_catch_photo_url is null then
+    raise exception 'Missing catch photo url';
+  end if;
+
+  v_is_gallery_catch := v_photo_source = 'gallery';
+
+  if v_is_gallery_catch and p_catch_photo_url is null then
+    raise exception 'Gallery catches require a photo';
+  end if;
+
+  if auth.role() <> 'service_role' and auth.uid() is distinct from p_catcher_id then
+    raise exception 'Catcher must match the authenticated user';
+  end if;
+
+  select
+    coalesce(p.default_catch_mode, 'AUTO_ACCEPT'),
+    f.owner_id
+  into
+    v_owner_catch_mode,
+    v_fursuit_owner_id
+  from public.fursuits f
+  left join public.profiles p on p.id = f.owner_id
+  where f.id = p_fursuit_id;
+
+  if not found then
+    raise exception 'Fursuit not found';
+  end if;
+
+  if v_fursuit_owner_id = p_catcher_id then
+    raise exception 'Cannot catch your own fursuit';
+  end if;
+
+  if v_is_gallery_catch and p_convention_id is null then
+    raise exception 'Gallery catches require a convention';
+  end if;
+
+  if p_convention_id is not null then
+    if v_is_gallery_catch then
+      if not public.is_convention_gallery_catchable(p_convention_id) then
+        raise exception 'Convention is not accepting gallery catches';
+      end if;
+
+      if not public.is_profile_convention_gallery_catch_eligible(p_catcher_id, p_convention_id) then
+        raise exception 'Catcher must have a playable convention before catching';
+      end if;
+
+      if not public.is_profile_convention_gallery_catch_eligible(v_fursuit_owner_id, p_convention_id) then
+        raise exception 'Fursuit owner must have a playable convention before catching';
+      end if;
+    else
+      if not public.is_convention_joinable(p_convention_id) then
+        raise exception 'Convention is not live';
+      end if;
+
+      if not public.is_profile_convention_gameplay_eligible(p_catcher_id, p_convention_id) then
+        raise exception 'Catcher must join the live convention before catching';
+      end if;
+
+      if not public.is_profile_convention_gameplay_eligible(v_fursuit_owner_id, p_convention_id) then
+        raise exception 'Fursuit owner must join the live convention before catching';
+      end if;
+    end if;
+
+    if not exists (
+      select 1
+        from public.fursuit_conventions fc
+       where fc.fursuit_id = p_fursuit_id
+         and fc.convention_id = p_convention_id
+    ) then
+      raise exception 'Fursuit must be assigned to the live convention before it can be caught there';
+    end if;
+
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id = p_convention_id
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught at this convention';
+    end if;
+  else
+    if exists (
+      select 1
+        from public.catches
+       where fursuit_id = p_fursuit_id
+         and catcher_id = p_catcher_id
+         and convention_id is null
+         and status in ('ACCEPTED', 'PENDING')
+    ) then
+      raise exception 'Fursuit already caught or pending';
+    end if;
+  end if;
+
+  if (v_owner_catch_mode = 'MANUAL_APPROVAL' or p_force_pending or v_is_gallery_catch) and not p_is_tutorial then
+    v_catch_status := 'PENDING';
+    if p_convention_id is not null then
+      v_expires_at := public.calculate_catch_expiration(p_convention_id);
+    else
+      v_expires_at := public.calculate_catch_expiration();
+    end if;
+  else
+    v_catch_status := 'ACCEPTED';
+    v_expires_at := null;
+  end if;
+
+  begin
+    insert into public.catches (
+      fursuit_id,
+      catcher_id,
+      convention_id,
+      is_tutorial,
+      status,
+      expires_at,
+      caught_at,
+      catch_photo_source,
+      catch_photo_path,
+      catch_photo_url
+    )
+    values (
+      p_fursuit_id,
+      p_catcher_id,
+      p_convention_id,
+      p_is_tutorial,
+      v_catch_status,
+      v_expires_at,
+      now(),
+      v_photo_source,
+      p_catch_photo_path,
+      p_catch_photo_url
+    )
+    returning id, catch_number into v_catch_id, v_catch_number;
+  exception
+    when unique_violation then
+      if p_convention_id is not null then
+        raise exception 'Fursuit already caught at this convention';
+      end if;
+
+      raise exception 'Fursuit already caught or pending';
+  end;
+
+  v_event_type := case when v_catch_status = 'PENDING' then 'catch_pending' else 'catch_performed' end;
+
+  select event_id, duplicate, enqueued
+    into v_event_id, v_event_duplicate, v_event_enqueued
+  from app_private.ingest_gameplay_event(
+    v_event_type,
+    p_catcher_id,
+    p_convention_id,
+    jsonb_build_object(
+      'catch_id', v_catch_id,
+      'fursuit_id', p_fursuit_id,
+      'catcher_id', p_catcher_id,
+      'fursuit_owner_id', v_fursuit_owner_id,
+      'convention_id', p_convention_id,
+      'is_tutorial', p_is_tutorial,
+      'status', v_catch_status,
+      'catch_photo_source', v_photo_source,
+      'client_attempt_id', nullif(btrim(p_client_attempt_id), '')
+    ),
+    now(),
+    format('catch:%s:%s', v_catch_id, v_event_type)
+  );
+
+  select json_build_object(
+    'catch_id', v_catch_id,
+    'status', v_catch_status,
+    'expires_at', v_expires_at,
+    'catch_number', v_catch_number,
+    'requires_approval', v_catch_status = 'PENDING',
+    'fursuit_owner_id', v_fursuit_owner_id,
+    'convention_id', p_convention_id,
+    'event_id', v_event_id,
+    'event_duplicate', coalesce(v_event_duplicate, false),
+    'event_enqueued', coalesce(v_event_enqueued, false)
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+revoke execute on function public.create_catch_with_event(
+  uuid,
+  uuid,
+  uuid,
+  boolean,
+  boolean,
+  text,
+  text,
+  text,
+  text
+) from public, anon, authenticated;
+
+grant execute on function public.create_catch_with_event(
+  uuid,
+  uuid,
+  uuid,
+  boolean,
+  boolean,
+  text,
+  text,
+  text,
+  text
+) to service_role;

--- a/supabase/migrations/20260514120000_create_catch_with_event.sql
+++ b/supabase/migrations/20260514120000_create_catch_with_event.sql
@@ -79,11 +79,17 @@ begin
         raise exception 'Convention is not accepting gallery catches';
       end if;
 
-      if not public.is_profile_convention_gallery_catch_eligible(p_catcher_id, p_convention_id) then
+      if not public.is_profile_convention_gallery_catch_eligible(
+        p_profile_id => p_catcher_id,
+        p_convention_id => p_convention_id
+      ) then
         raise exception 'Catcher must have a playable convention before catching';
       end if;
 
-      if not public.is_profile_convention_gallery_catch_eligible(v_fursuit_owner_id, p_convention_id) then
+      if not public.is_profile_convention_gallery_catch_eligible(
+        p_profile_id => v_fursuit_owner_id,
+        p_convention_id => p_convention_id
+      ) then
         raise exception 'Fursuit owner must have a playable convention before catching';
       end if;
     else

--- a/supabase/migrations/20260514123000_dedupe_catch_notifications.sql
+++ b/supabase/migrations/20260514123000_dedupe_catch_notifications.sql
@@ -6,7 +6,8 @@ with ranked_catch_notifications as (
       order by created_at asc, id asc
     ) as duplicate_rank
   from public.notifications
-  where payload ? 'catch_id'
+  where payload ->> 'catch_id' is not null
+    and payload ->> 'catch_id' <> ''
 )
 delete from public.notifications n
 using ranked_catch_notifications ranked
@@ -19,7 +20,8 @@ create unique index if not exists notifications_catch_once_idx
     type,
     ((payload ->> 'catch_id'))
   )
-  where payload ? 'catch_id';
+  where payload ->> 'catch_id' is not null
+    and payload ->> 'catch_id' <> '';
 
 create or replace function public.insert_catch_notification_once(
   p_user_id uuid,
@@ -40,7 +42,10 @@ begin
     raise exception 'Missing notification type';
   end if;
 
-  if p_payload is null or not (p_payload ? 'catch_id') then
+  if p_payload is null
+    or p_payload ->> 'catch_id' is null
+    or p_payload ->> 'catch_id' = ''
+  then
     raise exception 'Catch notification payload requires catch_id';
   end if;
 
@@ -59,7 +64,8 @@ begin
     type,
     ((payload ->> 'catch_id'))
   )
-  where payload ? 'catch_id'
+  where payload ->> 'catch_id' is not null
+    and payload ->> 'catch_id' <> ''
   do nothing;
 end;
 $$;

--- a/supabase/migrations/20260514123000_dedupe_catch_notifications.sql
+++ b/supabase/migrations/20260514123000_dedupe_catch_notifications.sql
@@ -1,0 +1,56 @@
+create unique index if not exists notifications_catch_once_idx
+  on public.notifications (
+    user_id,
+    type,
+    ((payload ->> 'catch_id'))
+  )
+  where payload ? 'catch_id';
+
+create or replace function public.insert_catch_notification_once(
+  p_user_id uuid,
+  p_type text,
+  p_payload jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path to 'public'
+as $$
+begin
+  if p_user_id is null then
+    raise exception 'Missing notification user_id';
+  end if;
+
+  if p_type is null or char_length(btrim(p_type)) = 0 then
+    raise exception 'Missing notification type';
+  end if;
+
+  if p_payload is null or not (p_payload ? 'catch_id') then
+    raise exception 'Catch notification payload requires catch_id';
+  end if;
+
+  insert into public.notifications (
+    user_id,
+    type,
+    payload
+  )
+  values (
+    p_user_id,
+    p_type,
+    p_payload
+  )
+  on conflict (
+    user_id,
+    type,
+    ((payload ->> 'catch_id'))
+  )
+  where payload ? 'catch_id'
+  do nothing;
+end;
+$$;
+
+revoke execute on function public.insert_catch_notification_once(uuid, text, jsonb)
+  from public, anon, authenticated;
+
+grant execute on function public.insert_catch_notification_once(uuid, text, jsonb)
+  to service_role;

--- a/supabase/migrations/20260514123000_dedupe_catch_notifications.sql
+++ b/supabase/migrations/20260514123000_dedupe_catch_notifications.sql
@@ -1,3 +1,18 @@
+with ranked_catch_notifications as (
+  select
+    id,
+    row_number() over (
+      partition by user_id, type, payload ->> 'catch_id'
+      order by created_at asc, id asc
+    ) as duplicate_rank
+  from public.notifications
+  where payload ? 'catch_id'
+)
+delete from public.notifications n
+using ranked_catch_notifications ranked
+where n.id = ranked.id
+  and ranked.duplicate_rank > 1;
+
 create unique index if not exists notifications_catch_once_idx
   on public.notifications (
     user_id,


### PR DESCRIPTION
This PR fixes the critical work path of catching fursuits by ensuring downstream systems process asynchronously unless the data is required to render the immediate result.

Resolves TAILTAG-105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catch creation is now a single transactional operation that returns event metadata, handles photo inputs, and enqueues event processing.
  * Gameplay processing now runs catch notification handling before achievement processing.

* **Bug Fixes**
  * Deduplicated catch notifications to prevent duplicate alerts.
  * Strengthened validation, authorization, and pending/approval logic for catches; more consistent photo handling and duplicate prevention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FinnThePanther/tailtag/pull/106)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->